### PR TITLE
Fix #19 Subtype indication without constraint

### DIFF
--- a/testsuite/gnat2goto/tests/subtyp/subtyp.adb
+++ b/testsuite/gnat2goto/tests/subtyp/subtyp.adb
@@ -1,0 +1,8 @@
+procedure subtyp is
+  type correct is new Integer range 1 .. 2;
+  type myint is new Integer;
+  x : myint := 2;
+  function inc (x : myint) return myint is (x+1);
+begin
+  x := inc (x);
+end subtyp;

--- a/testsuite/gnat2goto/tests/subtyp/test.out
+++ b/testsuite/gnat2goto/tests/subtyp/test.out
@@ -1,0 +1,27 @@
+CBMC version 5.6 64-bit x86_64 linux
+Parsing subtyp.json_symtab
+Converting
+Generating GOTO Program
+Adding CPROVER library (x86_64)
+Removal of function pointers and virtual functions
+Partial Inlining
+Generic Property Instrumentation
+Starting Bounded Model Checking
+
+simple slicing removed 5 assignments
+Generated 1 VCC(s), 1 remaining after simplification
+Passing problem to propositional reduction
+converting SSA
+Running propositional reduction
+Post-processing
+Solving with MiniSAT 2.2.1 with simplifier
+33 variables, 0 clauses
+SAT checker inconsistent: instance is UNSATISFIABLE
+Runtime decision procedure: 0s
+
+** Results:
+[overflow.1] arithmetic overflow on signed + in subtyp__inc__x + 1: SUCCESS
+
+** 0 of 1 failed (1 iteration)
+VERIFICATION SUCCESSFUL
+

--- a/testsuite/gnat2goto/tests/subtyp/test.py
+++ b/testsuite/gnat2goto/tests/subtyp/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
GNAT does not produce N_Subtype_Indication when no constraint is given, but provides the identifier directly. This fix checks for the type of the subtype indication node, and acts accordingly. Including test case.