### PR TITLE
Feature/nondet

### DIFF
--- a/gnat2goto/driver/goto_utils.adb
+++ b/gnat2goto/driver/goto_utils.adb
@@ -1,3 +1,7 @@
+with Namet; use Namet;
+with Sinfo; use Sinfo;
+with Atree; use Atree;
+
 package body GOTO_Utils is
 
    ---------------------
@@ -76,9 +80,9 @@ package body GOTO_Utils is
       return Ret;
    end Param_Symbol;
 
-   ------------------
+   -----------------
    -- Symbol_Expr --
-   ------------------
+   -----------------
 
    function Symbol_Expr (Sym : Symbol) return Irep is
       Ret : constant Irep := New_Irep (I_Symbol_Expr);
@@ -87,5 +91,25 @@ package body GOTO_Utils is
       Set_Type (Ret, Sym.SymType);
       return Ret;
    end Symbol_Expr;
+
+   ---------------------
+   -- Name_Has_Prefix --
+   ---------------------
+
+   function Name_Has_Prefix (N : Node_Id; Prefix : String) return Boolean is
+   begin
+      if not Present (Name (N)) then
+         return False;
+      else
+         declare
+            Short_Name : constant String :=
+              Get_Name_String (Chars (Name (N)));
+         begin
+            return Prefix'Length <= Short_Name'Length and then
+              Prefix = Short_Name
+                (Short_Name'First .. Short_Name'First - 1 + Prefix'Length);
+         end;
+      end if;
+   end Name_Has_Prefix;
 
 end GOTO_Utils;

--- a/gnat2goto/driver/goto_utils.ads
+++ b/gnat2goto/driver/goto_utils.ads
@@ -1,5 +1,7 @@
 with Ireps;             use Ireps;
 with Types;             use Types;
+with Atree;             use Atree;
+with Sinfo;             use Sinfo;
 with Symbol_Table_Info; use Symbol_Table_Info;
 
 package GOTO_Utils is
@@ -28,5 +30,12 @@ package GOTO_Utils is
    with Post => Kind (Symbol_Expr'Result) = I_Symbol_Expr;
 
    function Name_Has_Prefix (N : Node_Id; Prefix : String) return Boolean;
+
+   function Has_GNAT2goto_Annotation
+     (Def_Id : Entity_Id;
+      Annot  : String) return Boolean
+   with Pre => Nkind (Def_Id) = N_Defining_Identifier;
+   --  checks whether an entity has a certain GNAT2goto annotation.
+   --  This can be either an aspect, or a pragma.
 
 end GOTO_Utils;

--- a/gnat2goto/driver/goto_utils.ads
+++ b/gnat2goto/driver/goto_utils.ads
@@ -1,4 +1,5 @@
-with Ireps; use Ireps;
+with Ireps;             use Ireps;
+with Types;             use Types;
 with Symbol_Table_Info; use Symbol_Table_Info;
 
 package GOTO_Utils is
@@ -25,5 +26,7 @@ package GOTO_Utils is
 
    function Symbol_Expr (Sym : Symbol) return Irep
    with Post => Kind (Symbol_Expr'Result) = I_Symbol_Expr;
+
+   function Name_Has_Prefix (N : Node_Id; Prefix : String) return Boolean;
 
 end GOTO_Utils;

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -1257,17 +1257,13 @@ package body Tree_Walk is
 
    function Do_Function_Call (N : Node_Id) return Irep
    is
-      Func_Name    : constant Symbol_Id :=
-        Intern (Unique_Name (Entity (Name (N))));
+      Func_Ent     : constant Entity_Id := Entity (Name (N));
+      Func_Name    : constant Symbol_Id := Intern (Unique_Name (Func_Ent));
       Func_Symbol  : Symbol;
       The_Function : Irep;
 
-      --  Pragmas : constant String := Get_Entity_Pragmas (N);
-
-      function Has_Pragma_Nondet (N : Node_Id) return Boolean is
-        (False);
-
    begin
+
       --  TODO: in general, the Ada program must be able to
       --  use cbm's built-in functions, like "__cprover_assume".
       --  However, there are several problems:
@@ -1281,7 +1277,9 @@ package body Tree_Walk is
 
       --  For now, we only handle "nondet" prefixes here.
 
-      if Name_Has_Prefix (N, "nondet") or else Has_Pragma_Nondet (N) then
+      if Name_Has_Prefix (N, "nondet") or else
+        Has_GNAT2goto_Annotation (Func_Ent, "nondet")
+      then
          return Do_Nondet_Function_Call (N);
       else
          The_Function := New_Irep (I_Symbol_Expr);
@@ -1779,6 +1777,8 @@ package body Tree_Walk is
    begin
       if Pragma_Name (N_Orig) in Name_Assert | Name_Assume then
          Do_Pragma_Assert_or_Assume (N_Orig, Block);
+      elsif Pragma_Name (N_Orig) in Name_Annotate then
+         null; -- ignore here. Rather look for those when we process a node.
       else
          pp (Union_Id (N));
          raise Program_Error; -- unsupported pragma


### PR DESCRIPTION
Every function with prefix `nondet` is modeled as providing a non-deterministic return value, whereas the value is in the domain of the according type (i.e., respecting its ranges). This also works when such a function is part of an expression. Details here: https://github.com/mbeckersys/gnat2goto/wiki/Non-Determinism

Some other extensions are here, too: detecting calls of RTS functions (we don't have a body for those), as well as allowing null procedures.