### PR TITLE
Ureal to binary

### DIFF
--- a/gnat2goto/driver/ureal_to_binary.adb
+++ b/gnat2goto/driver/ureal_to_binary.adb
@@ -1,0 +1,228 @@
+with Uintp; use Uintp;
+with Types; use Types;
+with Ada.Text_IO;
+
+package body Ureal_To_Binary is
+   package IO renames Ada.Text_IO;
+
+   procedure Get_Integer_And_Fractional_Parts (Number : Ureal;
+                                              Int_Part : out String;
+                                              Frac_Part : out String;
+                                              Int_End : out Integer;
+                                              Frac_End : out Integer)
+     with Pre => (Denominator (Number) > Uint_0);
+
+   procedure Get_Integer_And_Fractional_Parts (Number : Ureal;
+                                               Int_Part : out String;
+                                               Frac_Part : out String;
+                                               Int_End : out Integer;
+                                               Frac_End : out Integer) is
+      Num : Uint := Numerator (Number);
+      Den : constant Uint := Denominator (Number);
+
+      function Get_Next_Exponent return Int;
+      procedure Do_Integer_Part;
+      procedure Do_Fractional_Part;
+
+      function Get_Next_Exponent return Int is
+         E : Int := 0;
+         Eth_Power_Of_Two : Uint := Uint_1;
+      begin
+         while (Den * Eth_Power_Of_Two) < Num loop
+            E := E + 1;
+            Eth_Power_Of_Two := Eth_Power_Of_Two * 2;
+         end loop;
+         return E;
+      end Get_Next_Exponent;
+
+      procedure Do_Integer_Part is
+         E : Int := Get_Next_Exponent;
+         Mantissa : Uint := Uint_2**E;
+         Digit_Position : Integer := Int_Part'First;
+      begin
+         --  we start with a string filled with 0
+         Int_Part := (others => '0');
+         --  if n is the smallest integer so that
+         --  our number is < 2^n,
+         --  then we'll need n digits
+         --  (powers of 2 from 2^0 to 2^(n-1))
+         if E > Int_Part'Length then
+            raise Integer_Part_Too_Large;
+         end if;
+         --  writing to the first position
+         Int_End := Int_Part'First + Integer (E);
+         pragma Assert (Int_End <= Int_Part'Last);
+         while E >= Uint_0 loop
+            pragma Assert (Digit_Position in Int_Part'Range);
+            declare Subtrahend : constant Uint := Mantissa * Den;
+            begin
+               if Int_End > Int_Part'Last then
+                  raise Integer_Part_Too_Large;
+               end if;
+
+               if Subtrahend <= Num then
+                  Num := Num - Subtrahend;
+                  Int_Part (Digit_Position) := '1';
+               end if;
+
+               E := E - 1;
+               Digit_Position := Digit_Position + 1;
+               Mantissa := Mantissa / 2;
+            end;
+         end loop;
+      end Do_Integer_Part;
+
+      procedure Do_Fractional_Part is
+      begin
+         pragma Assert (Frac_Part'Length >= 1);
+         Frac_Part := (others => '0');
+         Frac_End := Frac_Part'First;
+         while Num /= Uint_0 and Frac_End <= Frac_Part'Last loop
+            Num := Num * Uint_2;
+            if Den <= Num then
+               Num := Num - Den;
+               Frac_Part (Frac_End) := '1';
+            end if;
+            Frac_End := Frac_End + 1;
+         end loop;
+         if Frac_End > Frac_Part'Last then
+            Frac_End := Frac_Part'Last;
+         end if;
+      end Do_Fractional_Part;
+
+   begin
+      Do_Integer_Part;
+      Do_Fractional_Part;
+   end Get_Integer_And_Fractional_Parts;
+
+   function Convert_Ureal_To_Binary_Fixed (Number : Ureal;
+                                          Max_Digits : Positive := 30)
+                                           return String is
+      Int : String (1 .. Max_Digits);
+      Frac : String (1 .. Max_Digits);
+      Int_End : Integer;
+      Frac_End : Integer;
+   begin
+      Get_Integer_And_Fractional_Parts (Number, Int, Frac, Int_End, Frac_End);
+      return Int (Int'First .. Int_End) & "." & Frac (Frac'First .. Frac_End);
+   end Convert_Ureal_To_Binary_Fixed;
+
+   function Convert_Ureal_To_Binary_IEEE (Number : Ureal;
+                                         Fraction_Bits : Positive := 23;
+                                         Exponent_Bits : Positive := 8;
+                                         Exponent_Bias : Positive := 127)
+                                         return String is
+      Is_Negative : constant Boolean := Number < Ureal_0;
+      Int_Part : String (1 .. 2**Exponent_Bits);
+      Frac_Part : String (1 .. 2**Exponent_Bits);
+      Abs_Number : constant Ureal := (if Is_Negative then -Number else Number);
+      Result : String (1 .. Fraction_Bits + Exponent_Bits + 1)
+          := (others => '0');
+      Int_End : Integer;
+      Frac_End : Integer;
+      Exponent : Integer := 0;
+      Sign_Bit_Index : constant Integer := 1;
+      Exponent_Start_Index : constant Integer := 2;
+      Exponent_End_Index : constant Integer :=
+      Exponent_Start_Index + Exponent_Bits - 1;
+      Fraction_Start_Index : constant Integer := Exponent_End_Index + 1;
+      Fraction_End_Index : constant Integer :=
+          Fraction_Start_Index + Fraction_Bits - 1;
+
+      procedure Do_Fraction;
+      procedure Do_Fraction is
+         Fraction_Bit : Integer := Fraction_Start_Index;
+
+         procedure Do_Integer_Part;
+         procedure Do_Integer_Part is
+            First_One : Boolean := True;
+         begin
+            for Bit of Int_Part (1 .. Int_End) loop
+               if First_One then
+                  if Bit = '1' then
+                     First_One := False;
+                  end if;
+               else
+                  Result (Fraction_Bit) := Bit;
+                  Fraction_Bit := Fraction_Bit + 1;
+                  Exponent := Exponent + 1;
+               end if;
+            end loop;
+         end Do_Integer_Part;
+
+         procedure Do_Fraction_Part;
+         procedure Do_Fraction_Part is
+            First_One : Boolean := True;
+            Is_LT_One : constant Boolean := Abs_Number < Ureal_1;
+         begin
+            for Bit of Frac_Part (1 .. Frac_End) loop
+               if First_One then
+                  if Bit = '1' then
+                     First_One := False;
+                     if not Is_LT_One then
+                        Result (Fraction_Bit) := '1';
+                        Fraction_Bit := Fraction_Bit + 1;
+                     end if;
+                  end if;
+                  if Is_LT_One then
+                     Exponent := Exponent - 1;
+                  end if;
+               else
+                  Result (Fraction_Bit) := Bit;
+                  if Fraction_Bit = Fraction_End_Index then
+                     exit;
+                  else
+                     Fraction_Bit := Fraction_Bit + 1;
+                  end if;
+               end if;
+            end loop;
+         end Do_Fraction_Part;
+
+      begin
+         Do_Integer_Part;
+         if Fraction_Bit < Fraction_End_Index then
+            Do_Fraction_Part;
+         end if;
+      end Do_Fraction;
+
+      procedure Do_Exponent;
+      procedure Do_Exponent is
+         Power : Integer := 2 ** (Exponent_Bits - 1);
+         Exponent_Index : Integer := Exponent_Start_Index;
+      begin
+
+         if Exponent >= Power * 2 then
+            raise Exponent_Too_Large;
+         end if;
+
+         if Exponent < 0 then
+            raise Negative_Exponent;
+         end if;
+
+         while Power > 0 loop
+            if Exponent - Power >= 0 then
+               Result (Exponent_Index) := '1';
+               Exponent := Exponent - Power;
+            end if;
+            Exponent_Index := Exponent_Index + 1;
+            Power := Power / 2;
+         end loop;
+      end Do_Exponent;
+   begin
+      Result (Sign_Bit_Index) := (if Is_Negative then '1' else '0');
+      Get_Integer_And_Fractional_Parts (Abs_Number,
+                                      Int_Part,
+                                      Frac_Part,
+                                      Int_End,
+                                      Frac_End);
+      if Int_End > Fraction_Bits then
+         raise Integer_Part_Too_Large;
+      end if;
+
+      Do_Fraction;
+      Exponent := Exponent + Exponent_Bias;
+      Do_Exponent;
+      return Result;
+   end Convert_Ureal_To_Binary_IEEE;
+
+end Ureal_To_Binary;

--- a/gnat2goto/driver/ureal_to_binary.adb
+++ b/gnat2goto/driver/ureal_to_binary.adb
@@ -1,9 +1,7 @@
 with Uintp; use Uintp;
 with Types; use Types;
-with Ada.Text_IO;
 
 package body Ureal_To_Binary is
-   package IO renames Ada.Text_IO;
 
    procedure Get_Integer_And_Fractional_Parts (Number : Ureal;
                                               Int_Part : out String;
@@ -17,8 +15,8 @@ package body Ureal_To_Binary is
                                                Frac_Part : out String;
                                                Int_End : out Integer;
                                                Frac_End : out Integer) is
-      Num : Uint := Numerator (Number);
-      Den : constant Uint := Denominator (Number);
+      Num : Uint := Norm_Num (Number);
+      Den : constant Uint := Norm_Den (Number);
 
       function Get_Next_Exponent return Int;
       procedure Do_Integer_Part;
@@ -113,8 +111,8 @@ package body Ureal_To_Binary is
                                          Exponent_Bias : Positive := 127)
                                          return String is
       Is_Negative : constant Boolean := Number < Ureal_0;
-      Int_Part : String (1 .. 2**Exponent_Bits);
-      Frac_Part : String (1 .. 2**Exponent_Bits);
+      Int_Part : String (1 .. 2**(Exponent_Bits - 1));
+      Frac_Part : String (1 .. 2**(Exponent_Bits - 1));
       Abs_Number : constant Ureal := (if Is_Negative then -Number else Number);
       Result : String (1 .. Fraction_Bits + Exponent_Bits + 1)
           := (others => '0');
@@ -209,6 +207,9 @@ package body Ureal_To_Binary is
          end loop;
       end Do_Exponent;
    begin
+      if Number = Ureal_0 then
+         return Result;
+      end if;
       Result (Sign_Bit_Index) := (if Is_Negative then '1' else '0');
       Get_Integer_And_Fractional_Parts (Abs_Number,
                                       Int_Part,

--- a/gnat2goto/driver/ureal_to_binary.ads
+++ b/gnat2goto/driver/ureal_to_binary.ads
@@ -1,0 +1,19 @@
+with Urealp; use Urealp;
+
+package Ureal_To_Binary is
+
+   function Convert_Ureal_To_Binary_Fixed (Number : Ureal;
+                                           Max_Digits : Positive := 30)
+                                          return String;
+   function Convert_Ureal_To_Binary_IEEE (Number : Ureal;
+                                         Fraction_Bits : Positive := 23;
+                                         Exponent_Bits : Positive := 8;
+                                         Exponent_Bias : Positive := 127)
+     return String
+     with Post => (Convert_Ureal_To_Binary_IEEE'Result'Length
+                     = Fraction_Bits + Exponent_Bits + 1);
+
+   Integer_Part_Too_Large : exception;
+   Exponent_Too_Large : exception;
+   Negative_Exponent : exception;
+end Ureal_To_Binary;

--- a/gnat2goto/unit/floating_point_tests.adb
+++ b/gnat2goto/unit/floating_point_tests.adb
@@ -1,0 +1,125 @@
+with Test_Util;
+
+with Urealp; use Urealp;
+with Uintp; use Uintp;
+
+with Ureal_To_Binary; use Ureal_To_Binary;
+
+package body Floating_Point_Tests is
+
+   procedure Test_Integer;
+   procedure Test_Between_0_And_1;
+   procedure Test_General;
+
+   procedure Test_Negative_Integer;
+   procedure Test_Negative_Between_0_And_1;
+   procedure Test_Negative_General;
+
+   procedure Test_Suite;
+
+   procedure Do_Test_Suite is
+   begin
+      Test_Util.Run_Test_Suite ("Floating point literals", Test_Suite'Access);
+   end Do_Test_Suite;
+
+   procedure Test_Integer is
+      --  16/2 = 8
+      Eight : constant Ureal := UR_From_Components (Uint_16, Uint_2);
+      IEEE_Bits : constant String :=
+        "0" -- Sign bit
+        & "10000010" -- 130, i.e. exponent is 3 (+ 127)
+        & "00000000" -- fraction is all 0, so 2^3 * 1.0b = 8.0
+        & "00000000"
+        & "0000000";
+   begin
+      pragma Assert (Convert_Ureal_To_Binary_IEEE (Eight) = IEEE_Bits);
+   end Test_Integer;
+
+   procedure Test_Between_0_And_1 is
+      Zero_Point_Seven_Five : constant Ureal :=
+        UR_From_Components (Uint_3, Uint_4);
+      IEEE_Bits : constant String :=
+        "0" -- Sign bit
+        & "01111110" -- exponent 126 (-1 + 127)
+        & "10000000" -- 1.1b * 2^-2 = 0.11b = 0.75
+        & "00000000"
+        & "0000000";
+   begin
+      pragma Assert (Convert_Ureal_To_Binary_IEEE (Zero_Point_Seven_Five)
+                    = IEEE_Bits);
+   end Test_Between_0_And_1;
+
+   procedure Test_General is
+      Three_Point_Five : constant Ureal :=
+        UR_From_Components (Uint_14, Uint_4);
+      IEEE_Bits : constant String :=
+        "0" -- Sign bit
+        & "10000000" -- exponent 128 (1 + 127)
+        & "11000000" -- 1.11b * 2^1 = 11.1b = 3.5
+        & "00000000"
+        & "0000000";
+   begin
+      pragma Assert (Convert_Ureal_To_Binary_IEEE (Three_Point_Five)
+                    = IEEE_Bits);
+   end Test_General;
+
+   procedure Test_Negative_Integer is
+      Minus_Three : constant Ureal :=
+        UR_From_Components (-Uint_12, Uint_4);
+      IEEE_Bits : constant String :=
+        "1" -- Sign bit
+        & "10000000" -- exponent 128 (1 + 127)
+        & "10000000" -- 1.1b * 2^1 = 11.0b = 3
+        & "00000000"
+        & "0000000";
+   begin
+      pragma Assert (Convert_Ureal_To_Binary_IEEE (Minus_Three)
+                    = IEEE_Bits);
+   end Test_Negative_Integer;
+
+   procedure Test_Negative_Between_0_And_1 is
+      Minus_Zero_Point_Five : constant Ureal :=
+        UR_From_Components (-Uint_1, Uint_2);
+      IEEE_Bits : constant String :=
+        "1" -- Sign bit
+        & "01111110" -- exponent 126 (-1 + 127)
+        & "00000000" -- 1.0b * 2^-1 = 0.1b = 0.5
+        & "00000000"
+        & "0000000";
+   begin
+      pragma Assert (Convert_Ureal_To_Binary_IEEE (Minus_Zero_Point_Five)
+                    = IEEE_Bits);
+   end Test_Negative_Between_0_And_1;
+
+   procedure Test_Negative_General is
+      Minus_Forty_Point_Five : constant Ureal :=
+        UR_From_Components (Uint_Minus_80 + Uint_Minus_5, Uint_2);
+      IEEE_Bits : constant String :=
+        "1" -- Sign bit
+        & "10000100" -- exponent 132 (5 + 127)
+        & "01010100" -- 1.010101b * 2^5 = 101010.1b = 42.5
+        & "00000000"
+        & "0000000";
+   begin
+      pragma Assert (Convert_Ureal_To_Binary_IEEE (Minus_Forty_Point_Five)
+                       = IEEE_Bits);
+   end Test_Negative_General;
+
+   procedure Test_Suite is
+   begin
+
+      Uintp.Initialize;
+      Urealp.Initialize;
+
+      Test_Util.Run_Test ("Integer", Test_Integer'Access);
+      Test_Util.Run_Test ("Between 0 and 1", Test_Between_0_And_1'Access);
+      Test_Util.Run_Test ("General number", Test_General'Access);
+
+      Test_Util.Run_Test ("Negative Integer", Test_Negative_Integer'Access);
+      Test_Util.Run_Test ("Negative between 0 and 1",
+                          Test_Negative_Between_0_And_1'Access);
+      Test_Util.Run_Test ("General negative number",
+                          Test_Negative_General'Access);
+   end Test_Suite;
+
+end Floating_Point_Tests;

--- a/gnat2goto/unit/floating_point_tests.adb
+++ b/gnat2goto/unit/floating_point_tests.adb
@@ -15,6 +15,8 @@ package body Floating_Point_Tests is
    procedure Test_Negative_Between_0_And_1;
    procedure Test_Negative_General;
 
+   procedure Test_Zero;
+
    procedure Test_Suite;
 
    procedure Do_Test_Suite is
@@ -105,6 +107,18 @@ package body Floating_Point_Tests is
                        = IEEE_Bits);
    end Test_Negative_General;
 
+   procedure Test_Zero is
+      IEEE_Bits : constant String :=
+        "0" -- Sign Bit
+        & "00000000" -- Exponent -127
+        & "00000000" -- everything 0 is 1.0*2^-127,
+        & "00000000" -- which is the closest we get to 0 with 32 bit float
+        & "0000000";
+   begin
+      pragma Assert (Convert_Ureal_To_Binary_IEEE (Ureal_0)
+                    = IEEE_Bits);
+   end Test_Zero;
+
    procedure Test_Suite is
    begin
 
@@ -120,6 +134,9 @@ package body Floating_Point_Tests is
                           Test_Negative_Between_0_And_1'Access);
       Test_Util.Run_Test ("General negative number",
                           Test_Negative_General'Access);
+
+      Test_Util.Run_Test ("Zero",
+                         Test_Zero'Access);
    end Test_Suite;
 
 end Floating_Point_Tests;

--- a/gnat2goto/unit/floating_point_tests.ads
+++ b/gnat2goto/unit/floating_point_tests.ads
@@ -1,0 +1,3 @@
+package Floating_Point_Tests is
+   procedure Do_Test_Suite;
+end Floating_Point_Tests;

--- a/gnat2goto/unit/test_util.adb
+++ b/gnat2goto/unit/test_util.adb
@@ -1,0 +1,55 @@
+with Ada.Text_IO;
+package body Test_Util is
+
+   package IO renames Ada.Text_IO;
+
+   Suite_Test_Count : Natural;
+   Suite_Failed_Test_Count : Natural;
+
+   Total_Test_Count : Natural := 0;
+   Total_Failed_Test_Count : Natural := 0;
+
+   procedure Run_Test (Name : String; Test : Unit_Test) is
+   begin
+      IO.Put ("Running test: " & Name);
+      Suite_Test_Count := Suite_Test_Count + 1;
+      Test.all;
+      IO.Put_Line (" [Success]");
+      exception
+         when others =>
+            Suite_Failed_Test_Count := Suite_Failed_Test_Count + 1;
+            IO.Put_Line (" [Fail]");
+   end Run_Test;
+
+   procedure Run_Test_Suite (Name : String; Suite : Test_Suite) is
+   begin
+      Suite_Test_Count := 0;
+      Suite_Failed_Test_Count := 0;
+
+      IO.Put_Line
+        ("##########################################################");
+      IO.Put_Line ("# Running suite: " & Name);
+      IO.Put_Line
+        ("##########################################################");
+      Suite.all;
+      if Suite_Failed_Test_Count > 0 then
+         IO.Put_Line ("Failed"
+                        & Positive'Image (Suite_Failed_Test_Count)
+                        & " out of"
+                        & Positive'Image (Suite_Test_Count)
+                        & " tests");
+      else
+         IO.Put_Line ("All"
+                        & Positive'Image (Suite_Test_Count)
+                        & " tests succeeded");
+      end if;
+      IO.Put_Line ("");
+
+      Total_Test_Count := Total_Test_Count + Suite_Test_Count;
+      Total_Failed_Test_Count := Total_Failed_Test_Count +
+        Suite_Failed_Test_Count;
+   end Run_Test_Suite;
+
+   function Has_Test_Failures return Boolean is (Total_Failed_Test_Count > 0);
+
+end Test_Util;

--- a/gnat2goto/unit/test_util.ads
+++ b/gnat2goto/unit/test_util.ads
@@ -1,0 +1,9 @@
+package Test_Util is
+   type Unit_Test is access procedure;
+   type Test_Suite is access procedure;
+
+   procedure Run_Test (Name : String; Test : Unit_Test);
+   procedure Run_Test_Suite (Name : String; Suite : Test_Suite);
+
+   function Has_Test_Failures return Boolean;
+end Test_Util;

--- a/gnat2goto/unit/unit_tests.adb
+++ b/gnat2goto/unit/unit_tests.adb
@@ -1,10 +1,12 @@
 with Test_Util;
+with Floating_Point_Tests;
 
 with Ada.Command_Line;
 with Ada.Text_IO;
 
 procedure Unit_Tests is
 begin
+   Floating_Point_Tests.Do_Test_Suite;
    if Test_Util.Has_Test_Failures then
       Ada.Command_Line.Set_Exit_Status (1);
       Ada.Text_IO.Put_Line ("Some tests failed");

--- a/gnat2goto/unit/unit_tests.adb
+++ b/gnat2goto/unit/unit_tests.adb
@@ -1,0 +1,12 @@
+with Test_Util;
+
+with Ada.Command_Line;
+with Ada.Text_IO;
+
+procedure Unit_Tests is
+begin
+   if Test_Util.Has_Test_Failures then
+      Ada.Command_Line.Set_Exit_Status (1);
+      Ada.Text_IO.Put_Line ("Some tests failed");
+   end if;
+end Unit_Tests;

--- a/gnat2goto/unit_tests.gpr
+++ b/gnat2goto/unit_tests.gpr
@@ -1,0 +1,16 @@
+with "gnatcoll";
+with "gnat2goto_c";
+
+project Unit_Tests is
+for Object_Dir use "obj";
+for Exec_Dir use "install/bin";
+for Source_Dirs use ("driver", "ireps", "obj", "unit");
+for Main use ("unit_tests.adb");
+
+Common_Switches := ("-gnatg", "-g");
+package Compiler is
+   --  for Local_Configuration_Pragmas use "gnat.adc";
+   for Switches ("Ada") use Common_Switches & ("-O0", "-gnata", "-gnatVa", "-gnatwU");
+end Compiler;
+
+end Unit_Tests;


### PR DESCRIPTION
Adds a `Ureal_To_Binary_IEEE` helper that converts a "universal real" (that is GNAT lingo for rational number represented by a pair of big integers) to an IEEE_Float.

Only tested for 32 bit floats, but that's all we need for now.

Also adds a super basic unit testing framework so we can actually test things like this in isolation.