### PR TITLE
Change the test in Do_Constant for the Integer Literal

### DIFF
--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -12,7 +12,7 @@ with Follow;                use Follow;
 with GNAT_Utils;            use GNAT_Utils;
 with GOTO_Utils;            use GOTO_Utils;
 with Uint_To_Binary;        use Uint_To_Binary;
-
+with Stand;
 with Ada.Text_IO;           use Ada.Text_IO;
 
 package body Tree_Walk is
@@ -1006,10 +1006,11 @@ package body Tree_Walk is
    function Do_Constant (N : Node_Id) return Irep is
       Ret           : constant Irep := New_Irep (I_Constant_Expr);
       Constant_Type : constant Irep := Do_Type_Reference (Etype (N));
-      Is_Integer_Literal : constant Boolean := Nkind (N) = N_Integer_Literal;
+      Is_Integer_Literal : constant Boolean :=
+        Etype (N) = Stand.Universal_Integer;
       Constant_Resolved_Type : constant Irep :=
         (if Is_Integer_Literal then
-            New_Irep (I_Constant_Expr)
+            New_Irep (I_Signedbv_Type)
          else
             Follow_Symbol_Type (Constant_Type, Global_Symbol_Table));
       Constant_Width : constant Integer :=


### PR DESCRIPTION
@hannes-steffenhagen-diffblue Found out that the test I had implemented in in ccdd53f706c1eb6bef21e0c7fdfacf2eca9e89b7 was breaking tests because the test was not narrow enough so it was trivially passing it, marking most integer literals with a width of 64bits when the tests expected a width of 32bits. This fixes it by making the test narrower.