### PR TITLE
Create and output to <unit_name>.json_symtab

### DIFF
--- a/gnat2goto/driver/driver.adb
+++ b/gnat2goto/driver/driver.adb
@@ -40,6 +40,10 @@ with GNATCOLL.JSON;         use GNATCOLL.JSON;
 
 with Sinfo;                 use Sinfo;
 
+with Namet;                 use Namet;
+with Lib;                   use Lib;
+with GNAT_Utils;            use GNAT_Utils;
+
 package body Driver is
 
    procedure Translate_Standard_Types;
@@ -231,7 +235,20 @@ package body Driver is
 
       Global_Symbol_Table.Insert (Start_Name, Start_Symbol);
 
-      Put_Line (Create (SymbolTable2Json (Global_Symbol_Table)).Write);
+      declare
+         Sym_Tab_File : File_Type;
+         Base_Name  : constant String :=
+           File_Name_Without_Suffix
+             (Get_Name_String (Unit_File_Name (Main_Unit)));
+
+      begin
+         Create (Sym_Tab_File, Out_File, Base_Name & ".json_symtab");
+
+         Put_Line (Sym_Tab_File,
+                   Create (SymbolTable2Json (Global_Symbol_Table)).Write);
+
+         Close (Sym_Tab_File);
+      end;
    end Translate_Compilation_Unit;
 
    function Is_Back_End_Switch (Switch : String) return Boolean is

--- a/gnat2goto/driver/gnat_utils.adb
+++ b/gnat2goto/driver/gnat_utils.adb
@@ -94,4 +94,33 @@ package body GNAT_Utils is
       end loop Loop_Arg_Walk;
    end Iterate_Pragma_Parameters;
 
+   function File_Name_Without_Suffix (File_Name : String) return String is
+      Name_Index : Natural := File_Name'Last;
+
+   begin
+      pragma Assert (File_Name'Length > 0);
+
+      --  We loop in reverse to ensure that file names that follow nonstandard
+      --  naming conventions that include additional dots are handled properly,
+      --  preserving dots in front of the main file suffix (for example,
+      --  main.2.ada => main.2).
+
+      while Name_Index >= File_Name'First
+        and then File_Name (Name_Index) /= '.'
+      loop
+         Name_Index := Name_Index - 1;
+      end loop;
+
+      --  Return the part of the file name up to but not including the last dot
+      --  in the name, or return the whole name as is if no dot character was
+      --  found.
+
+      if Name_Index >= File_Name'First then
+         return File_Name (File_Name'First .. Name_Index - 1);
+
+      else
+         return File_Name;
+      end if;
+   end File_Name_Without_Suffix;
+
 end GNAT_Utils;

--- a/gnat2goto/driver/gnat_utils.ads
+++ b/gnat2goto/driver/gnat_utils.ads
@@ -26,4 +26,8 @@ package GNAT_Utils is
 
    function Get_Called_Entity (N : Node_Id) return Entity_Id;
 
+   --  File_Name_Without_Suffix has been copied from
+   --  gnat2why/spark/why/spark_util
+   function File_Name_Without_Suffix (File_Name : String) return String;
+
 end GNAT_Utils;


### PR DESCRIPTION
No longer need to redirect standard_output to json_symtab file.