### PR TITLE
Change test suite to expect output from gnat2goto in <test_name>.json…

### DIFF
--- a/testsuite/gnat2goto/README.md
+++ b/testsuite/gnat2goto/README.md
@@ -11,6 +11,24 @@ contain:
 * expected outputs in `test.out`
 * options in `test.opt`
 
+Each testcase is first translated by gnat2goto and any
+output from standard output or error output is included in
+the test results.
+
+If gnat2goto returns an error code then the error code is reported in
+the test results and cbmc is not run.
+Otherwise cbmc is run on the .json_symtab file produced
+by gnat2goto.
+
+If text is sent to the error stream by cbmc it is included in
+the test results and if cbmc returns an error code this
+is also reported in the test results.
+
+If an error or an unexpected output is found then a
+test output file *testcase*.out retained in the directory *test*
+
+See "Test support code" below for more details.
+
 Rationale and alternatives
 --------------------------
 
@@ -31,21 +49,59 @@ See also:
 
 Requirements
 ------------
-
-```
-$ apt-get install python-gnatpython
-```
+	Linux
+	-----
+		```
+		$ apt-get install python-gnatpython
+		```
+	Mac OSX
+	-------
+		Download or clone https://github.com/Nikokrock/gnatpython
+		run the setup.py scrip to build gnatpython:
+			```
+			$ gnatpython/scripts/setup.py build
+			```
+		run the setup.py script to install gnatpython
+			```
+			$ gnatpython/scripts/setup.py install
+			```
+	gnat2goto and cbmc must be on your program PATH
 
 Running tests
 -------------
+For the gnat2goto test suite each test subdirectory has a file test.py.
+  In this file is a call to a subprogram prove.  This subprogram has an
+  optional parameter, debug <prove (debug=True>),
+  to generate extra information in the test results. The extra information
+  is enclosed by the delimiting lines:
+  <<< DEBUG *test file* >>> and <<< END DEBUG *test file*  >>>
+  of course this will cause a DIFF to be reported between actual and
+  expected output.  By default debug=False.
 
+WARNING running ./update-expected outputs will replace all test.out
+	(expected result) files with the actual results.
+	A summary of the diffs between expected and actual results,
+	and unexpected outputs is given by testsuite so it is not necessary
+	to run ./update-expected-outputs.
+	If ./update-expected-outputs is run, then the recommendtion is to:
+	create a local git branch from the current branch (or be prepared to
+	revert all the changed test.out files, i.e.,
+	git checkout -- tests/<test-dir>/test.out for each changed test.out).
+
+* To run test suite:
 ```
 $ ./testsuite.py -j 4
+```
+where ```-j``` sets the number of tests to run in parallel (default is 1).
+
+* then, optionally
+
+```
 $ ./update-expected-outputs
 $ git diff
 ```
-
-where ```-j``` sets the number of tests to run in parallel (default is 1).
+* if update-expected-outputs has been run, to tidy up,
+  delete new local branch or revert all changed test.out files
 
 Adding tests
 ------------
@@ -53,9 +109,11 @@ Adding tests
 * create a subdirectory in `tests/`
 * create some .adb files
 * create a `test.py` driver file
+  This can normally be copied from another testcase
 * run test with `testsuite.py` followed by `./update-expected-outputs` to strip
   the expected test output from noise (e.g. CBMC timing)
 * check the test subdirectory into the version control
+* optionally revert all other changed test.out files.
 
 Disabling and skipping tests
 ----------------------------
@@ -119,3 +177,11 @@ into:
 * `testsuite.py`, for driving the entire testsuite
 * `run-test`, for driving a single test
 * `lib/python/test_support.py`, for routines that customize individual tests
+
+test_support.py is the python source code which controls the testing of an
+individual testcase.  It runs gnat2goto and cbmc on the testcase, determines
+what is included in the testcase output file and defines the subprogram
+*prove* which is called by the test.py in each testcase subdirectory.
+For complex testing it would be possible to have several test regimes
+by providing subprograms in addition to *prove*.
+

--- a/testsuite/gnat2goto/lib/python/test_support.py
+++ b/testsuite/gnat2goto/lib/python/test_support.py
@@ -28,7 +28,7 @@ def filter_timing(results):
     return re.sub(skip, r'', results)
 
 
-def process(file, cbmcargs):
+def process(debug, file, cbmcargs):
     """Process Ada file with gnat2goto and cbmc"""
     unit = os.path.splitext(file)[0]
     jsout    = unit + ".json_symtab"
@@ -36,17 +36,46 @@ def process(file, cbmcargs):
     gotoprog = unit + ".goto_functions"
     out      = unit + ".out"
     errout   = unit + ".error"
+    stdoutp  = unit + "stdoutp"
+    cbmcerr  = unit + "cbmc_error"
 
     cmd = ["gnat2goto", file]
 
-    Run(["gnat2goto", file], output=jsout, error=errout)
-    # ??? only run the following if gnat2goto succeeded
-    Run(["cbmc", jsout, "--show-symbol-table"], output=symtab)
-    Run(["cbmc", jsout, "--show-goto-functions"], output=gotoprog)
+    g2go_results = Run(["gnat2goto", file], output=stdoutp, error=errout)
+
+    stdout_file = open (stdoutp)
+    errout_file = open (errout)
+    stdout_text = stdout_file.read()
+    errout_text = errout_file.read()
+    stdout_file.close()
+    errout_file.close()
+    if stdout_text != '':
+        print "Standard_Output from gnat2goto " + unit + ":"
+        print stdout_text
+    if errout_text != '':
+        print "Standard_Error from gnat2goto " + unit + ":"
+        print errout_text
+    if g2go_results.status != 0:
+        print "ERROR code ", g2go_results.status, " returned by gnat2goto when translating " + unit
+        print "CBMC not run"
+        return ""
+    
+    # only run the following if gnat2goto succeeded
+    # Run(["cbmc", jsout, "--show-symbol-table"], output=symtab)
+    # Run(["cbmc", jsout, "--show-goto-functions"], output=gotoprog)
     cmdline = ["cbmc", jsout]
     if cbmcargs: cmdline += cbmcargs.split(" ")
-    results = Run(cmdline)
+    results = Run(cmdline, error=cbmcerr)
 
+    cbmcerr_file = open (cbmcerr)
+    cbmcerr_text = cbmcerr_file.read()
+    cbmcerr_file.close()
+    if cbmcerr_text != '':
+        print "Error from cbmc " + unit + ":"
+        print cbmcerr_text
+    if results.status != 0 and results.status != 10:
+        print "ERROR code ", results.status, "returned by cbmc when processing " + unit
+    
     return filter_timing(results.out)
 
 
@@ -67,7 +96,7 @@ def prove(cbmcargs="", debug=False):
       none: yet
     """
     for file in ada_body_files():
-        out = process(file, cbmcargs)
+        out = process(debug, file, cbmcargs)
         if debug:
             print('<<< DEBUG ' + file + ' >>>')
             print(out)

--- a/testsuite/gnat2goto/tests/pragmas/test.out
+++ b/testsuite/gnat2goto/tests/pragmas/test.out
@@ -1,3 +1,6 @@
+Standard_Error from gnat2goto pragmas:
+pragmas.adb:2:04: warning: variable "i" is read but never assigned
+
 [1] : SUCCESS
 [2] : FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/two_subprog_bodies/one.adb
+++ b/testsuite/gnat2goto/tests/two_subprog_bodies/one.adb
@@ -1,0 +1,4 @@
+procedure One (X : in out Integer) is
+begin
+   X := X + 1;
+end One;

--- a/testsuite/gnat2goto/tests/two_subprog_bodies/test.py
+++ b/testsuite/gnat2goto/tests/two_subprog_bodies/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()

--- a/testsuite/gnat2goto/tests/two_subprog_bodies/two.adb
+++ b/testsuite/gnat2goto/tests/two_subprog_bodies/two.adb
@@ -1,0 +1,5 @@
+with One;
+procedure Two (X : in out Integer) is
+begin
+   One (X);
+end Two;


### PR DESCRIPTION
These changes depend on #45 .
Changed test_support.py:
to expect a named output file from gnat2goto rather than output from standard_output,
to include in the test results any standard_output and standard_error from gnat2goto,
to include any any error return code from gnat2goto and inhibit running of cbmc on such errors,
to include any error codes produced by cbmc in the test results.

fixed a fault whereby, if a testcase has more than one body and gnat2goto fails on first body but not
the second, the second successful translation hides the faulty first.

commented out the superfluous running of cbmc to produce a symbol table and a goto program
- neither of these two outputs are or have been used in the testsuite, and,

Updated README.md:
to describe how to install gnatpython on Mac OSX, 
to describe the new operation of the test suite, and,
to give a fuller explanation of how to use and modify the testsuite.

Added a new test case which has two subprogram bodies.  The test case currently fails
and so a test.out has not yet been added to the test case directory.
The new test case was required to fix and check the testsuite when a testcase has more than one body.

Updated test.out for tests/pragmas which was the only pre-existing test expected result effected
by the changes to test_support.py
