### PR TITLE
Add a result type for explicit error handling

### DIFF
--- a/gnat2goto/driver/result.adb
+++ b/gnat2goto/driver/result.adb
@@ -1,0 +1,19 @@
+package body Result is
+
+   function Make_Error (Error_Value : Error_T) return Result_T is
+     ((Status => Error, Error => Error_Value));
+
+   function Make_Ok (Ok_Value : Ok_T) return Result_T is
+      ((Status => Ok, Ok => Ok_Value));
+
+   function Is_Error (Result : Result_T) return Boolean
+   is (Result.Status = Error);
+
+   function Is_Ok (Result : Result_T) return Boolean is (Result.Status = Ok);
+
+   function Get_Error (Result : Result_T) return Error_T
+     is (Result.Error);
+
+   function Get_Ok (Result : Result_T) return Ok_T
+     is (Result.Ok);
+end Result;

--- a/gnat2goto/driver/result.ads
+++ b/gnat2goto/driver/result.ads
@@ -1,0 +1,49 @@
+--  @summary
+--  A type to represent the union between a successful result and some error
+
+--  @description
+--  This is meant to be used in situations where a function might succeed or
+--  fail in interesting ways that should be handled immediately. This is similar
+--  to exceptions, with the difference that the possibility for an error to
+--  occur is apparent from the type of the function, and it is not possible to
+--  silently ignore the possible error (as Ada does not permit discarding the
+--  results of function calls)
+generic
+   type Error_T is private;
+   type Ok_T is private;
+package Result is
+   --  A type representing Union(Error, Ok)
+   type Result_T (<>) is private;
+
+   --  Create an error result from an error value
+   function Make_Error (Error_Value : Error_T) return Result_T;
+
+   --  Create a success result from an ok value
+   function Make_Ok (Ok_Value : Ok_T) return Result_T;
+
+   --  Is the result an error?
+   function Is_Error (Result : Result_T) return Boolean;
+
+   --  Is the result a success?
+   function Is_Ok (Result : Result_T) return Boolean;
+
+   --  Get the error from an error result
+   function Get_Error (Result : Result_T) return Error_T
+     with Pre => Is_Error (Result);
+
+   --  Get the ok value from a successful result
+   function Get_Ok (Result : Result_T) return Ok_T
+     with Pre => Is_Ok (Result);
+
+private
+   type Status_T is (Ok, Error);
+   type Result_T (Status : Status_T) is
+      record
+         case Status is
+            when Error =>
+               Error : Error_T;
+            when Ok =>
+               Ok : Ok_T;
+         end case;
+      end record;
+end Result;

--- a/gnat2goto/unit/result_tests.adb
+++ b/gnat2goto/unit/result_tests.adb
@@ -1,0 +1,42 @@
+with Test_Util;
+with Result;
+package body Result_Tests is
+
+   type Test_Error is (Err_1, Err_2);
+   type Test_Ok is (Ok_1, Ok_2);
+
+   package Test_Result is new Result (Ok_T => Test_Ok, Error_T => Test_Error);
+
+   procedure Test_Suite;
+
+   procedure Do_Test_Suite is
+   begin
+      Test_Util.Run_Test_Suite ("Result type tests", Test_Suite'Access);
+   end Do_Test_Suite;
+
+   procedure Make_Error_Is_Error_Test;
+   procedure Make_Ok_Is_Ok_Test;
+
+   procedure Test_Suite is
+   begin
+      Test_Util.Run_Test ("Can create and extract errors",
+                          Make_Error_Is_Error_Test'Access);
+      Test_Util.Run_Test ("Can create and extract ok values",
+                          Make_Ok_Is_Ok_Test'Access);
+   end Test_Suite;
+
+   procedure Make_Error_Is_Error_Test is
+      R : constant Test_Result.Result_T := Test_Result.Make_Error (Err_1);
+   begin
+      pragma Assert (Test_Result.Is_Error (R));
+      pragma Assert (Test_Result.Get_Error (R) = Err_1);
+   end Make_Error_Is_Error_Test;
+
+   procedure Make_Ok_Is_Ok_Test is
+      R : constant Test_Result.Result_T := Test_Result.Make_Ok (Ok_2);
+   begin
+      pragma Assert (Test_Result.Is_Ok (R));
+      pragma Assert (Test_Result.Get_Ok (R) = Ok_2);
+   end Make_Ok_Is_Ok_Test;
+
+end Result_Tests;

--- a/gnat2goto/unit/result_tests.ads
+++ b/gnat2goto/unit/result_tests.ads
@@ -1,0 +1,3 @@
+package Result_Tests is
+   procedure Do_Test_Suite;
+end Result_Tests;

--- a/gnat2goto/unit/unit_tests.adb
+++ b/gnat2goto/unit/unit_tests.adb
@@ -1,5 +1,6 @@
 with Test_Util;
 with Floating_Point_Tests;
+with Result_Tests;
 
 with Ada.Command_Line;
 with Ada.Text_IO;
@@ -7,6 +8,7 @@ with Ada.Text_IO;
 procedure Unit_Tests is
 begin
    Floating_Point_Tests.Do_Test_Suite;
+   Result_Tests.Do_Test_Suite;
    if Test_Util.Has_Test_Failures then
       Ada.Command_Line.Set_Exit_Status (1);
       Ada.Text_IO.Put_Line ("Some tests failed");


### PR DESCRIPTION
This is a utility type for explicit error handling. Not used at the moment, but might be useful for some of the work we're doing right now (we might run into situations where we have to replace exceptions, pre and postconditions with explicit checks whose failures can't be immediately handled at the check site, but could be handled one or two layers above).