### PR TITLE
Add a script to run gnat2goto against AdaYaml

### DIFF
--- a/experiments/ada-yaml.sh
+++ b/experiments/ada-yaml.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+if ! command -v gnat2goto; then
+  echo >&2 "gnat2goto not on PATH!"
+  exit 1
+fi
+
+ada_yaml_path="/tmp/AdaYaml"
+if [ ! -d "$ada_yaml_path" ]; then
+  echo "Grabbing AdaYaml..."
+  if ! git clone https://www.github.com/yaml/AdaYaml.git "$ada_yaml_path" >/dev/null 2>/dev/null; then
+    echo >&2 "Failed to download AdaYaml";
+    exit 1
+  fi
+fi
+gnat2goto -I "$ada_yaml_path/src/interface" -I "$ada_yaml_path/Parser_Tools/src/interface/" "$ada_yaml_path/src/implementation/yaml.adb"


### PR DESCRIPTION
This is meant to be used to test gnat2goto feature
support against a "real" implementation. For now
we are only trying to get to the point that gnat2goto
won't crash on reaching the first unhandled node type
(and similar), so there are no tests attached