### PR TITLE
Add statement handling exception fallback

### DIFF
--- a/gnat2goto/driver/driver.adb
+++ b/gnat2goto/driver/driver.adb
@@ -266,9 +266,9 @@ package body Driver is
            or else Switch (First .. Last) = "pipe"
          then
             return True;
-         elsif Switch (First .. Last) = No_Dump_Statement_AST_On_Error_Option
+         elsif Switch (First .. Last) = Dump_Statement_AST_On_Error_Option
          then
-            Dump_Statement_AST_On_Error := False;
+            Dump_Statement_AST_On_Error := True;
             return True;
          end if;
       end if;

--- a/gnat2goto/driver/driver.adb
+++ b/gnat2goto/driver/driver.adb
@@ -44,6 +44,8 @@ with Namet;                 use Namet;
 with Lib;                   use Lib;
 with GNAT_Utils;            use GNAT_Utils;
 
+with GNAT2GOTO.Options;
+
 package body Driver is
 
    procedure Translate_Standard_Types;
@@ -254,16 +256,23 @@ package body Driver is
    function Is_Back_End_Switch (Switch : String) return Boolean is
       First : constant Natural := Switch'First + 1;
       Last  : constant Natural := Switch_Last (Switch);
-
+      use GNAT2GOTO.Options;
    begin
       --  For now we allow the -g/-O/-f/-m/-W/-w and -pipe switches, even
       --  though they will have no effect. This permits compatibility with
       --  existing scripts.
-
-      return
-        Is_Switch (Switch)
-          and then (Switch (First) in 'f' | 'g' | 'm' | 'O' | 'W' | 'w'
-                      or else Switch (First .. Last) = "pipe");
+      if Is_Switch (Switch) then
+         if Switch (First) in 'f' | 'g' | 'm' | 'O' | 'W' | 'w'
+           or else Switch (First .. Last) = "pipe"
+         then
+            return True;
+         elsif Switch (First .. Last) = No_Dump_Statement_AST_On_Error_Option
+         then
+            Dump_Statement_AST_On_Error := False;
+            return True;
+         end if;
+      end if;
+      return False;
    end Is_Back_End_Switch;
 
    ------------------------------

--- a/gnat2goto/driver/gnat2goto-options.adb
+++ b/gnat2goto/driver/gnat2goto-options.adb
@@ -1,5 +1,5 @@
 package body GNAT2GOTO.Options is
 
 begin
-   Dump_Statement_AST_On_Error := True;
+   Dump_Statement_AST_On_Error := False;
 end GNAT2GOTO.Options;

--- a/gnat2goto/driver/gnat2goto-options.adb
+++ b/gnat2goto/driver/gnat2goto-options.adb
@@ -1,0 +1,5 @@
+package body GNAT2GOTO.Options is
+
+begin
+   Dump_Statement_AST_On_Error := True;
+end GNAT2GOTO.Options;

--- a/gnat2goto/driver/gnat2goto-options.ads
+++ b/gnat2goto/driver/gnat2goto-options.ads
@@ -3,7 +3,7 @@ package GNAT2GOTO.Options is
    --  that a package can have a body if the rest of the specification doesn't
    --  REQUIRE there to be one
    pragma Elaborate_Body;
-   No_Dump_Statement_AST_On_Error_Option : constant String :=
-     "no-dump-statement-ast-on-error";
+   Dump_Statement_AST_On_Error_Option : constant String :=
+     "dump-statement-ast-on-error";
    Dump_Statement_AST_On_Error : Boolean;
 end GNAT2GOTO.Options;

--- a/gnat2goto/driver/gnat2goto-options.ads
+++ b/gnat2goto/driver/gnat2goto-options.ads
@@ -1,0 +1,9 @@
+package GNAT2GOTO.Options is
+   --  we want initialisation to happen and the specification needs to indicate
+   --  that a package can have a body if the rest of the specification doesn't
+   --  REQUIRE there to be one
+   pragma Elaborate_Body;
+   No_Dump_Statement_AST_On_Error_Option : constant String :=
+     "no-dump-statement-ast-on-error";
+   Dump_Statement_AST_On_Error : Boolean;
+end GNAT2GOTO.Options;

--- a/gnat2goto/driver/gnat2goto.ads
+++ b/gnat2goto/driver/gnat2goto.ads
@@ -1,0 +1,2 @@
+package GNAT2GOTO is
+end GNAT2GOTO;

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -15,6 +15,7 @@ with Uint_To_Binary;        use Uint_To_Binary;
 with Stand;
 with Ureal_To_Binary;       use Ureal_To_Binary;
 with Ada.Text_IO;           use Ada.Text_IO;
+with Ada.Exceptions;
 
 package body Tree_Walk is
 
@@ -3864,7 +3865,14 @@ package body Tree_Walk is
 
    begin
       while Present (Stmt) loop
-         Process_Statement (Stmt, Reps);
+         begin
+            Process_Statement (Stmt, Reps);
+         exception
+            when Error : others =>
+                  Ada.Text_IO.Put_Line (Ada.Text_IO.Standard_Error,
+                                        Ada.Exceptions.Exception_Information
+                                          (Error));
+         end;
          Next (Stmt);
       end loop;
 

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -3862,16 +3862,19 @@ package body Tree_Walk is
    function Process_Statements (L : List_Id) return Irep is
       Reps : constant Irep := New_Irep (I_Code_Block);
       Stmt : Node_Id := First (L);
-
+      package IO renames Ada.Text_IO;
    begin
       while Present (Stmt) loop
          begin
             Process_Statement (Stmt, Reps);
          exception
             when Error : others =>
-                  Ada.Text_IO.Put_Line (Ada.Text_IO.Standard_Error,
-                                        Ada.Exceptions.Exception_Information
-                                          (Error));
+               IO.Put_Line (IO.Standard_Error, "<========================>");
+               IO.Put_Line (IO.Standard_Error,
+                            Ada.Exceptions.Exception_Information
+                              (Error));
+               Treepr.Print_Node_Subtree (Stmt);
+               IO.Put_Line (IO.Standard_Error, "<========================>");
          end;
          Next (Stmt);
       end loop;

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -17,6 +17,8 @@ with Ureal_To_Binary;       use Ureal_To_Binary;
 with Ada.Text_IO;           use Ada.Text_IO;
 with Ada.Exceptions;
 
+with GNAT2GOTO.Options;
+
 package body Tree_Walk is
 
    procedure Add_Entity_Substitution (E : Entity_Id; Subst : Irep);
@@ -3873,7 +3875,9 @@ package body Tree_Walk is
                IO.Put_Line (IO.Standard_Error,
                             Ada.Exceptions.Exception_Information
                               (Error));
-               Treepr.Print_Node_Subtree (Stmt);
+               if GNAT2GOTO.Options.Dump_Statement_AST_On_Error then
+                  Treepr.Print_Node_Subtree (Stmt);
+               end if;
                IO.Put_Line (IO.Standard_Error, "<========================>");
          end;
          Next (Stmt);

--- a/gnat2goto/gnat2goto.gpr
+++ b/gnat2goto/gnat2goto.gpr
@@ -10,7 +10,7 @@ project GNAT2GOTO is
 
    for Main use ("gnat1drv.adb");
 
-   Common_Switches := ("-gnatg", "-g");
+   Common_Switches := ("-gnatg", "-g", "-gnateE");
 
    package Compiler is
       --  for Local_Configuration_Pragmas use "gnat.adc";
@@ -20,5 +20,10 @@ project GNAT2GOTO is
    package Builder is
       for Executable ("gnat1drv.adb") use "gnat2goto";
    end Builder;
+
+   package Binder is
+     -- this enables extended exception information (like backtraces)
+     for Switches ("Ada") use ("-g", "-E");
+   end Binder;
 
 end GNAT2GOTO;


### PR DESCRIPTION
If an exception occured during exception handling we'd
halt compilation. With this commit, what we do instead is
report the error and continue on.

The result of the compilation will be ultimately not very useful,
but at least with this we can find out all the places where something
is going wrong rather easily.

For example, with the AdaYaml script we now get output like this:

```
Warning: Subprogram yaml__version_major not in symbol table
Warning: Subprogram yaml__version_minor not in symbol table
Warning: Subprogram yaml__version_patch not in symbol table
N_Use_Type_Clause (Node_Id=2295) (source,analyzed)
 Sloc = 8534  yaml.adb:12:4
 Subtype_Marks = List (List_Id=-99999978)
 Hidden_By_Use_Clause = <no elist>
 Used_Operations = (Elist_Id=100000158)
raised PROGRAM_ERROR : tree_walk.adb:3853 explicit raise
Call stack traceback locations:
0x960ee6 0x961099 0x958eaa 0x948532 0x903ad6 0x903846 0x10e49a4 0x10e62c6 0x405ef2 0x408635 0x7f7c941fdb95 0x403538 0xfffffffffffffffe

raised PROGRAM_ERROR : tree_walk.adb:1239 explicit raise
Call stack traceback locations:
0x94b199 0x9453cb 0x943e72 0x94ae0a 0x957a4c 0x960a8d 0x961099 0x94d2a3 0x960b48 0x958f53 0x958237 0x960d36 0x961099 0x958eaa 0x948532 0x903ad6 0x903846 0x10e49a4 0x10e62c6 0x405ef2 0x408635 0x7f7c941fdb95 0x403538 0xfffffffffffffffe

Warning: Subprogram yaml__default_properties not in symbol table
raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from goto_utils.ads:37
Call stack traceback locations:
0x1140fbf 0x6e4683 0x94c99b 0x94aa11 0x94b448 0x94b02a 0x957a4c 0x960a8d 0x961099 0x94d2a3 0x960b48 0x958f53 0x958237 0x960d36 0x961099 0x958eaa 0x948532 0x903ad6 0x903846 0x10e49a4 0x10e62c6 0x405ef2 0x408635 0x7f7c941fdb95 0x403538 0xfffffffffffffffe

Warning: Subprogram yaml__is_empty not in symbol table
Warning: Casestatements unhandled
Warning: First attributeexpressions unhandled
Warning: Last attributeexpressions unhandled
raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from goto_utils.ads:37
Call stack traceback locations:
0x1140fbf 0x6e4683 0x94c99b 0x94aa11 0x94767d 0x94afd2 0x953286 0x954787 0x94a909 0x957a4c 0x960a8d 0x961099 0x94d2a3 0x960b48 0x958f53 0x958237 0x960d36 0x961099 0x958eaa 0x958237 0x960d36 0x961099 0x958eaa 0x948532 0x903ad6 0x903846 0x10e49a4 0x10e62c6 0x405ef2 0x408635 0x7f7c941fdb95 0x403538 0xfffffffffffffffe

raised PROGRAM_ERROR : tree_walk.adb:1622 explicit raise
Call stack traceback locations:
0x94eae3 0x9439e1 0x94a7c5 0x947b09 0x94adb2 0x957a4c 0x960a8d 0x961099 0x94d2a3 0x960b48 0x958f53 0x958237 0x960d36 0x961099 0x958eaa 0x958237 0x960d36 0x961099 0x958eaa 0x948532 0x903ad6 0x903846 0x10e49a4 0x10e62c6 0x405ef2 0x408635 0x7f7c941fdb95 0x403538 0xfffffffffffffffe

Warning: Casestatements unhandled
Warning: Subprogram yaml__to_string not in symbol table
raised PROGRAM_ERROR : tree_walk.adb:1622 explicit raise
Call stack traceback locations:
0x94eae3 0x9439e1 0x94a7c5 0x956718 0x94a8b1 0x946914 0x9609af 0x961099 0x94d2a3 0x960b48 0x958f53 0x958237 0x960d36 0x961099 0x958eaa 0x948532 0x903ad6 0x903846 0x10e49a4 0x10e62c6 0x405ef2 0x408635 0x7f7c941fdb95 0x403538 0xfffffffffffffffe

Warning: Subprogram yaml__increase_refcount not in symbol table
raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : sinfo.adb:1183
Call stack traceback locations:
0x1140fbf 0x5d4e50 0x959260 0x958485 0x960d36 0x961099 0x958eaa 0x948532 0x903ad6 0x903846 0x10e49a4 0x10e62c6 0x405ef2 0x408635 0x7f7c941fdb95 0x403538 0xfffffffffffffffe

N_Access_To_Object_Definition (Node_Id=2860) (source)
 Parent = N_Full_Type_Declaration (Node_Id=2864)
 Sloc = 11888  yaml.adb:99:27
 All_Present = True
 Subtype_Indication = N_Attribute_Reference (Node_Id=2863)
raised PROGRAM_ERROR : tree_walk.adb:3130 explicit raise
Call stack traceback locations:
0x95a7eb 0x94b64a 0x960c80 0x961099 0x958eaa 0x958237 0x960d36 0x961099 0x958eaa 0x948532 0x903ad6 0x903846 0x10e49a4 0x10e62c6 0x405ef2 0x408635 0x7f7c941fdb95 0x403538 0xfffffffffffffffe

raised PROGRAM_ERROR : tree_walk.adb:1622 explicit raise
Call stack traceback locations:
0x94eae3 0x9439e1 0x94a7c5 0x959f9a 0x94a9b9 0x9519b5 0x960b01 0x961099 0x958eaa 0x958237 0x960d36 0x961099 0x958eaa 0x948532 0x903ad6 0x903846 0x10e49a4 0x10e62c6 0x405ef2 0x408635 0x7f7c941fdb95 0x403538 0xfffffffffffffffe

N_Package_Declaration (Node_Id=12610) (analyzed)
 Sloc = 11977  yaml.adb:103:7
 Specification = N_Package_Specification (Node_Id=12609)
raised PROGRAM_ERROR : tree_walk.adb:3853 explicit raise
Call stack traceback locations:
0x960ee6 0x961099 0x958eaa 0x958237 0x960d36 0x961099 0x958eaa 0x948532 0x903ad6 0x903846 0x10e49a4 0x10e62c6 0x405ef2 0x408635 0x7f7c941fdb95 0x403538 0xfffffffffffffffe

N_Procedure_Instantiation (Node_Id=2885) (source,analyzed)
 Sloc = 11977  yaml.adb:103:7
 Defining_Unit_Name = N_Defining_Identifier "free" (Entity_Id=2877)
 Name = N_Expanded_Name "unchecked_deallocation" (Node_Id=2887)
 Generic_Associations = List (List_Id=-99999876)
 Instance_Spec = N_Package_Declaration (Node_Id=12610)
raised PROGRAM_ERROR : tree_walk.adb:3853 explicit raise
Call stack traceback locations:
0x960ee6 0x961099 0x958eaa 0x958237 0x960d36 0x961099 0x958eaa 0x948532 0x903ad6 0x903846 0x10e49a4 0x10e62c6 0x405ef2 0x408635 0x7f7c941fdb95 0x403538 0xfffffffffffffffe

raised PROGRAM_ERROR : tree_walk.adb:2553 explicit raise
Call stack traceback locations:
0x9552b1 0x960a1e 0x961099 0x94e2dd 0x94de53 0x960bb7 0x961099 0x94d2a3 0x960b48 0x958f53 0x958237 0x960d36 0x961099 0x958eaa 0x948532 0x903ad6 0x903846 0x10e49a4 0x10e62c6 0x405ef2 0x408635 0x7f7c941fdb95 0x403538 0xfffffffffffffffe

Warning: Subprogram yaml__decrease_refcount not in symbol table
raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : sinfo.adb:1183
Call stack traceback locations:
0x1140fbf 0x5d4e50 0x959260 0x958485 0x960d36 0x961099 0x958eaa 0x948532 0x903ad6 0x903846 0x10e49a4 0x10e62c6 0x405ef2 0x408635 0x7f7c941fdb95 0x403538 0xfffffffffffffffe
```

As you can see this isn't hugely useful in all places, but we do at least get some useful information in here. 

__EDIT__: Now with stacktraces! Binary addresses, but can be turned into useful source locations with the normal `addr2line` tool

__EDIT 2__: Not shown in the output above: Huge AST dumps. Not sure yet if I like them yet, but might give us useful information. Probably shouldn't keep them in there for actual usage, but as long as we're in "debug and fix" mode I think they should be OK?