### PR TITLE
Fix typo in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ install:
       cmake --build build -- -j4
     )
 
-  - export PATH=${CMBC}/build/bin:${PATH}
+  - export PATH=${CBMC}/build/bin:${PATH}
   - export PATH=$(pwd)/gnat2goto/install/bin:${PATH}
 
 script:


### PR DESCRIPTION
The `CBMC` variable was referred to as `CMBC` in the path definition, leading to scripts in the build not being able to see the cbmc executable.