### PR TITLE
testsuite/ranges fix [ADA-202]

### DIFF
--- a/gnat2goto/driver/driver.adb
+++ b/gnat2goto/driver/driver.adb
@@ -280,6 +280,21 @@ package body Driver is
    ------------------------------
 
    procedure Translate_Standard_Types is
+      procedure Add_Universal_Integer;
+      procedure Add_Universal_Integer is
+         Builtin   : Symbol;
+         Builtin_Node : constant Node_Id := Universal_Integer;
+         Type_Irep : constant Irep := Make_Integer_Type;
+      begin
+         Builtin.Name       := Intern (Unique_Name (Builtin_Node));
+         Builtin.PrettyName := Builtin.Name;
+         Builtin.BaseName   := Builtin.Name;
+         Builtin.SymType    := Type_Irep;
+         Builtin.IsType     := True;
+
+         Global_Symbol_Table.Insert (Builtin.Name, Builtin);
+      end Add_Universal_Integer;
+
    begin
       --  Add primitive types to the symtab
       for Standard_Type in S_Types'Range loop
@@ -338,6 +353,7 @@ package body Driver is
             end if;
          end;
       end loop;
+      Add_Universal_Integer;
    end Translate_Standard_Types;
 
    procedure Add_CProver_Internal_Symbols is

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -1159,18 +1159,20 @@ package body Tree_Walk is
       Set_Type (Ret, Make_Signedbv_Type (Ireps.Empty, 32));
       Set_Value (Ret, "00000000000000000000000000000000");
 
-      if not Global_Symbol_Table.Contains (
-                                       Intern (Get_Identifier (Constant_Type)))
-      then
-         Report_Unhandled_Node_Empty (N, "Do_Constant",
-                                      "Constant Type not in symbol table");
-         return Ret;
+      if Is_Integer_Literal then
+         Constant_Resolved_Type :=  New_Irep (I_Signedbv_Type);
+      else
+         if not Global_Symbol_Table.Contains (
+                                              Intern (Get_Identifier
+                                                        (Constant_Type)))
+         then
+            Report_Unhandled_Node_Empty (N, "Do_Constant",
+                                         "Constant Type not in symbol table");
+            return Ret;
+         end if;
+         Constant_Resolved_Type := Follow_Symbol_Type (Constant_Type,
+                                                       Global_Symbol_Table);
       end if;
-      Constant_Resolved_Type :=
-        (if Is_Integer_Literal then
-        New_Irep (I_Signedbv_Type)
-        else
-        Follow_Symbol_Type (Constant_Type, Global_Symbol_Table));
 
       if Is_Integer_Literal then
          null;

--- a/testsuite/gnat2goto/tests/ranges/test.opt
+++ b/testsuite/gnat2goto/tests/ranges/test.opt
@@ -1,1 +1,0 @@
-ALL XFAIL cbmc runs into invariant violation when reading gnat2goto output


### PR DESCRIPTION
Adds Universal_Integer type to symbol table.
Also moves the unsupported feature check to allow universal integer type not to
be in the table during gnat parsing.