### PR TITLE
Fail testsuite on travis on UOK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ install:
 
 script:
   #run the tests
-  - (cd testsuite/gnat2goto; ! ./testsuite.py -j 2 2>&1 >/dev/null | tee /dev/tty | grep "ERROR" > /dev/null)
+  - (cd testsuite/gnat2goto; ! ./testsuite.py -j 2 2>&1 >/dev/null | tee /dev/tty | grep -E "ERROR|UOK" > /dev/null)
   - gnat2goto/install/bin/unit_tests
 
 before_cache:


### PR DESCRIPTION
An UOK in the testsuite means that the test was marked as "expected fail" XFAIL
but actually ended up passing. This is something that requires attention,
so reporting a failure in this case is appropriate.