### PR TITLE
Improvements to gnat2goto CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ install:
 
 script:
   #run the tests
-  - (cd testsuite/gnat2goto; ! ./testsuite.py --diffs -j 2 2>&1 >/dev/null | tee /dev/tty | grep -E "ERROR|UOK" > /dev/null)
+  - (cd testsuite/gnat2goto; ! ./testsuite.py --timeout 60 --diffs -j 2 2>&1 >/dev/null | tee /dev/tty | grep -E "ERROR|UOK" > /dev/null)
   - gnat2goto/install/bin/unit_tests
 
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ install:
     ( set -euo pipefail
       cd ${CBMC}
       cmake -H. -Bbuild '-DCMAKE_BUILD_TYPE=Release'  '-DCMAKE_CXX_COMPILER=/usr/bin/g++-7'
-      cmake --build build -- -j4
+      cmake --build build --target cbmc -- -j4
     )
 
   - export PATH=${CBMC}/build/bin:${PATH}

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ install:
 
 script:
   #run the tests
-  - (cd testsuite/gnat2goto; ! ./testsuite.py -j 2 2>&1 >/dev/null | tee /dev/tty | grep -E "ERROR|UOK" > /dev/null)
+  - (cd testsuite/gnat2goto; ! ./testsuite.py --diffs -j 2 2>&1 >/dev/null | tee /dev/tty | grep -E "ERROR|UOK" > /dev/null)
   - gnat2goto/install/bin/unit_tests
 
 before_cache:


### PR DESCRIPTION
This PR builds on #72 and adds a couple of extra improvements:

* Enable the regression tests to output a diff where tests fail due to differing output (rather than a single line saying "DIFF"
* Reduces the amount of CBMC we build, since we don't need to build all of it to be able to run the gnat2goto regression tests
* Add a 60 second timeout per-test. The default time out value is too large (760 seconds) which causes a hanging test case to then cause Travis to timeout the entire job.

Only the final two commits need to be reviewed. 
NOTE: This should not be merged until #72 has been merged