### PR TITLE
Turn on gnat python color output for regression test results in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ install:
 
 script:
   #run the tests
-  - (cd testsuite/gnat2goto; ! ./testsuite.py --timeout 60 --diffs -j 2 2>&1 >/dev/null | tee /dev/tty | grep -E "ERROR|UOK" > /dev/null)
+  - (cd testsuite/gnat2goto; ! ./testsuite.py --timeout 60 --diffs --enable-color -j 2 2>&1 >/dev/null | tee /dev/tty | grep -E "ERROR|UOK" > /dev/null)
   - gnat2goto/install/bin/unit_tests
 
 before_cache:


### PR DESCRIPTION
NOTE, this builds on PR #75 so only the final commit in this PR is for review, and this PR will need rebasing once #75 is merged.