### PR TITLE
Speedup Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,14 +29,12 @@ install:
   - ccache --max-size=1G
   - wget -qO- http://mirrors.cdn.adacore.com/art/5739cefdc7a447658e0b016b | tar xz
   - wget -qO- http://mirrors.cdn.adacore.com/art/5a15cb87c7a4479a23674d44 | tar xz
-  #build gnat gpl
-  # doinstall script is interactive
-  # it queries 4 responses from the user:
-  # 1) Press RETURN if you want to proceed? --> "\n"
-  # 2) Path to install GNAT --> "~/opt/gnat\n"
-  # 3) Are you sure? --> "y\n"
-  # 4) Are you sure? --> "y"
-  - (cd gnat-gpl-2016-x86_64-linux-bin; echo -e "\n${GNAT}\ny\ny" | ./doinstall)
+  - |
+    #install gnat gpl
+    ( set -euo pipefail
+      cd gnat-gpl-2016-x86_64-linux-bin
+      make ins-basic prefix=${GNAT}
+    )
 
   - |
     #build gnatcoll

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ os: linux
 
 compiler: gcc
 
-sudo: true
-
 env:
   GNAT: "${HOME}/opt/gnat"
   CBMC: "${TRAVIS_BUILD_DIR}/lib/cbmc"
@@ -19,6 +17,7 @@ addons:
     packages:
       - build-essential
       - g++-7
+      - python-gnatpython
 
 before_install:
   - mkdir bin
@@ -58,9 +57,6 @@ install:
       make
       gprbuild -P unit_tests.gpr -cargs -largs
     )
-
-  - sudo apt-get install python-gnatpython
-  - export PYTHONPATH="/usr/lib/python2.7/dist-packages"
 
   - |
     #build updated cbmc

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,13 @@ os: linux
 compiler: gcc
 
 env:
-  GNAT: "${HOME}/opt/gnat"
-  CBMC: "${TRAVIS_BUILD_DIR}/lib/cbmc"
+  GNAT: "http://mirrors.cdn.adacore.com/art/5739cefdc7a447658e0b016b"
+  GNATCOLL: "http://mirrors.cdn.adacore.com/art/5a15cb87c7a4479a23674d44"
 
-cache: ccache
+cache:
+  ccache: true
+  directories:
+    - ${TRAVIS_BUILD_DIR}/gnat
 
 addons:
   apt:
@@ -25,47 +28,60 @@ before_install:
   - ln -s /usr/bin/g++-7 bin/g++
 
 install:
+  - export GNAT_TOOLS="${TRAVIS_BUILD_DIR}/gnat"
   - ccache -z
   - ccache --max-size=1G
-  - wget -qO- http://mirrors.cdn.adacore.com/art/5739cefdc7a447658e0b016b | tar xz
-  - wget -qO- http://mirrors.cdn.adacore.com/art/5a15cb87c7a4479a23674d44 | tar xz
   - |
     #install gnat gpl
     ( set -euo pipefail
-      cd gnat-gpl-2016-x86_64-linux-bin
-      make ins-basic prefix=${GNAT}
+      if ! [ -r ${GNAT_TOOLS}/gnat_version \
+             -a "${GNAT}" = "$(cat ${GNAT_TOOLS}/gnat_version)" \
+             -a -x ${GNAT_TOOLS}/bin/gnat ]
+      then
+        echo "Downloading GNAT GPL from ${GNAT} ..."
+        wget -qO- "${GNAT}" | tar xz
+        cd gnat-gpl-2016-x86_64-linux-bin
+        make ins-basic prefix=${GNAT_TOOLS}
+        echo "${GNAT}" > ${GNAT_TOOLS}/gnat_version
+      fi
     )
+    export PATH=${GNAT_TOOLS}/bin:${PATH}
+    export GPR_PROJECT_PATH=${GNAT_TOOLS}/lib/gnat
 
   - |
     #build gnatcoll
     ( set -euo pipefail
-      cd gnatcoll-gpl-2016-src
-      export PATH=${GNAT}/bin:${PATH}
-      ./configure --prefix=${GNAT} --disable-shared --enable-build=Debug
-      make
-      make install
+      if ! [ -r ${GNAT_TOOLS}/gnatcoll_version \
+             -a "${GNATCOLL}" = "$(cat ${GNAT_TOOLS}/gnatcoll_version)" \
+             -a -d ${GNAT_TOOLS}/lib/gnatcoll ]
+      then
+        echo "Downloading GNATCOLL from ${GNATCOLL} ..."
+        wget -qO- ${GNATCOLL} | tar xz
+        cd gnatcoll-gpl-2016-src
+        ./configure --prefix=${GNAT_TOOLS} --disable-shared --enable-build=Debug
+        make
+        make install
+        echo "${GNATCOLL}" > ${GNAT_TOOLS}/gnatcoll_version
+      fi
     )
 
   - |
     #build gnat2goto + unit tests
     ( set -euo pipefail
       cd gnat2goto
-      export PATH=${GNAT}/bin:${PATH}
-      export GPR_PROJECT_PATH=${GNAT}/lib/gnat
       make
       gprbuild -P unit_tests.gpr -cargs -largs
     )
+    export PATH=$(pwd)/gnat2goto/install/bin:${PATH}
 
   - |
     #build updated cbmc
     ( set -euo pipefail
-      cd ${CBMC}
+      cd ${TRAVIS_BUILD_DIR}/lib/cbmc
       cmake -H. -Bbuild '-DCMAKE_BUILD_TYPE=Release'  '-DCMAKE_CXX_COMPILER=/usr/bin/g++-7'
       cmake --build build --target cbmc -- -j4
     )
-
-  - export PATH=${CBMC}/build/bin:${PATH}
-  - export PATH=$(pwd)/gnat2goto/install/bin:${PATH}
+    export PATH=${TRAVIS_BUILD_DIR}/lib/cbmc/build/bin:${PATH}
 
 script:
   #run the tests


### PR DESCRIPTION
This PR does a number of things to speedup the travis builds:

* Don't require 'sudo' access. 
* Ensures Travis build caches are used as often as possible (eg env variables don't change too often)
* Caches dependencies (gnat and gnatcoll)