### PR TITLE
Make testsuite.py return a fail code when any regression test fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ install:
 
 script:
   #run the tests
-  - (cd testsuite/gnat2goto; ! ./testsuite.py --timeout 60 --diffs --enable-color -j 2 2>&1 >/dev/null | tee /dev/tty | grep -q -E "^ERROR|^UOK")
+  - (cd testsuite/gnat2goto; ./testsuite.py --timeout 60 --diffs --enable-color -j 2 )
   - gnat2goto/install/bin/unit_tests
 
 before_cache:

--- a/testsuite/gnat2goto/testsuite.py
+++ b/testsuite/gnat2goto/testsuite.py
@@ -14,6 +14,7 @@ from gnatpython.testdriver import add_run_test_options
 from gnatpython.reports import ReportDiff
 from glob import glob
 import os
+import sys
 
 
 def main():
@@ -51,15 +52,26 @@ def main():
     if m.options.discs:
         discs += m.options.discs.split(',')
 
+    test_metrics = {'total': len(test_list)}
+
     collect_result = generate_collect_result(
-        m.options.output_dir, m.options.results_file, m.options.view_diffs)
+        result_dir = m.options.output_dir,
+        results_file = m.options.results_file,
+        output_diff = m.options.view_diffs,
+        metrics = test_metrics)
 
     run_testcase = generate_run_testcase('run-test', discs, m.options)
 
     MainLoop(test_list, run_testcase, collect_result, m.options.mainloop_jobs)
+
+    print "Summary: Ran %(run)s/%(total)s tests, with %(failed)s failed, %(crashed)s crashed." % test_metrics
+
     # Generate the report file
     ReportDiff(m.options.output_dir,
                m.options.old_output_dir).txt_image(m.options.report_file)
+
+    if test_metrics['failed'] > 0 or test_metrics['crashed'] > 0:
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change to testsuite.py means we no longer need to have the fragile grep'ing of the output to indicate to travis whether any regression tests failed or not.