### PR TITLE
Make hex bitvector output uppercase

### DIFF
--- a/gnat2goto/driver/binary_to_hex.adb
+++ b/gnat2goto/driver/binary_to_hex.adb
@@ -4,10 +4,11 @@ with Ureal_To_Binary; use Ureal_To_Binary;
 package body Binary_To_Hex is
    function Convert_Binary_To_Hex (Binary : String) return String is
       type Hex_Digit_Pos is mod 16;
+      --  this needs to be uppercase for CBMC
       type Hex_Digit is ('0', '1', '2', '3', '4',
                          '5', '6', '7', '8', '9',
-                         'a', 'b', 'c', 'd', 'e',
-                         'f');
+                         'A', 'B', 'C', 'D', 'E',
+                         'F');
       subtype Binary_Quartet_T is String (1 .. 4);
 
       function Convert_Binary_To_Hex_Digit (Binary_Quartet : Binary_Quartet_T)

--- a/gnat2goto/unit/binary_to_hex_tests.adb
+++ b/gnat2goto/unit/binary_to_hex_tests.adb
@@ -59,7 +59,7 @@ package body Binary_To_Hex_Tests is
         (Uint_128 + Uint_10, 8);
       Hex : constant String := Convert_Binary_To_Hex (Binary);
    begin
-      pragma Assert (Hex = "8a");
+      pragma Assert (Hex = "8A");
    end Convert_138_Test;
 
    procedure Convert_48879_Test is
@@ -67,7 +67,7 @@ package body Binary_To_Hex_Tests is
         (UI_From_Int (48879), 16);
       Hex : constant String := Convert_Binary_To_Hex (Binary);
    begin
-      pragma Assert (Hex = "beef");
+      pragma Assert (Hex = "BEEF");
    end Convert_48879_Test;
 
 end Binary_To_Hex_Tests;


### PR DESCRIPTION
CBMC expects bitvectors in hexadecimal format to be uppercase