### PR TITLE
Strip leading zeroes from hex bitvector output

### DIFF
--- a/gnat2goto/driver/binary_to_hex.adb
+++ b/gnat2goto/driver/binary_to_hex.adb
@@ -2,6 +2,9 @@ with Uint_To_Binary; use Uint_To_Binary;
 with Ureal_To_Binary; use Ureal_To_Binary;
 
 package body Binary_To_Hex is
+
+   function Strip_Leading_Zeroes (Str : String) return String;
+
    function Convert_Binary_To_Hex (Binary : String) return String is
       type Hex_Digit_Pos is mod 16;
       --  this needs to be uppercase for CBMC
@@ -44,7 +47,7 @@ package body Binary_To_Hex is
               (Convert_Binary_To_Hex_Digit (Binary_Quartet)));
          end;
       end loop;
-      return Result;
+      return Strip_Leading_Zeroes (Result);
    end Convert_Binary_To_Hex;
 
    function Convert_Uint_To_Hex (Value : Uint; Bit_Width : Pos) return String
@@ -66,4 +69,14 @@ package body Binary_To_Hex is
           Exponent_Bits,
           Exponent_Bias));
    end Convert_Ureal_To_Hex_IEEE;
+
+   function Strip_Leading_Zeroes (Str : String) return String is
+   begin
+      for Ix in Str'Range loop
+         if Str (Ix) /= '0' then
+            return Str (Ix .. Str'Last);
+         end if;
+      end loop;
+      return "0";
+   end Strip_Leading_Zeroes;
 end Binary_To_Hex;

--- a/gnat2goto/driver/binary_to_hex.ads
+++ b/gnat2goto/driver/binary_to_hex.ads
@@ -4,8 +4,7 @@ with Types; use Types;
 package Binary_To_Hex is
 
    function Convert_Binary_To_Hex (Binary : String) return String with
-     Pre => (Binary'Length mod 4 = 0),
-     Post => (Convert_Binary_To_Hex'Result'Length = Binary'Length / 4);
+     Pre => (Binary'Length mod 4 = 0);
 
    function Convert_Uint_To_Hex (Value : Uint; Bit_Width : Pos) return String
      with Pre => (Bit_Width mod 4 = 0);

--- a/gnat2goto/unit/binary_to_hex_tests.adb
+++ b/gnat2goto/unit/binary_to_hex_tests.adb
@@ -36,7 +36,7 @@ package body Binary_To_Hex_Tests is
       Binary : constant String := Convert_Uint_To_Binary (Uint_0, 32);
       Hex : constant String := Convert_Binary_To_Hex (Binary);
    begin
-      pragma Assert (Hex = "00000000");
+      pragma Assert (Hex = "0");
    end Convert_0_Test;
 
    procedure Convert_2_Test is
@@ -44,7 +44,7 @@ package body Binary_To_Hex_Tests is
         (Uint_2, 16);
       Hex : constant String := Convert_Binary_To_Hex (Binary);
    begin
-      pragma Assert (Hex = "0002");
+      pragma Assert (Hex = "2");
    end Convert_2_Test;
 
    procedure Convert_17_Test is

--- a/testsuite/gnat2goto/tests/primitive_pointer/primitive_pointer.adb
+++ b/testsuite/gnat2goto/tests/primitive_pointer/primitive_pointer.adb
@@ -5,5 +5,5 @@ procedure Primitive_Pointer is
 begin
    A := 5;
    B.all := B.all + 1;
-   --pragma Assert (A = 6);
+   pragma Assert (A = 6);
 end;


### PR DESCRIPTION
CBMC expects hex bitvectors to not have leading zeroes.