### PR TITLE
Fix an for statement initialisation and improve record_init test

### DIFF
--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -3833,7 +3833,9 @@ package body Tree_Walk is
          Append_Declare_And_Init
            (Counter_Sym, Make_Integer_Constant (0, Index_Type), Body_Block, 0);
 
+         Set_Init (Body_Loop, Make_Nil (Get_Source_Location (Body_Loop)));
          Set_Iter (Body_Loop, Make_Increment (Counter_Sym, Index_Type, 1));
+         Set_Type (Loop_Test, Make_Bool_Type);
          Set_Lhs (Loop_Test, Counter_Sym);
          Set_Rhs (Loop_Test, Param_Symbol (Len_Arg));
          Set_Cond (Body_Loop, Loop_Test);

--- a/testsuite/gnat2goto/tests/record_init/test.opt
+++ b/testsuite/gnat2goto/tests/record_init/test.opt
@@ -1,1 +1,1 @@
-ALL XFAIL For some reason gnat2goto generates an empty for statement in here
+ALL XFAIL CBMC fails with __new_array not found, like in arrays


### PR DESCRIPTION
This contains the changes from #98 that are changing the behaviour of gnat2goto. This is to make #98 easier to review, as to isolate in it only the changes that were done in the test suite. After this gets merged, then #98 will be rebased on top of `master`.

This is fixing a particular issue with how a `for` loop in gnat2goto was getting constructed and how it was interacting with the transfer (casting) functions in CBMC. It was creating the following (pseudo)code:

```
int decl;
decl = (some int);
for (/* here is the problem, this is empty */; decl < array_length; decl++)
  {body}
```

The problem with that the CBMC's [to_code_fort](https://github.com/diffblue/cbmc/blob/9129e09d093f55299bc540da42fc6568b0363483/src/util/std_code.h#L971) is doing a precondition check for 4 operands, and the way it was being constructed in gnat2goto only assigned 3 operands, missing the loop variable initialisation because it was done at an earlier stage.