### PR TITLE
Fix LHS assignment in Do_Procedure_Call_Statement and Fix the recursion

### DIFF
--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -2995,7 +2995,7 @@ package body Tree_Walk is
       Set_Identifier (Proc, To_String (Callee));
 
       Set_Source_Location (R, Sloc (N));
-      --  Set_LHS (R, Make_Nil (Sloc (N)));
+      Set_Lhs (R, Make_Nil (Sloc (N)));
       Set_Function (R, Proc);
       Set_Arguments (R, Do_Call_Parameters (N));
 

--- a/testsuite/gnat2goto/tests/recursion/recursion.adb
+++ b/testsuite/gnat2goto/tests/recursion/recursion.adb
@@ -3,6 +3,6 @@ begin
    if (A <= 0) then
       return;
    else
-      Recursion (A - 1);
+      Recursion (A + 1);
    end if;
 end;

--- a/testsuite/gnat2goto/tests/recursion/test.opt
+++ b/testsuite/gnat2goto/tests/recursion/test.opt
@@ -1,1 +1,0 @@
-ALL XFAIL cbmc crashes when reading gnat2goto output

--- a/testsuite/gnat2goto/tests/recursion/test.out
+++ b/testsuite/gnat2goto/tests/recursion/test.out
@@ -1,2 +1,1 @@
-[overflow.1] arithmetic overflow on signed - in recursion__a - 1: SUCCESS
 VERIFICATION SUCCESSFUL


### PR DESCRIPTION
This contains the changes from #98 that are changing the behaviour of gnat2goto. This is to make #98 easier to review, as to isolate in it only the changes that were done in the test suite. After this gets merged, then #98 will be rebased on top of `master`.