### PR TITLE
Initialize ada true/false variables

### DIFF
--- a/gnat2goto/driver/driver.adb
+++ b/gnat2goto/driver/driver.adb
@@ -121,9 +121,57 @@ package body Driver is
          end loop;
       end Initialize_Enum_Values;
 
+      procedure Initialize_Boolean_Values;
+      procedure Initialize_Boolean_Values is
+         True_Symbol_Expr : constant Irep := Make_Symbol_Expr
+           (I_Type => Make_Bool_Type,
+            Identifier => "standard__boolean__true",
+            Source_Location => No_Location);
+         True_Val : constant Irep := Make_Op_Typecast
+           (Op0 => Make_Constant_Expr
+              (I_Type => Int_32_T,
+               Value => "1",
+               Source_Location => No_Location),
+            I_Type => Make_Bool_Type,
+            Source_Location => No_Location);
+         True_Assign : constant Irep := Make_Code_Assign
+           (Lhs => True_Symbol_Expr,
+            Rhs => True_Val,
+            Source_Location => No_Location);
+
+         False_Symbol_Expr : constant Irep := Make_Symbol_Expr
+           (I_Type => Make_Bool_Type,
+            Identifier => "standard__boolean__false",
+            Source_Location => No_Location);
+         False_Val : constant Irep := Make_Op_Typecast
+           (Op0 => Make_Constant_Expr
+              (I_Type => Int_32_T,
+               Value => "0",
+               Source_Location => No_Location),
+            I_Type => Make_Bool_Type,
+            Source_Location => No_Location);
+         False_Assign : constant Irep := Make_Code_Assign
+           (Lhs => False_Symbol_Expr,
+            Rhs => False_Val,
+            Source_Location => No_Location);
+      begin
+         --  True and false only appear in the symbol table if they're actually
+         --  being used in the program, hence we need to check so we don't
+         --  create assignments to undefined symbols
+         if Global_Symbol_Table.Contains (Intern ("standard__boolean__true"))
+         then
+            Append_Op (Start_Body, True_Assign);
+         end if;
+         if Global_Symbol_Table.Contains (Intern ("standard__boolean__false"))
+         then
+            Append_Op (Start_Body, False_Assign);
+         end if;
+      end Initialize_Boolean_Values;
+
    begin
       Initialize_CProver_Rounding_Mode;
       Initialize_Enum_Values;
+      Initialize_Boolean_Values;
    end Initialize_CProver_Internal_Variables;
 
    procedure Translate_Compilation_Unit (GNAT_Root : Node_Id)

--- a/testsuite/gnat2goto/tests/boolean_type/boolean_type.adb
+++ b/testsuite/gnat2goto/tests/boolean_type/boolean_type.adb
@@ -1,0 +1,9 @@
+procedure Boolean_Type is
+  A : Boolean := True;
+  B : Boolean := False;
+begin
+  pragma Assert (A);
+  pragma Assert (B);
+  pragma Assert (True);
+  pragma Assert (False);
+end Boolean_Type;

--- a/testsuite/gnat2goto/tests/boolean_type/test.out
+++ b/testsuite/gnat2goto/tests/boolean_type/test.out
@@ -1,0 +1,5 @@
+[1] file boolean_type.adb line 5 : SUCCESS
+[2] file boolean_type.adb line 6 : FAILURE
+[3] file boolean_type.adb line 7 : SUCCESS
+[4] file boolean_type.adb line 8 : FAILURE
+VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/boolean_type/test.py
+++ b/testsuite/gnat2goto/tests/boolean_type/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
The way we represent Ada Standard True / False is (similar to how we
represent enums) having them be global variables. So far unfortunately
there was no code initialising them, so things like

```
pragma Assert (True)
```

would, confusingly, lead to cbmc assertion failures. This fixes that by
initialising `standard__boolean__{true,false}` in `__CPROVER__start`