### PR TITLE
Pretty json output

### DIFF
--- a/gnat2goto/driver/driver.adb
+++ b/gnat2goto/driver/driver.adb
@@ -227,7 +227,8 @@ package body Driver is
 
       if not Add_Start then
          Put_Line (Sym_Tab_File,
-                   Create (SymbolTable2Json (Global_Symbol_Table)).Write);
+                   Create (SymbolTable2Json (
+                              Global_Symbol_Table)).Write (False));
       else
          Initialize_CProver_Internal_Variables (Start_Body);
          declare
@@ -335,7 +336,8 @@ package body Driver is
          Global_Symbol_Table.Insert (Start_Name, Start_Symbol);
          Follow_Type_Declarations (Global_Symbol_Table, Followed_Symbol_Table);
          Put_Line (Sym_Tab_File,
-                   Create (SymbolTable2Json (Followed_Symbol_Table)).Write);
+                   Create (SymbolTable2Json (
+                              Followed_Symbol_Table)).Write (False));
       end if;
 
       Close (Sym_Tab_File);

--- a/gnat2goto/ireps/ireps_generator.py
+++ b/gnat2goto/ireps/ireps_generator.py
@@ -1916,9 +1916,18 @@ class IrepsGenerator(object):
             self.to_json_single_schema_name(b, sn)
         write(b, "end case;")
         write(b, "")
-        write(b, 'V.Set_Field ("sub",      Sub);')
-        write(b, 'V.Set_Field ("namedSub", Named_Sub);')
-        write(b, 'V.Set_Field ("comment",  Comment);')
+        write(b, "if not Is_Empty (Sub) then")
+        with indent(b):
+            write(b, 'V.Set_Field ("sub",      Sub);')
+        write(b, "end if;")
+        write(b, "if not Is_Empty (Named_Sub) then")
+        with indent(b):
+            write(b, 'V.Set_Field ("namedSub", Named_Sub);')
+        write(b, "end if;")
+        write(b, "if not Is_Empty (Comment) then")
+        with indent(b):
+            write(b, 'V.Set_Field ("comment",  Comment);')
+        write(b, "end if;")
         manual_outdent(b)
         write(b, "end;")
         write(b, "return V;")


### PR DESCRIPTION
This small PR makes the generated JSON slightly prettier/easier to work with. It makes two changes:

1) Produces fully indented JSON, rather than the current compact single line, no indentation form. CProver json-ui will produce indented JSON, so this change mimics the behaviour CProver.

2) Only outputs arrays/objects if they are non-empty. This gets rid of a lot of cruft where we have empty "sub", "namedSub" or "comment" objects.