### PR TITLE
Add failing test for operator abs

### DIFF
--- a/testsuite/gnat2goto/tests/abs/absolute.adb
+++ b/testsuite/gnat2goto/tests/abs/absolute.adb
@@ -1,0 +1,7 @@
+procedure Absolute is
+   A : Integer := -22;
+   B : Integer;
+begin
+   B := abs A;
+   pragma Assert (B >= 0);
+end Absolute;

--- a/testsuite/gnat2goto/tests/abs/test.opt
+++ b/testsuite/gnat2goto/tests/abs/test.opt
@@ -1,0 +1,1 @@
+ALL XFAIL gnat2goto fails with Wrong node kind

--- a/testsuite/gnat2goto/tests/abs/test.py
+++ b/testsuite/gnat2goto/tests/abs/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
We don't have an implementation for computing absolute values (as an in-built
operator). Fix will probably require building a new function (in C) that
implements it and returning a function call.