### PR TITLE
Add failing test for unary minus operator

### DIFF
--- a/testsuite/gnat2goto/tests/minus/minus.adb
+++ b/testsuite/gnat2goto/tests/minus/minus.adb
@@ -1,0 +1,7 @@
+procedure Minus is
+   A : Integer := -22;
+   B : Integer;
+begin
+   B := -A;
+   pragma Assert (B = 22);
+end Minus;

--- a/testsuite/gnat2goto/tests/minus/test.opt
+++ b/testsuite/gnat2goto/tests/minus/test.opt
@@ -1,0 +1,1 @@
+ALL XFAIL gnat2goto fails with Wrong node kind

--- a/testsuite/gnat2goto/tests/minus/test.py
+++ b/testsuite/gnat2goto/tests/minus/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
We only support binary minus. There is unary_minus_exprt in CBMC. We may need to
introduce a new irep to be able to use it.