### PR TITLE
Add failing test for or operator

### DIFF
--- a/testsuite/gnat2goto/tests/lhs_op_or/lhs_op_or.adb
+++ b/testsuite/gnat2goto/tests/lhs_op_or/lhs_op_or.adb
@@ -1,0 +1,8 @@
+procedure LHS_Op_Or is
+   A : Boolean := True;
+   B : Boolean := True;
+   C : Boolean;
+begin
+   C := A or B;
+   pragma Assert (C);
+end LHS_Op_Or;

--- a/testsuite/gnat2goto/tests/lhs_op_or/test.opt
+++ b/testsuite/gnat2goto/tests/lhs_op_or/test.opt
@@ -1,0 +1,1 @@
+ALL XFAIL gna2goto fails with unsupported kind of lhs

--- a/testsuite/gnat2goto/tests/lhs_op_or/test.py
+++ b/testsuite/gnat2goto/tests/lhs_op_or/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
Or (and other logical operators) is not binary (or at least it's irep isn't): we
can't simply set the lhs. We will probably need to handle the n-ary operators
separately, appending the lhs and rhs using the append_op setter.