### PR TITLE
Add failing test for unsupported declarations

### DIFF
--- a/testsuite/gnat2goto/tests/process_statement/external_types.ads
+++ b/testsuite/gnat2goto/tests/process_statement/external_types.ads
@@ -1,0 +1,3 @@
+package External_Types is
+   type New_Integer is new Integer;
+end External_Types;

--- a/testsuite/gnat2goto/tests/process_statement/process_statement.adb
+++ b/testsuite/gnat2goto/tests/process_statement/process_statement.adb
@@ -1,0 +1,14 @@
+with External_Types; use type External_Types.New_Integer;
+
+procedure Process_Statement is
+   A : External_Types.New_Integer := 1;
+   function My_Plus(Left, Right : External_Types.New_Integer) return External_Types.New_Integer renames "+";
+begin
+   A := A + 1;
+   declare
+      B : External_Types.New_Integer := A + 1;
+   begin
+      pragma Assert (B=3);
+   end;
+   pragma Assert (My_Plus(A,A)=2);
+end Process_Statement;

--- a/testsuite/gnat2goto/tests/process_statement/test.opt
+++ b/testsuite/gnat2goto/tests/process_statement/test.opt
@@ -1,0 +1,1 @@
+ALL XFAIL gnat2goto fails unsupported declarations, CBMC fails with malformed symbol

--- a/testsuite/gnat2goto/tests/process_statement/test.py
+++ b/testsuite/gnat2goto/tests/process_statement/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
This new tests only covers N_Renaming_Declaration, N_Block_Statement, and
N_Use_Type_Clause. The first two fail in gnat2goto with warning and the third
fails in CBMC with malformed symbol.