### PR TITLE
Add failing test for funny real literals

### DIFF
--- a/testsuite/gnat2goto/tests/real_literal/real_literal.adb
+++ b/testsuite/gnat2goto/tests/real_literal/real_literal.adb
@@ -1,0 +1,5 @@
+procedure Real_Literal is
+  X : Float := 16777215.0*(2.0**104);
+begin
+   pragma Assert (X>0.0);
+end Real_Literal;

--- a/testsuite/gnat2goto/tests/real_literal/test.opt
+++ b/testsuite/gnat2goto/tests/real_literal/test.opt
@@ -1,0 +1,1 @@
+ALL XFAIL gnat2goto fails with negative denominator

--- a/testsuite/gnat2goto/tests/real_literal/test.py
+++ b/testsuite/gnat2goto/tests/real_literal/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
We do not support negative denominators which can only happen for real literals
represented with base 0. Small reals are represented with base 2 for which
denominator cannot be negative. I think the check can be safely removed but
perhaps we want to investigate the consequences.