### PR TITLE
Add failing test for character literals

### DIFF
--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -1967,6 +1967,9 @@ package body Tree_Walk is
          when N_Quantified_Expression =>
             return Report_Unhandled_Node_Irep (N, "Do_Expression",
                                                "Quantified");
+         when N_Character_Literal =>
+            return Report_Unhandled_Node_Irep (N, "Do_Expression",
+                                             "Character Literals unsupported");
          when others                 =>
             return Report_Unhandled_Node_Irep (N, "Do_Expression",
                                                "Unknown expression kind");

--- a/testsuite/gnat2goto/tests/character_literal/character_literal.adb
+++ b/testsuite/gnat2goto/tests/character_literal/character_literal.adb
@@ -1,0 +1,6 @@
+procedure Character_Literal is
+   A : Character := 'a';
+   B : Character := 'b';
+begin
+   pragma Assert (A > B);
+end Character_Literal;

--- a/testsuite/gnat2goto/tests/character_literal/test.opt
+++ b/testsuite/gnat2goto/tests/character_literal/test.opt
@@ -1,0 +1,1 @@
+ALL XFAIL gnat2goto fails with character literal unsupported

--- a/testsuite/gnat2goto/tests/character_literal/test.py
+++ b/testsuite/gnat2goto/tests/character_literal/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
We don't support character literals: this needs a new function (similar to
`do_constant`) to be called from `do_expression`.