### PR TITLE
Add failing test for floating type definition

### DIFF
--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -1998,11 +1998,16 @@ package body Tree_Walk is
                             Discriminant_Specifications (N));
       E        : constant Entity_Id := Defining_Identifier (N);
    begin
-      if not Is_Type (E) or else
-        not (Kind (New_Type) in Class_Type)
+      if not (Kind (New_Type) in Class_Type)
       then
          Report_Unhandled_Node_Empty (N, "Do_Full_Type_Declaration",
-                                 "identifier not a type or not in class type");
+                      "Identifier not in class type. Type definition failed.");
+         return;
+      end if;
+      if not Is_Type (E)
+      then
+         Report_Unhandled_Node_Empty (N, "Do_Full_Type_Declaration",
+                                      "identifier not a type");
          return;
       end if;
       Do_Type_Declaration (New_Type, E);
@@ -4369,6 +4374,9 @@ package body Tree_Walk is
             return Do_Unconstrained_Array_Definition (N);
          when N_Modular_Type_Definition =>
             return Create_Dummy_Irep;
+         when N_Floating_Point_Definition =>
+            return Report_Unhandled_Node_Irep (N, "Do_Type_Definition",
+                                     "Floating Point Definitions unsupported");
          when others =>
             return Report_Unhandled_Node_Irep (N, "Do_Type_Definition",
                                                "Unknown expression kind");

--- a/testsuite/gnat2goto/tests/floating_definition/floating_definition.adb
+++ b/testsuite/gnat2goto/tests/floating_definition/floating_definition.adb
@@ -1,0 +1,5 @@
+procedure Floating_Definition is
+   type Coefficient is digits 10 range -1.0 .. 1.0;
+begin
+   null;
+end Floating_Definition;

--- a/testsuite/gnat2goto/tests/floating_definition/test.opt
+++ b/testsuite/gnat2goto/tests/floating_definition/test.opt
@@ -1,0 +1,1 @@
+ALL XFAIL gnat2goto fails with type definition and type declaration failure

--- a/testsuite/gnat2goto/tests/floating_definition/test.py
+++ b/testsuite/gnat2goto/tests/floating_definition/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
There is no infrastructure for constructing floating point types in gnat2goto.
This PR introduces a simple test to start with and clears the reporting in
`tree_walk` a bit.