### PR TITLE
Add support for operator and

### DIFF
--- a/testsuite/gnat2goto/tests/op_and/op_and.adb
+++ b/testsuite/gnat2goto/tests/op_and/op_and.adb
@@ -1,0 +1,17 @@
+procedure Op_And is
+  A : boolean := True;
+  B : boolean := False;
+  C : boolean := True;
+begin
+  --  CBMC: false
+  pragma Assert (A and B);
+  --  CBMC: false
+  pragma Assert (B and A);
+  --  CBMC: success
+  pragma Assert (A and A);
+  --  CBMC: false
+  pragma Assert (B and B);
+  --  CBMC: false
+  pragma Assert (C and A and B);
+end Op_And;
+

--- a/testsuite/gnat2goto/tests/op_and/op_and_example.adb
+++ b/testsuite/gnat2goto/tests/op_and/op_and_example.adb
@@ -1,0 +1,17 @@
+procedure Op_And_Example is
+  X : Integer := 0;
+  function Boom return Boolean is
+  begin
+    X := 1;
+    return True;
+  end Boom;
+  A : Boolean := False;
+begin
+  if A and Boom then
+    pragma Assert (False); --  we don't get here because and returns false
+  end if;
+
+  --  X is now 1 because Boom side effect was executed
+  pragma Assert (X = 1);
+  pragma Assert (False);
+end Op_And_Example;

--- a/testsuite/gnat2goto/tests/op_and/test.out
+++ b/testsuite/gnat2goto/tests/op_and/test.out
@@ -1,0 +1,10 @@
+[1] file op_and_example.adb line 11 : SUCCESS
+[2] file op_and_example.adb line 15 : SUCCESS
+[3] file op_and_example.adb line 16 : FAILURE
+VERIFICATION FAILED
+[1] file op_and.adb line 7 : FAILURE
+[2] file op_and.adb line 9 : FAILURE
+[3] file op_and.adb line 11 : SUCCESS
+[4] file op_and.adb line 13 : FAILURE
+[5] file op_and.adb line 15 : FAILURE
+VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/op_and/test.py
+++ b/testsuite/gnat2goto/tests/op_and/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
I started playing around with adding a test for operator `and`, and I noticed we don't support it. Since it's implementation is extremely similar to the `or` operator I implemented yesterday, I figured it wouldn't take me long to implement it.

Without this patch, when we try to run gnat2goto and then cbmc on the result we get this:

```
Standard_Output from gnat2goto op_and:
N_Op_And "Oand" (Node_Id=2293) (source,analyzed)
 Parent = N_Pragma_Argument_Association <No_Name> (Node_Id=2329)
 Sloc = 8325  op_and.adb:7:20
 Chars = "Oand" (Name_Id=300000398)
 Left_Opnd = N_Identifier "a" (Node_Id=2290)
 Right_Opnd = N_Identifier "b" (Node_Id=2292)
 Entity = N_Defining_Identifier "Oand" (Entity_Id=1809s)
 Etype = N_Defining_Identifier "boolean" (Entity_Id=16s)
N_Op_And "Oand" (Node_Id=2300) (source,analyzed)
 Parent = N_Pragma_Argument_Association <No_Name> (Node_Id=2335)
 Sloc = 8370  op_and.adb:9:20
 Chars = "Oand" (Name_Id=300000398)
 Left_Opnd = N_Identifier "b" (Node_Id=2297)
 Right_Opnd = N_Identifier "a" (Node_Id=2299)
 Entity = N_Defining_Identifier "Oand" (Entity_Id=1809s)
 Etype = N_Defining_Identifier "boolean" (Entity_Id=16s)
N_Op_And "Oand" (Node_Id=2307) (source,analyzed)
 Parent = N_Pragma_Argument_Association <No_Name> (Node_Id=2341)
 Sloc = 8417  op_and.adb:11:20
 Chars = "Oand" (Name_Id=300000398)
 Left_Opnd = N_Identifier "a" (Node_Id=2304)
 Right_Opnd = N_Identifier "a" (Node_Id=2306)
 Entity = N_Defining_Identifier "Oand" (Entity_Id=1809s)
 Etype = N_Defining_Identifier "boolean" (Entity_Id=16s)
N_Op_And "Oand" (Node_Id=2314) (source,analyzed)
 Parent = N_Pragma_Argument_Association <No_Name> (Node_Id=2347)
 Sloc = 8462  op_and.adb:13:20
 Chars = "Oand" (Name_Id=300000398)
 Left_Opnd = N_Identifier "b" (Node_Id=2311)
 Right_Opnd = N_Identifier "b" (Node_Id=2313)
 Entity = N_Defining_Identifier "Oand" (Entity_Id=1809s)
 Etype = N_Defining_Identifier "boolean" (Entity_Id=16s)
N_Op_And "Oand" (Node_Id=2321) (source,analyzed)
 Parent = N_Op_And "Oand" (Node_Id=2323)
 Sloc = 8507  op_and.adb:15:20
 Chars = "Oand" (Name_Id=300000398)
 Left_Opnd = N_Identifier "c" (Node_Id=2318)
 Right_Opnd = N_Identifier "a" (Node_Id=2320)
 Entity = N_Defining_Identifier "Oand" (Entity_Id=1809s)
 Etype = N_Defining_Identifier "boolean" (Entity_Id=16s)
N_Op_And "Oand" (Node_Id=2323) (source,analyzed)
 Parent = N_Pragma_Argument_Association <No_Name> (Node_Id=2353)
 Sloc = 8513  op_and.adb:15:26
 Chars = "Oand" (Name_Id=300000398)
 Left_Opnd = N_Op_And "Oand" (Node_Id=2321)
 Right_Opnd = N_Identifier "b" (Node_Id=2322)
 Entity = N_Defining_Identifier "Oand" (Entity_Id=1809s)
 Etype = N_Defining_Identifier "boolean" (Entity_Id=16s)

Standard_Error from gnat2goto op_and:
----------At: Do_Operator_Simple----------
----------Unsupported kind of LHS----------
----------At: Do_Operator_Simple----------
----------Unsupported kind of LHS----------
----------At: Do_Operator_Simple----------
----------Unsupported kind of LHS----------
----------At: Do_Operator_Simple----------
----------Unsupported kind of LHS----------
----------At: Do_Operator_Simple----------
----------Unsupported kind of LHS----------
----------At: Do_Operator_Simple----------
----------Unsupported kind of LHS----------

Error from cbmc op_and:
C++ string exception : `and' must be Boolean, but got and
  * type: nil
  * #source_location: source_location
      * file: op_and.adb
      * line: 7
      * column: 20
  * range_check: 0

ERROR code  6 returned by cbmc when processing op_and
```

With it, we just get:

```
[1] file op_and.adb line 7 : FAILURE
[2] file op_and.adb line 9 : FAILURE
[3] file op_and.adb line 11 : SUCCESS
[4] file op_and.adb line 13 : FAILURE
[5] file op_and.adb line 15 : FAILURE 

 VERIFICATION FAILED
```