### PR TITLE
Fix handling of operator or.

### DIFF
--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -3537,11 +3537,23 @@ package body Tree_Walk is
    function Do_Op_Or (N : Node_Id) return Irep is
       LHS_Bool_Value : constant Irep := Do_Expression (Left_Opnd (N));
       RHS_Bool_Value : constant Irep := Do_Expression (Right_Opnd (N));
-      R : constant Irep := Make_Op_Or (Sloc (N), Make_Bool_Type, False);
+      Cast_LHS_To_Integer : constant Irep :=
+        Make_Op_Typecast (Op0 => LHS_Bool_Value,
+                          Source_Location => Sloc (N),
+                          I_Type => Make_Signedbv_Type (Make_Nil_Type, 32));
+      Cast_RHS_To_Integer : constant Irep :=
+        Make_Op_Typecast (Op0 => RHS_Bool_Value,
+                          Source_Location => Sloc (N),
+                          I_Type => Make_Signedbv_Type (Make_Nil_Type, 32));
+      R : constant Irep := Make_Op_Bitor (Lhs => Cast_LHS_To_Integer,
+                                          Rhs => Cast_RHS_To_Integer,
+                                          Source_Location => Sloc (N),
+                                          I_Type =>
+                                            Get_Type (Cast_LHS_To_Integer));
    begin
-      Append_Op (R, LHS_Bool_Value);
-      Append_Op (R, RHS_Bool_Value);
-      return R;
+      return Make_Op_Typecast (Op0 => R,
+                               Source_Location => Sloc (N),
+                               I_Type => Make_Bool_Type);
    end Do_Op_Or;
 
    -------------------------

--- a/testsuite/gnat2goto/tests/op_or/op_or_example.adb
+++ b/testsuite/gnat2goto/tests/op_or/op_or_example.adb
@@ -1,0 +1,17 @@
+procedure Op_Or_Example is
+  X : Integer := 0;
+  function Boom return Boolean is
+  begin
+    X := 1;
+    return True;
+  end Boom;
+  A : Boolean := True;
+begin
+  if A or Boom then
+    pragma Assert (True); --  we should get here so this should be SUCCESS
+  end if;
+
+  --  X is now 1 because Boom side effect was executed
+  pragma Assert (X = 1);
+  pragma Assert (False);
+end Op_Or_Example;

--- a/testsuite/gnat2goto/tests/op_or/test.out
+++ b/testsuite/gnat2goto/tests/op_or/test.out
@@ -3,5 +3,8 @@
 [3] file op_or.adb line 8 : SUCCESS
 [4] file op_or.adb line 9 : FAILURE
 [5] file op_or.adb line 10 : SUCCESS
-
+VERIFICATION FAILED
+[1] file op_or_example.adb line 11 : SUCCESS
+[2] file op_or_example.adb line 15 : SUCCESS
+[3] file op_or_example.adb line 16 : FAILURE
 VERIFICATION FAILED


### PR DESCRIPTION
Before this change, the operator or had been implemented as the short circuiting operator, which in reality is or else. This fixes the semantics to be closer to the non-short circuiting operator.