### PR TITLE
Do not depend on file ordering in testsuite

### DIFF
--- a/testsuite/gnat2goto/lib/python/test_support.py
+++ b/testsuite/gnat2goto/lib/python/test_support.py
@@ -17,7 +17,9 @@ os.chdir(TESTDIR)
 
 def ada_body_files():
     """Return list of *.adb files in the current folder."""
-    return [f for f in os.listdir(os.curdir)\
+    files = os.listdir(os.curdir)
+    files.sort()
+    return [f for f in files\
             if os.path.isfile(f) and fnmatch.fnmatch (f, "*.adb")]
 
 def filter_timing(results):
@@ -59,7 +61,7 @@ def process(debug, file, cbmcargs):
         print "ERROR code ", g2go_results.status, " returned by gnat2goto when translating " + unit
         print "CBMC not run"
         return ""
-    
+
     # only run the following if gnat2goto succeeded
     # Run(["cbmc", jsout, "--show-symbol-table"], output=symtab)
     # Run(["cbmc", jsout, "--show-goto-functions"], output=gotoprog)
@@ -75,7 +77,7 @@ def process(debug, file, cbmcargs):
         print cbmcerr_text
     if results.status != 0 and results.status != 10:
         print "ERROR code ", results.status, "returned by cbmc when processing " + unit
-    
+
     return filter_timing(results.out)
 
 

--- a/testsuite/gnat2goto/tests/op_and/test.out
+++ b/testsuite/gnat2goto/tests/op_and/test.out
@@ -1,10 +1,10 @@
-[1] file op_and_example.adb line 11 : SUCCESS
-[2] file op_and_example.adb line 15 : SUCCESS
-[3] file op_and_example.adb line 16 : FAILURE
-VERIFICATION FAILED
 [1] file op_and.adb line 7 : FAILURE
 [2] file op_and.adb line 9 : FAILURE
 [3] file op_and.adb line 11 : SUCCESS
 [4] file op_and.adb line 13 : FAILURE
 [5] file op_and.adb line 15 : FAILURE
+VERIFICATION FAILED
+[1] file op_and_example.adb line 11 : SUCCESS
+[2] file op_and_example.adb line 15 : SUCCESS
+[3] file op_and_example.adb line 16 : FAILURE
 VERIFICATION FAILED


### PR DESCRIPTION
Previously test output could have changed depending on what the OS or
filesystem decided would be appropriate, which could lead to randomly
breaking tests. This makes sure that test cases are always sorted
alphabetically.

Fixes #141