### PR TITLE
Introduce floating point type definition

### DIFF
--- a/gnat2goto/driver/binary_to_hex.adb
+++ b/gnat2goto/driver/binary_to_hex.adb
@@ -56,11 +56,16 @@ package body Binary_To_Hex is
         Convert_Uint_To_Binary (Value, Bit_Width));
    end Convert_Uint_To_Hex;
 
+   --  This function should not be used directly: used the wrappers below
+   --  instead.
+   --  See e.g. https://en.wikipedia.org/wiki/IEEE_754 for more info on the
+   --  fraction and exponent bits and the exponent bias; and the conversion
+   --  algorithm in general.
    function Convert_Ureal_To_Hex_IEEE
      (Value : Ureal;
-      Fraction_Bits : Positive := 23;
-      Exponent_Bits : Positive := 8;
-      Exponent_Bias : Positive := 127) return String
+      Fraction_Bits : Positive;
+      Exponent_Bits : Positive;
+      Exponent_Bias : Positive) return String
    is begin
       return Convert_Binary_To_Hex (
        Convert_Ureal_To_Binary_IEEE
@@ -69,6 +74,24 @@ package body Binary_To_Hex is
           Exponent_Bits,
           Exponent_Bias));
    end Convert_Ureal_To_Hex_IEEE;
+
+   --  Convert Ada real to IEEE float in HEX (as a string)
+   function Convert_Ureal_To_Hex_32bits_IEEE (Value : Ureal) return String
+   is begin
+      return Convert_Ureal_To_Hex_IEEE (Value         => Value,
+                                        Fraction_Bits => 23,
+                                        Exponent_Bits => 8,
+                                        Exponent_Bias => 127);
+   end Convert_Ureal_To_Hex_32bits_IEEE;
+
+   --  Convert Ada real to IEEE double in HEX (as a string)
+   function Convert_Ureal_To_Hex_64bits_IEEE (Value : Ureal) return String
+   is begin
+      return Convert_Ureal_To_Hex_IEEE (Value         => Value,
+                                        Fraction_Bits => 52,
+                                        Exponent_Bits => 11,
+                                        Exponent_Bias => 1023);
+   end Convert_Ureal_To_Hex_64bits_IEEE;
 
    function Strip_Leading_Zeroes (Str : String) return String is
    begin

--- a/gnat2goto/driver/binary_to_hex.ads
+++ b/gnat2goto/driver/binary_to_hex.ads
@@ -11,8 +11,11 @@ package Binary_To_Hex is
 
    function Convert_Ureal_To_Hex_IEEE
      (Value : Ureal;
-      Fraction_Bits : Positive := 23;
-      Exponent_Bits : Positive := 8;
-      Exponent_Bias : Positive := 127) return String
+      Fraction_Bits : Positive;
+      Exponent_Bits : Positive;
+      Exponent_Bias : Positive) return String
      with Pre => ((Fraction_Bits + Exponent_Bits + 1) mod 4 = 0);
+
+   function Convert_Ureal_To_Hex_32bits_IEEE (Value : Ureal) return String;
+   function Convert_Ureal_To_Hex_64bits_IEEE (Value : Ureal) return String;
 end Binary_To_Hex;

--- a/gnat2goto/driver/driver.adb
+++ b/gnat2goto/driver/driver.adb
@@ -542,15 +542,7 @@ package body Driver is
                      --  interesting for now... Let's use float32 or float64
                      --  for now and fix this later.
 
-                     Set_F (Type_Irep,
-                            (case Esize_Width is
-                                when 32     => 23,
-                                --  23-bit mantissa, 8-bit exponent
-
-                                when 64     => 52,
-                                --  52-bit mantissa, 11-bit exponent
-
-                                when others => raise Program_Error));
+                     Set_F (Type_Irep, Float_Mantissa_Size (Type_Irep));
                   end if;
 
                   Builtin.Name       := Intern (Unique_Name (Builtin_Node));

--- a/gnat2goto/driver/goto_utils.adb
+++ b/gnat2goto/driver/goto_utils.adb
@@ -329,6 +329,32 @@ package body GOTO_Utils is
                           I_Type          => Pointer_Type);
    end Offset_Array_Data;
 
+   function To_Float_Format (Float_Type : Irep) return Float_Format
+   is
+      Float_Width : constant Integer := Get_Width (Float_Type);
+      Unsupported_Float_Width : exception;
+   begin
+      case Float_Width is
+         when 32 => return IEEE_32_Bit;
+         when 64 => return IEEE_64_Bit;
+         when others =>
+            raise Unsupported_Float_Width
+              with "Unsupported float width: " &  Integer'Image (Float_Width);
+      end case;
+   end To_Float_Format;
+
+   function Float_Mantissa_Size (Float_Type : Irep) return Integer
+   is
+      Format : constant Float_Format := To_Float_Format (Float_Type);
+   begin
+      case Format is
+         when IEEE_32_Bit =>
+            return 23;
+         when IEEE_64_Bit =>
+            return 52;
+      end case;
+   end Float_Mantissa_Size;
+
    ---------------------
    -- Name_Has_Prefix --
    ---------------------

--- a/gnat2goto/driver/goto_utils.ads
+++ b/gnat2goto/driver/goto_utils.ads
@@ -93,7 +93,14 @@ package GOTO_Utils is
      with Pre => (Kind (Base) in Class_Expr
                   and then Kind (Offset) in Class_Expr
                   and then Kind (Pointer_Type) = I_Pointer_Type),
-       Post => Get_Type (Offset_Array_Data'Result) = Pointer_Type;
+     Post => Get_Type (Offset_Array_Data'Result) = Pointer_Type;
+
+   type Float_Format is (IEEE_32_Bit, IEEE_64_Bit);
+
+   function To_Float_Format (Float_Type : Irep) return Float_Format
+     with Pre => Kind (Float_Type) in I_Floatbv_Type | I_Bounded_Floatbv_Type;
+
+   function Float_Mantissa_Size (Float_Type : Irep) return Integer;
 
    function Build_Index_Constant (Value : Int; Index_Type : Irep;
                                   Source_Loc : Source_Ptr) return Irep

--- a/gnat2goto/driver/range_check.adb
+++ b/gnat2goto/driver/range_check.adb
@@ -1,4 +1,6 @@
 with Binary_To_Hex;         use Binary_To_Hex;
+with Types;                 use Types;
+with GOTO_Utils;             use GOTO_Utils;
 
 package body Range_Check is
 
@@ -14,12 +16,26 @@ package body Range_Check is
       return Length;
    end Store_Bound;
 
+   ----------------------
+   -- Store_Real_Bound --
+   ----------------------
+
+   function Store_Real_Bound (Number : Bound_Type_Real) return Integer
+   is
+      Length : constant Integer := Integer (Integer_Bounds_Real_Table.Length);
+   begin
+      Integer_Bounds_Real_Table.Append (Number);
+      return Length;
+   end Store_Real_Bound;
+
    -----------------------
    -- Load_Bound_In_Hex --
    -----------------------
 
-   function Load_Bound_In_Hex (Index : Integer; Bit_Width : Pos) return String
+   function Load_Bound_In_Hex (Index : Integer; Actual_Type : Irep)
+                               return String
    is
+      Bit_Width : constant Pos := Pos (Get_Width (Actual_Type));
       Bound : constant Uint := Uint (Integer_Bounds_Table.Element (Index));
    begin
       return Convert_Uint_To_Hex (
@@ -27,4 +43,20 @@ package body Range_Check is
                  Bit_Width => Bit_Width);
    end Load_Bound_In_Hex;
 
+   ----------------------------
+   -- Load_Real_Bound_In_Hex --
+   ----------------------------
+
+   function Load_Real_Bound_In_Hex (Index : Integer; Actual_Type : Irep)
+                                    return String
+   is
+      Bit_Width : constant Float_Format := To_Float_Format (Actual_Type);
+      Bound : constant Ureal :=
+        Ureal (Integer_Bounds_Real_Table.Element (Index));
+   begin
+      case Bit_Width is
+         when IEEE_32_Bit => return Convert_Ureal_To_Hex_32bits_IEEE (Bound);
+         when IEEE_64_Bit => return Convert_Ureal_To_Hex_64bits_IEEE (Bound);
+      end case;
+   end Load_Real_Bound_In_Hex;
 end Range_Check;

--- a/gnat2goto/driver/range_check.ads
+++ b/gnat2goto/driver/range_check.ads
@@ -1,20 +1,34 @@
 with Uintp;                  use Uintp;
-with Types;                  use Types;
+with Urealp;                 use Urealp;
+with Ireps;                  use Ireps;
 
 with Ada.Containers.Vectors; use Ada.Containers;
 package Range_Check is
 
    type Bound_Type is new Uint;
+   type Bound_Type_Real is new Ureal;
 
    package Integer_Bounds_Vector is new
      Ada.Containers.Vectors (Index_Type   => Natural,
                              Element_Type => Bound_Type);
+   package Integer_Bounds_Real_Vector is new
+     Ada.Containers.Vectors (Index_Type   => Natural,
+                             Element_Type => Bound_Type_Real);
 
    function Store_Bound (Number : Bound_Type) return Integer;
+   function Store_Real_Bound (Number : Bound_Type_Real) return Integer;
 
    Integer_Bounds_Table : Integer_Bounds_Vector.Vector;
+   Integer_Bounds_Real_Table : Integer_Bounds_Real_Vector.Vector;
 
-   function Load_Bound_In_Hex (Index : Integer; Bit_Width : Pos) return String
-     with Pre => Integer (Integer_Bounds_Table.Length) >= Index;
-
+   function Load_Bound_In_Hex (Index : Integer; Actual_Type : Irep)
+                               return String
+     with Pre => (Kind (Actual_Type) = I_Bounded_Signedbv_Type
+                  and then
+                    Integer (Integer_Bounds_Table.Length) >= Index);
+   function Load_Real_Bound_In_Hex (Index : Integer; Actual_Type : Irep)
+                                    return String
+     with Pre => (Kind (Actual_Type) = I_Bounded_Floatbv_Type
+                  and then
+                    Integer (Integer_Bounds_Real_Table.Length) >= Index);
 end Range_Check;

--- a/gnat2goto/driver/ureal_to_binary.adb
+++ b/gnat2goto/driver/ureal_to_binary.adb
@@ -106,9 +106,9 @@ package body Ureal_To_Binary is
    end Convert_Ureal_To_Binary_Fixed;
 
    function Convert_Ureal_To_Binary_IEEE (Number : Ureal;
-                                         Fraction_Bits : Positive := 23;
-                                         Exponent_Bits : Positive := 8;
-                                         Exponent_Bias : Positive := 127)
+                                         Fraction_Bits : Positive;
+                                         Exponent_Bits : Positive;
+                                         Exponent_Bias : Positive)
                                          return String is
       Is_Negative : constant Boolean := Number < Ureal_0;
       Int_Part : String (1 .. 2**(Exponent_Bits - 1));

--- a/gnat2goto/driver/ureal_to_binary.ads
+++ b/gnat2goto/driver/ureal_to_binary.ads
@@ -6,9 +6,9 @@ package Ureal_To_Binary is
                                            Max_Digits : Positive := 30)
                                           return String;
    function Convert_Ureal_To_Binary_IEEE (Number : Ureal;
-                                         Fraction_Bits : Positive := 23;
-                                         Exponent_Bits : Positive := 8;
-                                         Exponent_Bias : Positive := 127)
+                                         Fraction_Bits : Positive;
+                                         Exponent_Bits : Positive;
+                                         Exponent_Bias : Positive)
      return String
      with Post => (Convert_Ureal_To_Binary_IEEE'Result'Length
                      = Fraction_Bits + Exponent_Bits + 1);

--- a/gnat2goto/ireps/irep_specs/bounded_floatbv_type.json
+++ b/gnat2goto/ireps/irep_specs/bounded_floatbv_type.json
@@ -1,0 +1,9 @@
+{
+  "parent": "bitvector_type",
+  "id": "bounded_floatbv",
+   "namedSub": {
+      "f": {"type": "integer"},
+    "lower_bound": {"type": "integer"},
+    "upper_bound": {"type": "integer"}
+  }
+}

--- a/gnat2goto/ireps/ireps_generator.py
+++ b/gnat2goto/ireps/ireps_generator.py
@@ -2050,6 +2050,11 @@ class IrepsGenerator(object):
             write(b, "return Make_Signedbv_Type (Get_Subtype (I), Get_Width (I));")
         write(b, "end if;")
         write(b, "")
+        write(b, "if Kind (I) = I_Bounded_Floatbv_Type then")
+        with indent(b):
+            write(b, "return Make_Floatbv_Type (Get_Subtype (I), Get_Width (I), Get_F (I));")
+        write(b, "end if;")
+        write(b, "")
         write(b, "declare")
         with indent(b):
             write(b, "N : Irep_Node renames Irep_Table.Table (I);")

--- a/gnat2goto/unit/floating_point_tests.adb
+++ b/gnat2goto/unit/floating_point_tests.adb
@@ -35,7 +35,8 @@ package body Floating_Point_Tests is
         & "00000000"
         & "0000000";
    begin
-      pragma Assert (Convert_Ureal_To_Binary_IEEE (Eight) = IEEE_Bits);
+      pragma Assert (Convert_Ureal_To_Binary_IEEE (Eight, 23, 8, 127)
+                     = IEEE_Bits);
    end Test_Integer;
 
    procedure Test_Between_0_And_1 is
@@ -48,8 +49,8 @@ package body Floating_Point_Tests is
         & "00000000"
         & "0000000";
    begin
-      pragma Assert (Convert_Ureal_To_Binary_IEEE (Zero_Point_Seven_Five)
-                    = IEEE_Bits);
+      pragma Assert (Convert_Ureal_To_Binary_IEEE
+                     (Zero_Point_Seven_Five, 23, 8, 127) = IEEE_Bits);
    end Test_Between_0_And_1;
 
    procedure Test_General is
@@ -62,8 +63,8 @@ package body Floating_Point_Tests is
         & "00000000"
         & "0000000";
    begin
-      pragma Assert (Convert_Ureal_To_Binary_IEEE (Three_Point_Five)
-                    = IEEE_Bits);
+      pragma Assert (Convert_Ureal_To_Binary_IEEE
+                     (Three_Point_Five, 23, 8, 127) = IEEE_Bits);
    end Test_General;
 
    procedure Test_Negative_Integer is
@@ -76,8 +77,8 @@ package body Floating_Point_Tests is
         & "00000000"
         & "0000000";
    begin
-      pragma Assert (Convert_Ureal_To_Binary_IEEE (Minus_Three)
-                    = IEEE_Bits);
+      pragma Assert (Convert_Ureal_To_Binary_IEEE (Minus_Three, 23, 8, 127)
+                     = IEEE_Bits);
    end Test_Negative_Integer;
 
    procedure Test_Negative_Between_0_And_1 is
@@ -90,8 +91,8 @@ package body Floating_Point_Tests is
         & "00000000"
         & "0000000";
    begin
-      pragma Assert (Convert_Ureal_To_Binary_IEEE (Minus_Zero_Point_Five)
-                    = IEEE_Bits);
+      pragma Assert (Convert_Ureal_To_Binary_IEEE
+                     (Minus_Zero_Point_Five, 23, 8, 127) = IEEE_Bits);
    end Test_Negative_Between_0_And_1;
 
    procedure Test_Negative_General is
@@ -104,8 +105,8 @@ package body Floating_Point_Tests is
         & "00000000"
         & "0000000";
    begin
-      pragma Assert (Convert_Ureal_To_Binary_IEEE (Minus_Forty_Point_Five)
-                       = IEEE_Bits);
+      pragma Assert (Convert_Ureal_To_Binary_IEEE
+                     (Minus_Forty_Point_Five, 23, 8, 127) = IEEE_Bits);
    end Test_Negative_General;
 
    procedure Test_Zero is
@@ -116,8 +117,8 @@ package body Floating_Point_Tests is
         & "00000000" -- which is the closest we get to 0 with 32 bit float
         & "0000000";
    begin
-      pragma Assert (Convert_Ureal_To_Binary_IEEE (Ureal_0)
-                    = IEEE_Bits);
+      pragma Assert (Convert_Ureal_To_Binary_IEEE (Ureal_0, 23, 8, 127)
+                     = IEEE_Bits);
    end Test_Zero;
 
    procedure Test_One_Point_Two is
@@ -131,7 +132,7 @@ package body Floating_Point_Tests is
         + Ureal_1;
    begin
       pragma Assert
-        (Convert_Ureal_To_Binary_IEEE (One_Point_Two) = IEEE_Bits);
+        (Convert_Ureal_To_Binary_IEEE (One_Point_Two, 23, 8, 127) = IEEE_Bits);
    end Test_One_Point_Two;
 
    procedure Test_Suite is

--- a/testsuite/gnat2goto/tests/floating_definition/floating_definition.adb
+++ b/testsuite/gnat2goto/tests/floating_definition/floating_definition.adb
@@ -1,5 +1,12 @@
 procedure Floating_Definition is
-   type Coefficient is digits 10 range -1.0 .. 1.0;
+   type Coefficient is digits 10 range -1.0 .. 2.0;
+   type Unbounded is digits 8;
+
+   Small_Number : Coefficient := 0.5;
+   Large_Number : Unbounded := 22.0;
 begin
-   null;
+   Large_Number := Large_Number + 0.7;
+   Small_Number := Small_Number * 2.0;
+   pragma Assert (Small_Number > 0.9);
+   pragma Assert (Large_Number > 22.7);
 end Floating_Definition;

--- a/testsuite/gnat2goto/tests/floating_definition/test.opt
+++ b/testsuite/gnat2goto/tests/floating_definition/test.opt
@@ -1,1 +1,0 @@
-ALL XFAIL gnat2goto fails with type definition and type declaration failure

--- a/testsuite/gnat2goto/tests/floating_definition/test.out
+++ b/testsuite/gnat2goto/tests/floating_definition/test.out
@@ -1,0 +1,4 @@
+[assertion.1] Range Check: SUCCESS
+[1] file floating_definition.adb line 10 : SUCCESS
+[2] file floating_definition.adb line 11 : FAILURE
+VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/floating_point_literals/floating_point_literals.adb
+++ b/testsuite/gnat2goto/tests/floating_point_literals/floating_point_literals.adb
@@ -2,9 +2,11 @@ procedure Floating_Point_Literals is
   X : Float := 1.0;
   Y : Float := 1.0;
   Z : Float := 3.0;
+  W : Float := 1.1;
 begin
   pragma Assert (X > Z);
   pragma Assert (X < Z);
   pragma Assert (X + Y = Z);
   pragma Assert (X + Y < Z);
+  pragma Assert (W < 1.2);
 end Floating_Point_Literals;

--- a/testsuite/gnat2goto/tests/floating_point_literals/test.opt
+++ b/testsuite/gnat2goto/tests/floating_point_literals/test.opt
@@ -1,0 +1,1 @@
+ALL XFAIL CBMC reads wrong value of the non-zero fraction

--- a/testsuite/gnat2goto/tests/floating_point_literals/test.out
+++ b/testsuite/gnat2goto/tests/floating_point_literals/test.out
@@ -1,5 +1,0 @@
-[1] file floating_point_literals.adb line 6 : FAILURE
-[2] file floating_point_literals.adb line 7 : SUCCESS
-[3] file floating_point_literals.adb line 8 : FAILURE
-[4] file floating_point_literals.adb line 9 : SUCCESS
-VERIFICATION FAILED


### PR DESCRIPTION
The type definition may contain ranges so this PR also brings in a new irep spec for bounded floatbv type, conversion to regular floatbv type, storage for real bounds, etc. We also found a bug in the conversion and demonstrate it via a modified test.