### PR TITLE
Add failing float conversion test

### DIFF
--- a/gnat2goto/unit/floating_point_tests.adb
+++ b/gnat2goto/unit/floating_point_tests.adb
@@ -16,6 +16,7 @@ package body Floating_Point_Tests is
    procedure Test_Negative_General;
 
    procedure Test_Zero;
+   procedure Test_One_Point_Two;
 
    procedure Test_Suite;
 
@@ -119,9 +120,22 @@ package body Floating_Point_Tests is
                     = IEEE_Bits);
    end Test_Zero;
 
+   procedure Test_One_Point_Two is
+      IEEE_Bits : constant String :=
+        "0"
+        & "01111111"
+        & "00110011"
+        & "00110011"
+        & "0011010";
+      One_Point_Two : constant Ureal := UR_From_Components (Uint_2, Uint_10)
+        + Ureal_1;
+   begin
+      pragma Assert
+        (Convert_Ureal_To_Binary_IEEE (One_Point_Two) = IEEE_Bits);
+   end Test_One_Point_Two;
+
    procedure Test_Suite is
    begin
-
       Uintp.Initialize;
       Urealp.Initialize;
 
@@ -137,6 +151,8 @@ package body Floating_Point_Tests is
 
       Test_Util.Run_Test ("Zero",
                          Test_Zero'Access);
+      Test_Util.Expect_Failure ("1.2 is incorrectly converted",
+                         Test_One_Point_Two'Access);
    end Test_Suite;
 
 end Floating_Point_Tests;

--- a/gnat2goto/unit/test_util.adb
+++ b/gnat2goto/unit/test_util.adb
@@ -3,6 +3,8 @@ package body Test_Util is
 
    package IO renames Ada.Text_IO;
 
+   Unexpected_Success : exception;
+
    Suite_Test_Count : Natural;
    Suite_Failed_Test_Count : Natural;
 
@@ -20,6 +22,27 @@ package body Test_Util is
             Suite_Failed_Test_Count := Suite_Failed_Test_Count + 1;
             IO.Put_Line (" [Fail]");
    end Run_Test;
+
+   procedure Expect_Failure (Name : String; Test : Unit_Test) is
+      procedure Expect_Failure_Test;
+      procedure Expect_Failure_Test is
+      begin
+         begin
+            Test.all;
+         exception
+            when others =>
+               return;
+         end;
+         raise Unexpected_Success;
+      end Expect_Failure_Test;
+   begin
+      --  Unrestricted Access is a GNAT extension
+      --  that allows us to access things that
+      --  are more deeply nested than the access type
+      --  itself
+      Run_Test ("[Expect Failure] " & Name,
+                Expect_Failure_Test'Unrestricted_Access);
+   end Expect_Failure;
 
    procedure Run_Test_Suite (Name : String; Suite : Test_Suite) is
    begin

--- a/gnat2goto/unit/test_util.ads
+++ b/gnat2goto/unit/test_util.ads
@@ -2,8 +2,18 @@ package Test_Util is
    type Unit_Test is access procedure;
    type Test_Suite is access procedure;
 
+   --  Run a test. Succeeds if Test doesn't throw an exception
    procedure Run_Test (Name : String; Test : Unit_Test);
+
+   --  Like Run_Test, but fail on success and succeed on failure
+   procedure Expect_Failure (Name : String; Test : Unit_Test);
+
+   --  Run a suite of tests.
+   --  Suite should be a procedure that calls Run_Test
+   --  or Expect_Failure for each test of the suite.
    procedure Run_Test_Suite (Name : String; Suite : Test_Suite);
 
+   --  True if any tests in any suite failed
    function Has_Test_Failures return Boolean;
+
 end Test_Util;


### PR DESCRIPTION
Currently 1.2 and 1.1 get converted to 1.8 instead, this unit test documents and checks for this buggy behaviour.

Also adds a facility to expect test failures for the unit tests.

This is related to https://github.com/diffblue/gnat2goto/pull/148, I also wanted a unit test for the conversion bug that was found in there.