### PR TITLE
Array attributes first and last

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -1,4 +1,4 @@
-Occurs: 2448 times
+Occurs: 2447 times
 Calling function: Process_Declaration
 Error message: Pragmas in declaration
 Nkind: N_Pragma
@@ -13,17 +13,12 @@ Calling function: Process_Declaration
 Error message: Unknown declaration kind
 Nkind: N_Freeze_Generic_Entity
 --
-Occurs: 160 times
+Occurs: 159 times
 Calling function: Process_Declaration
 Error message: Number declaration
 Nkind: N_Number_Declaration
 --
-Occurs: 132 times
-Calling function: Do_Expression
-Error message: First attribute
-Nkind: N_Attribute_Reference
---
-Occurs: 121 times
+Occurs: 117 times
 Calling function: Do_Function_Call
 Error message: func name not in symbol table
 Nkind: N_Function_Call
@@ -33,40 +28,25 @@ Calling function: Process_Declaration
 Error message: Generic declaration
 Nkind: N_Generic_Subprogram_Declaration
 --
-Occurs: 90 times
-Calling function: Do_Expression
-Error message: Last attribute
-Nkind: N_Attribute_Reference
---
-Occurs: 86 times
+Occurs: 78 times
 Calling function: Do_Expression
 Error message: Unknown attribute
 Nkind: N_Attribute_Reference
---
-Occurs: 49 times
-Calling function: Process_Statement
-Error message: Raise statement
-Nkind: N_Raise_Statement
 --
 Occurs: 42 times
 Calling function: Do_Type_Definition
 Error message: Access type unsupported
 Nkind: N_Access_To_Object_Definition
 --
+Occurs: 39 times
+Calling function: Process_Statement
+Error message: Raise statement
+Nkind: N_Raise_Statement
+--
 Occurs: 37 times
 Calling function: Process_Declaration
 Error message: Package declaration
 Nkind: N_Package_Declaration
---
-Occurs: 29 times
-Calling function: Do_Expression
-Error message: Unknown expression kind
-Nkind: N_Raise_Expression
---
-Occurs: 22 times
-Calling function: Do_Procedure_Call_Statement
-Error message: sym id not in symbol table
-Nkind: N_Procedure_Call_Statement
 --
 Occurs: 21 times
 Calling function: Process_Declaration
@@ -88,20 +68,15 @@ Calling function: Process_Declaration
 Error message: Package body declaration
 Nkind: N_Package_Body
 --
-Occurs: 18 times
-Calling function: Process_Statement
-Error message: Extended return statement
-Nkind: N_Extended_Return_Statement
+Occurs: 17 times
+Calling function: Do_Procedure_Call_Statement
+Error message: sym id not in symbol table
+Nkind: N_Procedure_Call_Statement
 --
 Occurs: 15 times
 Calling function: Process_Declaration
 Error message: Unknown declaration kind
 Nkind: N_Null_Statement
---
-Occurs: 14 times
-Calling function: Do_Function_Call
-Error message: function entity not defining identifier
-Nkind: N_Function_Call
 --
 Occurs: 13 times
 Calling function: Do_Constant
@@ -134,11 +109,6 @@ Error message: Unknown expression kind
 Nkind: N_Null
 --
 Occurs: 7 times
-Calling function: Do_Itype_Integer_Subtype
-Error message: Non-literal bound unsupported
-Nkind: N_Defining_Identifier
---
-Occurs: 7 times
 Calling function: Process_Declaration
 Error message: Unknown declaration kind
 Nkind: N_Validate_Unchecked_Conversion
@@ -148,20 +118,10 @@ Calling function: Process_Declaration
 Error message: Use package clause declaration
 Nkind: N_Use_Package_Clause
 --
-Occurs: 6 times
-Calling function: Process_Statement
-Error message: Unknown expression kind
-Nkind: N_Freeze_Entity
---
 Occurs: 5 times
 Calling function: Do_Operator_General
 Error message: Concat unsupported
 Nkind: N_Op_Concat
---
-Occurs: 5 times
-Calling function: Do_Operator_Simple
-Error message: Unsupported operand
-Nkind: N_Op_Expon
 --
 Occurs: 5 times
 Calling function: Do_Type_Definition
@@ -189,6 +149,11 @@ Error message: Generic declaration
 Nkind: N_Generic_Package_Declaration
 --
 Occurs: 3 times
+Calling function: Do_Operator_Simple
+Error message: Unsupported operand
+Nkind: N_Op_Expon
+--
+Occurs: 3 times
 Calling function: Process_Statement
 Error message: Unknown expression kind
 Nkind: N_Object_Declaration
@@ -203,6 +168,21 @@ Calling function: Do_Base_Range_Constraint
 Error message: range expression not bitvector type
 Nkind: N_Range
 --
+Occurs: 2 times
+Calling function: Do_Constant
+Error message: Constant Type not in Class_Bitvector_Type
+Nkind: N_Integer_Literal
+--
+Occurs: 2 times
+Calling function: Do_Function_Call
+Error message: function entity not defining identifier
+Nkind: N_Function_Call
+--
+Occurs: 2 times
+Calling function: Do_Itype_Integer_Subtype
+Error message: Non-literal bound unsupported
+Nkind: N_Defining_Identifier
+--
 Occurs: 1 times
 Calling function: Do_Base_Range_Constraint
 Error message: low bound range expression not literal
@@ -214,11 +194,6 @@ Error message: Unknown tree node
 Nkind: N_Compilation_Unit
 --
 Occurs: 1 times
-Calling function: Do_Constant
-Error message: Constant Type not in Class_Bitvector_Type
-Nkind: N_Integer_Literal
---
-Occurs: 1 times
 Calling function: Do_Pragma
 Error message: Unknown pragma name
 Nkind: N_Pragma
@@ -227,6 +202,11 @@ Occurs: 1 times
 Calling function: Process_Declaration
 Error message: Subprogram body stub declaration
 Nkind: N_Subprogram_Body_Stub
+--
+Occurs: 1 times
+Calling function: Process_Statement
+Error message: Extended return statement
+Nkind: N_Extended_Return_Statement
 --
 Occurs: 1 times
 Calling function: Process_Statement

--- a/experiments/golden-results/Tokeneer-summary.txt
+++ b/experiments/golden-results/Tokeneer-summary.txt
@@ -60,16 +60,6 @@ Nkind: N_Enumeration_Representation_Clause
 --
 Occurs: 4 times
 Calling function: Do_Expression
-Error message: First attribute
-Nkind: N_Attribute_Reference
---
-Occurs: 4 times
-Calling function: Do_Expression
-Error message: Last attribute
-Nkind: N_Attribute_Reference
---
-Occurs: 4 times
-Calling function: Do_Expression
 Error message: Unknown attribute
 Nkind: N_Attribute_Reference
 --

--- a/experiments/golden-results/UKNI-Information-Barrier-summary.txt
+++ b/experiments/golden-results/UKNI-Information-Barrier-summary.txt
@@ -25,11 +25,6 @@ Nkind: N_Subprogram_Body_Stub
 --
 Occurs: 6 times
 Calling function: Do_Expression
-Error message: First attribute
-Nkind: N_Attribute_Reference
---
-Occurs: 6 times
-Calling function: Do_Expression
 Error message: Unknown expression kind
 Nkind: N_Expanded_Name
 --
@@ -53,11 +48,6 @@ Calling function: Do_Base_Range_Constraint
 Error message: range expression not bitvector type
 Nkind: N_Range
 --
-Occurs: 4 times
-Calling function: Do_Expression
-Error message: Last attribute
-Nkind: N_Attribute_Reference
---
 Occurs: 2 times
 Calling function: Do_While_Statement
 Error message: Wrong Nkind spec
@@ -67,11 +57,6 @@ Occurs: 1 times
 Calling function: Do_Operator_General
 Error message: Mod of unsupported type
 Nkind: N_Op_Not
---
-Occurs: 1 times
-Calling function: Make_Array_Index_Op
-Error message: Kinds not in classes
-Nkind: N_Defining_Identifier
 --
 Occurs: 1 times
 Calling function: Process_Declaration

--- a/experiments/golden-results/muen-summary.txt
+++ b/experiments/golden-results/muen-summary.txt
@@ -38,11 +38,6 @@ Calling function: Process_Declaration
 Error message: Representation clause declaration
 Nkind: N_Record_Representation_Clause
 --
-Occurs: 16 times
-Calling function: Do_Expression
-Error message: First attribute
-Nkind: N_Attribute_Reference
---
 Occurs: 14 times
 Calling function: Do_Expression
 Error message: Qualified
@@ -64,11 +59,6 @@ Error message: Private extension declaration unsupported
 Nkind: N_Private_Extension_Declaration
 --
 Occurs: 10 times
-Calling function: Do_Expression
-Error message: Last attribute
-Nkind: N_Attribute_Reference
---
-Occurs: 10 times
 Calling function: Do_Type_Definition
 Error message: Unknown expression kind
 Nkind: N_Access_Function_Definition
@@ -83,7 +73,7 @@ Calling function: Process_Declaration
 Error message: Use type clause declaration
 Nkind: N_Use_Type_Clause
 --
-Occurs: 7 times
+Occurs: 8 times
 Calling function: Do_Itype_Integer_Subtype
 Error message: Non-literal bound unsupported
 Nkind: N_Defining_Identifier

--- a/gnat2goto/driver/arrays.adb
+++ b/gnat2goto/driver/arrays.adb
@@ -2,9 +2,8 @@ with Nlists;                use Nlists;
 with Uintp;                 use Uintp;
 
 with GOTO_Utils;            use GOTO_Utils;
-
-with Symbol_Table_Info;     use Symbol_Table_Info;
 with Tree_Walk;             use Tree_Walk;
+with Follow;                use Follow;
 
 package body Arrays is
 
@@ -903,5 +902,81 @@ package body Arrays is
          (Do_Expression (Prefix (N)),
           Etype (Prefix (N)),
           Do_Expression (First (Expressions (N)))));
+
+   function Get_First_Index_Component (Array_Struct : Irep;
+                                       A_Symbol_Table : Symbol_Table)
+                                       return Irep
+   is
+      Array_Struct_Type : constant Irep :=
+        Follow_Symbol_Type (Get_Type (Array_Struct), A_Symbol_Table);
+      Struct_Component : constant Irep_List :=
+        Get_Component (Get_Components (Array_Struct_Type));
+   begin
+      return List_Element (Struct_Component, List_First (Struct_Component));
+   end Get_First_Index_Component;
+
+   function Get_Last_Index_Component (Array_Struct : Irep;
+                                      A_Symbol_Table : Symbol_Table)
+                                      return Irep
+   is
+      Array_Struct_Type : constant Irep :=
+        Follow_Symbol_Type (Get_Type (Array_Struct), A_Symbol_Table);
+      Struct_Component : constant Irep_List :=
+        Get_Component (Get_Components (Array_Struct_Type));
+      Last_Cursor :  constant List_Cursor :=
+        List_Next (Struct_Component, List_First (Struct_Component));
+   begin
+      return List_Element (Struct_Component, Last_Cursor);
+   end Get_Last_Index_Component;
+
+   function Get_Data_Component (Array_Struct : Irep;
+                                A_Symbol_Table : Symbol_Table)
+                                return Irep
+   is
+      Array_Struct_Type : constant Irep :=
+        Follow_Symbol_Type (Get_Type (Array_Struct), A_Symbol_Table);
+      Struct_Component : constant Irep_List :=
+        Get_Component (Get_Components (Array_Struct_Type));
+      Last_Cursor :  constant List_Cursor :=
+        List_Next (Struct_Component,
+                   List_Next (Struct_Component,
+                     List_First (Struct_Component)));
+   begin
+      return List_Element (Struct_Component, Last_Cursor);
+   end Get_Data_Component;
+
+   function Get_First_Index (Array_Struct : Irep; Source_Loc : Source_Ptr;
+                             A_Symbol_Table : Symbol_Table)
+                             return Irep
+   is
+      First_Index_Component : constant Irep :=
+        Get_First_Index_Component (Array_Struct   => Array_Struct,
+                                   A_Symbol_Table => A_Symbol_Table);
+   begin
+      return Make_Member_Expr (Compound         => Array_Struct,
+                               Source_Location  => Source_Loc,
+                               Component_Number => 0,
+                               I_Type           =>
+                                 Get_Type (First_Index_Component),
+                               Component_Name   =>
+                                 Get_Name (First_Index_Component));
+   end Get_First_Index;
+
+   function Get_Last_Index (Array_Struct : Irep; Source_Loc : Source_Ptr;
+                             A_Symbol_Table : Symbol_Table)
+                             return Irep
+   is
+      Last_Index_Component : constant Irep :=
+        Get_Last_Index_Component (Array_Struct   => Array_Struct,
+                                   A_Symbol_Table => A_Symbol_Table);
+   begin
+      return Make_Member_Expr (Compound         => Array_Struct,
+                               Source_Location  => Source_Loc,
+                               Component_Number => 1,
+                               I_Type           =>
+                                 Get_Type (Last_Index_Component),
+                               Component_Name   =>
+                                 Get_Name (Last_Index_Component));
+   end Get_Last_Index;
 
 end Arrays;

--- a/gnat2goto/driver/arrays.adb
+++ b/gnat2goto/driver/arrays.adb
@@ -669,6 +669,22 @@ package body Arrays is
                                Idx_Type => Do_Type_Reference (Index_Type));
    end Do_Array_Length;
 
+   function Do_Array_First (N : Node_Id) return Irep
+   is
+   begin
+      return Get_First_Index (Array_Struct   => Do_Expression (Prefix (N)),
+                              Source_Loc     => Sloc (N),
+                              A_Symbol_Table => Global_Symbol_Table);
+   end Do_Array_First;
+
+   function Do_Array_Last (N : Node_Id) return Irep
+   is
+   begin
+      return Get_Last_Index (Array_Struct   => Do_Expression (Prefix (N)),
+                              Source_Loc     => Sloc (N),
+                              A_Symbol_Table => Global_Symbol_Table);
+   end Do_Array_Last;
+
    --  This handled the oddball anonymous range nodes that can occur
    --  in array type declarations; they're effectively subtype indication
    --  nodes with an implied base type and a range constraint.

--- a/gnat2goto/driver/arrays.ads
+++ b/gnat2goto/driver/arrays.ads
@@ -5,6 +5,8 @@ with Sinfo;             use Sinfo;
 with Ireps;             use Ireps;
 with Types;             use Types;
 
+with Symbol_Table_Info; use Symbol_Table_Info;
+
 package Arrays is
 
    type Irep_Array is array (Positive range <>) of Irep;
@@ -38,6 +40,38 @@ package Arrays is
 
    function Do_Indexed_Component (N : Node_Id) return Irep
      with Pre  => Nkind (N) = N_Indexed_Component;
+
+   function Get_First_Index_Component (Array_Struct : Irep;
+                                       A_Symbol_Table : Symbol_Table)
+                                       return Irep;
+
+   function Get_Last_Index_Component (Array_Struct : Irep;
+                                      A_Symbol_Table : Symbol_Table)
+                                      return Irep;
+
+   function Get_Data_Component (Array_Struct : Irep;
+                                A_Symbol_Table : Symbol_Table)
+                                return Irep
+     with Pre => (Kind (Array_Struct) in Class_Expr
+                  and then Kind (Get_Type (Array_Struct)) in
+                    I_Symbol_Type | I_Struct_Type),
+     Post => Kind (Get_Type (Get_Data_Component'Result)) = I_Pointer_Type;
+
+   function Get_First_Index (Array_Struct : Irep; Source_Loc : Source_Ptr;
+                             A_Symbol_Table : Symbol_Table)
+                             return Irep
+     with Pre => (Kind (Array_Struct) in Class_Expr
+                  and then Kind (Get_Type (Array_Struct)) in
+                    I_Symbol_Type | I_Struct_Type),
+     Post => Kind (Get_First_Index'Result) = I_Member_Expr;
+
+   function Get_Last_Index (Array_Struct : Irep; Source_Loc : Source_Ptr;
+                             A_Symbol_Table : Symbol_Table)
+                             return Irep
+     with Pre => (Kind (Array_Struct) in Class_Expr
+                  and then Kind (Get_Type (Array_Struct)) in
+                    I_Symbol_Type | I_Struct_Type),
+       Post => Kind (Get_Last_Index'Result) = I_Member_Expr;
 
 private
    function Get_Array_Index_Type (N : Node_Id) return Entity_Id

--- a/gnat2goto/driver/arrays.ads
+++ b/gnat2goto/driver/arrays.ads
@@ -32,6 +32,12 @@ package Arrays is
    function Do_Array_Length (N : Node_Id) return Irep
      with Pre => Nkind (N) = N_Attribute_Reference;
 
+   function Do_Array_First (N : Node_Id) return Irep
+     with Pre => Nkind (N) = N_Attribute_Reference;
+
+   function Do_Array_Last (N : Node_Id) return Irep
+     with Pre => Nkind (N) = N_Attribute_Reference;
+
    function Get_Array_Component_Type (N : Node_Id) return Entity_Id
      with Post => Is_Type (Get_Array_Component_Type'Result);
 

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -1277,12 +1277,8 @@ package body Tree_Walk is
                when Attribute_Range  =>
                   return Report_Unhandled_Node_Irep (N, "Do_Expression",
                                                      "Range attribute");
-               when Attribute_First  =>
-                  return Report_Unhandled_Node_Irep (N, "Do_Expression",
-                                                     "First attribute");
-               when Attribute_Last   =>
-                  return Report_Unhandled_Node_Irep (N, "Do_Expression",
-                                                     "Last attribute");
+               when Attribute_First  => return Do_Array_First (N);
+               when Attribute_Last   => return Do_Array_Last (N);
                when Attribute_Val =>
                   return Do_Attribute_Pos_Val (N);
                when Attribute_Pos =>

--- a/testsuite/gnat2goto/tests/arrays_attributes_dynamic/array_attributes_dynamic.adb
+++ b/testsuite/gnat2goto/tests/arrays_attributes_dynamic/array_attributes_dynamic.adb
@@ -1,0 +1,15 @@
+-- covers first, last, and length
+procedure Array_Attributes_Dynamic is
+   type Indet_Array is array(Integer range <>) of Integer;
+
+   procedure Array_Consumer(Arr : Indet_Array) is
+   begin
+      pragma Assert(Arr'First = 1);
+      pragma Assert(Arr'Last = 1); -- should fail
+      pragma Assert(Arr'Length=2);
+   end Array_Consumer;
+
+   My_Arr : Indet_Array(1..2) := (others => 0);
+begin
+   Array_Consumer(My_Arr);
+end Array_Attributes_Dynamic;

--- a/testsuite/gnat2goto/tests/arrays_attributes_dynamic/test.out
+++ b/testsuite/gnat2goto/tests/arrays_attributes_dynamic/test.out
@@ -1,0 +1,7 @@
+[precondition_instance.1] memcpy src/dst overlap: SUCCESS
+[precondition_instance.2] memcpy source region readable: SUCCESS
+[precondition_instance.3] memcpy destination region writeable: SUCCESS
+[1] file array_attributes_dynamic.adb line 7 assertion: SUCCESS
+[2] file array_attributes_dynamic.adb line 8 assertion: FAILURE
+[3] file array_attributes_dynamic.adb line 9 assertion: SUCCESS
+VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/arrays_attributes_dynamic/test.py
+++ b/testsuite/gnat2goto/tests/arrays_attributes_dynamic/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()

--- a/testsuite/gnat2goto/tests/arrays_attributes_static/arrays_attributes_static.adb
+++ b/testsuite/gnat2goto/tests/arrays_attributes_static/arrays_attributes_static.adb
@@ -1,0 +1,18 @@
+-- covers array attributes: first, last, range, length
+procedure Arrays_Attributes_Static is
+   subtype Range1 is Integer range 10 .. 20;
+   type Arr3 is array (Range1) of Integer;
+   Actual3 : Arr3 := (7, 8, 9, others => 10);
+   subtype My_Index is Integer range Actual3'Range;
+   Array_Attribs : Integer;
+   Val : Integer := 10;
+   An_Index : My_Index := 12;
+begin
+   Actual3 (10 .. 11) := Actual3 (17 .. 18);
+   Actual3 (11) := 100;
+   Actual3 (13 .. 16) := Actual3 (11 .. 12) & Actual3 (15 .. 16);
+   Array_Attribs := Actual3'First + Actual3'Last + Actual3'Length;
+
+   pragma Assert (Array_Attribs = 41);
+   pragma Assert (An_Index = 12);
+end Arrays_Attributes_Static;

--- a/testsuite/gnat2goto/tests/arrays_attributes_static/test.out
+++ b/testsuite/gnat2goto/tests/arrays_attributes_static/test.out
@@ -1,0 +1,21 @@
+[precondition_instance.1] memcpy src/dst overlap: SUCCESS
+[precondition_instance.10] memcpy src/dst overlap: SUCCESS
+[precondition_instance.11] memcpy source region readable: SUCCESS
+[precondition_instance.12] memcpy destination region writeable: SUCCESS
+[precondition_instance.13] memcpy src/dst overlap: SUCCESS
+[precondition_instance.14] memcpy source region readable: SUCCESS
+[precondition_instance.15] memcpy destination region writeable: SUCCESS
+[precondition_instance.16] memcpy src/dst overlap: SUCCESS
+[precondition_instance.17] memcpy source region readable: SUCCESS
+[precondition_instance.18] memcpy destination region writeable: SUCCESS
+[precondition_instance.2] memcpy source region readable: SUCCESS
+[precondition_instance.3] memcpy destination region writeable: SUCCESS
+[precondition_instance.4] memcpy src/dst overlap: SUCCESS
+[precondition_instance.5] memcpy source region readable: SUCCESS
+[precondition_instance.6] memcpy destination region writeable: SUCCESS
+[precondition_instance.7] memcpy src/dst overlap: SUCCESS
+[precondition_instance.8] memcpy source region readable: SUCCESS
+[precondition_instance.9] memcpy destination region writeable: SUCCESS
+[1] file arrays_attributes_static.adb line 16 assertion: SUCCESS
+[2] file arrays_attributes_static.adb line 17 assertion: SUCCESS
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/arrays_attributes_static/test.py
+++ b/testsuite/gnat2goto/tests/arrays_attributes_static/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()

--- a/testsuite/gnat2goto/tests/arrays_range/arrays_range.adb
+++ b/testsuite/gnat2goto/tests/arrays_range/arrays_range.adb
@@ -1,0 +1,14 @@
+procedure Arrays_Range is
+   type Indet_Array is array(Integer range <>) of Integer;
+
+   procedure Array_Consumer(Arr : Indet_Array) is
+      subtype My_Index is Integer range Arr'Range;
+      An_Index : My_Index := 1;
+   begin
+      pragma Assert(An_Index = 1);
+   end Array_Consumer;
+
+   My_Arr : Indet_Array(1..2) := (others => 0);
+begin
+   Array_Consumer(My_Arr);
+end Arrays_Range;

--- a/testsuite/gnat2goto/tests/arrays_range/test.opt
+++ b/testsuite/gnat2goto/tests/arrays_range/test.opt
@@ -1,0 +1,1 @@
+ALL XFAIL gnat2goto fails with low bound range not literal

--- a/testsuite/gnat2goto/tests/arrays_range/test.py
+++ b/testsuite/gnat2goto/tests/arrays_range/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()

--- a/testsuite/gnat2goto/tests/in_expression/in_expression.adb
+++ b/testsuite/gnat2goto/tests/in_expression/in_expression.adb
@@ -1,0 +1,12 @@
+procedure In_Expression is
+   subtype Range1 is Integer range 10 .. 20;
+   type Arr3 is array (Range1) of Integer;
+   Actual3 : Arr3 := (7, 8, 9, others => 10);
+   Val : Integer := 10;
+begin
+   if Val in Actual3'Range then
+      pragma Assert (Val > 1);
+   else
+      pragma Assert (Val <= 1);
+   end if;
+end In_Expression;

--- a/testsuite/gnat2goto/tests/in_expression/test.opt
+++ b/testsuite/gnat2goto/tests/in_expression/test.opt
@@ -1,0 +1,1 @@
+ALL XFAIL gnat2goto fails with not supporting n_in node

--- a/testsuite/gnat2goto/tests/in_expression/test.py
+++ b/testsuite/gnat2goto/tests/in_expression/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
As far as I could find there are only 4 array attributes and they all work for static arrays (at least to the extend of the added test). For dynamic arrays, this PR adds support for `first` and `last` (length worked before). `Range` for dynamic is still unsupported.

 I also include test for `in_expression` that uses range-attribute but fails since we do not support `n_in`.