### PR TITLE
Remove a bash-ism to ensure script is posix compliant

### DIFF
--- a/experiments/list_unsupported.sh
+++ b/experiments/list_unsupported.sh
@@ -43,9 +43,9 @@ fi
 ADA_HOME=`which gnat`
 ADA_HOME="$(dirname "$ADA_HOME")/.."
 PLATFORM=`${ADA_HOME}/bin/gcc -dumpmachine`
-DEF_ADA_INCLUDE_PATH="${ADA_HOME}/lib/gcc/${PLATFORM}/"
+DEF_ADA_INCLUDE_PATH="${ADA_HOME}/lib/gcc/${PLATFORM}"
 ADA_GCC_VERSION=`${ADA_HOME}/bin/gcc -dumpversion`
-DEF_ADA_INCLUDE_PATH+="${ADA_GCC_VERSION}/rts-native/adainclude"
+DEF_ADA_INCLUDE_PATH="${DEF_ADA_INCLUDE_PATH}/${ADA_GCC_VERSION}/rts-native/adainclude"
 export ADA_INCLUDE_PATH="${ADA_INCLUDE_PATH:-$DEF_ADA_INCLUDE_PATH}"
 
 export GPR_PROJECT_PATH="${GPR_PROJECT_PATH:-/opt/gnat/lib/gnat}"


### PR DESCRIPTION
I believe the issue see in https://github.com/martin-cs/ASVAT/issues/33#issuecomment-475199120 is probably due to a piece of Bash syntax in the Posix SH script. This PR removes that Bash syntax in favour of pure Posix SH syntax. 