### PR TITLE
Array attribute range support

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -13,22 +13,22 @@ Calling function: Process_Declaration
 Error message: Unknown declaration kind
 Nkind: N_Freeze_Generic_Entity
 --
-Occurs: 159 times
+Occurs: 146 times
 Calling function: Process_Declaration
 Error message: Number declaration
 Nkind: N_Number_Declaration
---
-Occurs: 117 times
-Calling function: Do_Function_Call
-Error message: func name not in symbol table
-Nkind: N_Function_Call
 --
 Occurs: 107 times
 Calling function: Process_Declaration
 Error message: Generic declaration
 Nkind: N_Generic_Subprogram_Declaration
 --
-Occurs: 78 times
+Occurs: 99 times
+Calling function: Do_Function_Call
+Error message: func name not in symbol table
+Nkind: N_Function_Call
+--
+Occurs: 62 times
 Calling function: Do_Expression
 Error message: Unknown attribute
 Nkind: N_Attribute_Reference
@@ -43,7 +43,7 @@ Calling function: Process_Statement
 Error message: Raise statement
 Nkind: N_Raise_Statement
 --
-Occurs: 37 times
+Occurs: 35 times
 Calling function: Process_Declaration
 Error message: Package declaration
 Nkind: N_Package_Declaration
@@ -63,15 +63,10 @@ Calling function: Process_Declaration
 Error message: Generic instantiation declaration
 Nkind: N_Function_Instantiation
 --
-Occurs: 19 times
+Occurs: 17 times
 Calling function: Process_Declaration
 Error message: Package body declaration
 Nkind: N_Package_Body
---
-Occurs: 17 times
-Calling function: Do_Procedure_Call_Statement
-Error message: sym id not in symbol table
-Nkind: N_Procedure_Call_Statement
 --
 Occurs: 15 times
 Calling function: Process_Declaration
@@ -82,6 +77,11 @@ Occurs: 13 times
 Calling function: Do_Constant
 Error message: Constant Type not in symbol table
 Nkind: N_Integer_Literal
+--
+Occurs: 13 times
+Calling function: Do_Procedure_Call_Statement
+Error message: sym id not in symbol table
+Nkind: N_Procedure_Call_Statement
 --
 Occurs: 11 times
 Calling function: Do_Expression
@@ -130,11 +130,6 @@ Nkind: N_Access_Procedure_Definition
 --
 Occurs: 5 times
 Calling function: Process_Declaration
-Error message: Generic instantiation declaration
-Nkind: N_Procedure_Instantiation
---
-Occurs: 5 times
-Calling function: Process_Declaration
 Error message: Use type clause declaration
 Nkind: N_Use_Type_Clause
 --
@@ -152,6 +147,11 @@ Occurs: 3 times
 Calling function: Do_Operator_Simple
 Error message: Unsupported operand
 Nkind: N_Op_Expon
+--
+Occurs: 3 times
+Calling function: Process_Declaration
+Error message: Generic instantiation declaration
+Nkind: N_Procedure_Instantiation
 --
 Occurs: 3 times
 Calling function: Process_Statement
@@ -185,8 +185,13 @@ Nkind: N_Defining_Identifier
 --
 Occurs: 1 times
 Calling function: Do_Base_Range_Constraint
-Error message: low bound range expression not literal
-Nkind: N_Range
+Error message: unsupported lower range kind
+Nkind: N_Real_Literal
+--
+Occurs: 1 times
+Calling function: Do_Base_Range_Constraint
+Error message: unsupported upper range kind
+Nkind: N_Real_Literal
 --
 Occurs: 1 times
 Calling function: Do_Compilation_Unit

--- a/experiments/golden-results/Tokeneer-summary.txt
+++ b/experiments/golden-results/Tokeneer-summary.txt
@@ -40,8 +40,8 @@ Nkind: N_Expanded_Name
 --
 Occurs: 28 times
 Calling function: Do_Base_Range_Constraint
-Error message: high bound range expression not literal
-Nkind: N_Range
+Error message: unsupported upper range kind
+Nkind: N_Identifier
 --
 Occurs: 15 times
 Calling function: Do_Base_Range_Constraint
@@ -74,6 +74,11 @@ Error message: Unknown expression kind
 Nkind: N_Object_Declaration
 --
 Occurs: 2 times
+Calling function: Do_Itype_Integer_Subtype
+Error message: Non-literal bound unsupported
+Nkind: N_Defining_Identifier
+--
+Occurs: 2 times
 Calling function: Do_Operator_General
 Error message: Concat unsupported
 Nkind: N_Op_Concat
@@ -82,11 +87,6 @@ Occurs: 2 times
 Calling function: Process_Declaration
 Error message: Private extension declaration unsupported
 Nkind: N_Private_Extension_Declaration
---
-Occurs: 1 times
-Calling function: Do_Itype_Integer_Subtype
-Error message: Non-literal bound unsupported
-Nkind: N_Defining_Identifier
 --
 Occurs: 159 times
 Redacted compiler error message:

--- a/experiments/golden-results/muen-summary.txt
+++ b/experiments/golden-results/muen-summary.txt
@@ -150,8 +150,8 @@ Nkind: N_Object_Renaming_Declaration
 --
 Occurs: 1 times
 Calling function: Do_Base_Range_Constraint
-Error message: high bound range expression not literal
-Nkind: N_Range
+Error message: unsupported upper range kind
+Nkind: N_Op_Divide
 --
 Occurs: 1 times
 Calling function: Do_Expression

--- a/gnat2goto/driver/gnat2goto_itypes.adb
+++ b/gnat2goto/driver/gnat2goto_itypes.adb
@@ -139,9 +139,9 @@ package body Gnat2goto_Itypes is
       end if;
       return
         Make_Bounded_Signedbv_Type (
-                               Lower_Bound => Store_Bound (Bound_Type (Intval (
+                       Lower_Bound => Store_Nat_Bound (Bound_Type_Nat (Intval (
                                       Low_Bound (Scalar_Range (N))))),
-                               Upper_Bound => Store_Bound (Bound_Type (Intval (
+                       Upper_Bound => Store_Nat_Bound (Bound_Type_Nat (Intval (
                                       High_Bound (Scalar_Range (N))))),
                                Width       => Positive (UI_To_Int (Esize (N))),
                                I_Subtype   => Ireps.Empty);
@@ -153,9 +153,9 @@ package body Gnat2goto_Itypes is
 
    function Do_Itype_Integer_Type (N : Entity_Id) return Irep is
      (Make_Bounded_Signedbv_Type (
-                               Lower_Bound => Store_Bound (Bound_Type (Intval (
+                       Lower_Bound => Store_Nat_Bound (Bound_Type_Nat (Intval (
                                       Low_Bound (Scalar_Range (N))))),
-                               Upper_Bound => Store_Bound (Bound_Type (Intval (
+                       Upper_Bound => Store_Nat_Bound (Bound_Type_Nat (Intval (
                                       High_Bound (Scalar_Range (N))))),
                                Width       => Positive (UI_To_Int (Esize (N))),
                                I_Subtype   => Ireps.Empty));

--- a/gnat2goto/driver/range_check.adb
+++ b/gnat2goto/driver/range_check.adb
@@ -16,9 +16,16 @@ package body Range_Check is
 
    function Store_Nat_Bound (Number : Bound_Type_Nat) return Integer
    is
-      Length : constant Integer := Integer (Integer_Bounds_Table.Length);
+      Length : constant Integer := Integer (All_Bounds_Table.Length);
+      Where : Nat_Bounds_Map.Cursor;
+      Success_Insert : Boolean;
    begin
-      Integer_Bounds_Table.Append (Number);
+      All_Bounds_Table.Append (Nat_Bound);
+      Nat_Bounds_Table.Insert (Key      => Length,
+                               New_Item => Number,
+                               Position => Where,
+                               Inserted => Success_Insert);
+      pragma Assert (Success_Insert);
       return Length;
    end Store_Nat_Bound;
 
@@ -28,11 +35,42 @@ package body Range_Check is
 
    function Store_Real_Bound (Number : Bound_Type_Real) return Integer
    is
-      Length : constant Integer := Integer (Integer_Bounds_Real_Table.Length);
+      Length : constant Integer := Integer (All_Bounds_Table.Length);
+      Where : Real_Bounds_Map.Cursor;
+      Success_Insert : Boolean;
    begin
-      Integer_Bounds_Real_Table.Append (Number);
+      All_Bounds_Table.Append (Real_Bound);
+      Real_Bounds_Table.Insert (Key      => Length,
+                                New_Item => Number,
+                                Position => Where,
+                                Inserted => Success_Insert);
+      pragma Assert (Success_Insert);
       return Length;
    end Store_Real_Bound;
+
+   ----------------------
+   -- Store_Symbol_Bound --
+   ----------------------
+
+   function Store_Symbol_Bound (Number : Bound_Type_Symbol) return Integer
+   is
+      Length : constant Integer := Integer (All_Bounds_Table.Length);
+      Where : Symbol_Bounds_Map.Cursor;
+      Success_Insert : Boolean;
+   begin
+      All_Bounds_Table.Append (Symb_Bound);
+      Expr_Bounds_Table.Insert (Key      => Length,
+                                New_Item => Number,
+                                Position => Where,
+                                Inserted => Success_Insert);
+      pragma Assert (Success_Insert);
+      return Length;
+   end Store_Symbol_Bound;
+
+   function Get_Bound_Type (Bound_Index : Integer) return Bound_Type is
+   begin
+      return All_Bounds_Table.Element (Bound_Index);
+   end Get_Bound_Type;
 
    ----------------------------
    -- Make_Range_Assert_Expr --
@@ -220,7 +258,7 @@ package body Range_Check is
                                return String
    is
       Bit_Width : constant Pos := Pos (Get_Width (Actual_Type));
-      Bound : constant Uint := Uint (Integer_Bounds_Table.Element (Index));
+      Bound : constant Uint := Uint (Nat_Bounds_Table.Element (Index));
    begin
       return Convert_Uint_To_Hex (
                  Value     => Bound,
@@ -236,13 +274,19 @@ package body Range_Check is
    is
       Bit_Width : constant Float_Format := To_Float_Format (Actual_Type);
       Bound : constant Ureal :=
-        Ureal (Integer_Bounds_Real_Table.Element (Index));
+        Ureal (Real_Bounds_Table.Element (Index));
    begin
       case Bit_Width is
          when IEEE_32_Bit => return Convert_Ureal_To_Hex_32bits_IEEE (Bound);
          when IEEE_64_Bit => return Convert_Ureal_To_Hex_64bits_IEEE (Bound);
       end case;
    end Load_Real_Bound_In_Hex;
+
+   function Load_Symbol_Bound (Index : Integer) return Irep
+   is
+   begin
+      return Irep (Expr_Bounds_Table.Element (Index));
+   end Load_Symbol_Bound;
 
    ----------------------
    -- Make_Assert_Call --

--- a/gnat2goto/driver/range_check.adb
+++ b/gnat2goto/driver/range_check.adb
@@ -72,6 +72,29 @@ package body Range_Check is
       return All_Bounds_Table.Element (Bound_Index);
    end Get_Bound_Type;
 
+   function Get_Bound (Bound_Type : Irep; Pos : Bound_Low_Or_High) return Irep
+   is
+      Bound_Index : constant Integer := (if Pos = Bound_Low
+                                         then Get_Lower_Bound (Bound_Type)
+                                         else Get_Upper_Bound (Bound_Type));
+      Source_Loc : constant Source_Ptr := No_Location;
+   begin
+      case Get_Bound_Type (Bound_Index) is
+         when Nat_Bound =>
+            return Make_Constant_Expr (Source_Location => Source_Loc,
+                                       I_Type          => Bound_Type,
+                                       Range_Check     => False,
+                     Value => Load_Nat_Bound_In_Hex (Bound_Index, Bound_Type));
+         when Real_Bound =>
+            return Make_Constant_Expr (Source_Location => Source_Loc,
+                                       I_Type          => Bound_Type,
+                                       Range_Check     => False,
+                   Value => Load_Real_Bound_In_Hex (Bound_Index, Bound_Type));
+         when Symb_Bound =>
+            return Load_Symbol_Bound (Bound_Index);
+      end case;
+   end Get_Bound;
+
    ----------------------------
    -- Make_Range_Assert_Expr --
    ----------------------------

--- a/gnat2goto/driver/range_check.adb
+++ b/gnat2goto/driver/range_check.adb
@@ -10,17 +10,17 @@ with Tree_Walk;             use Tree_Walk;
 
 package body Range_Check is
 
-   -----------------
-   -- Store_Bound --
-   -----------------
+   ---------------------
+   -- Store_Nat_Bound --
+   ---------------------
 
-   function Store_Bound (Number : Bound_Type) return Integer
+   function Store_Nat_Bound (Number : Bound_Type_Nat) return Integer
    is
       Length : constant Integer := Integer (Integer_Bounds_Table.Length);
    begin
       Integer_Bounds_Table.Append (Number);
       return Length;
-   end Store_Bound;
+   end Store_Nat_Bound;
 
    ----------------------
    -- Store_Real_Bound --
@@ -216,7 +216,7 @@ package body Range_Check is
    -- Load_Bound_In_Hex --
    -----------------------
 
-   function Load_Bound_In_Hex (Index : Integer; Actual_Type : Irep)
+   function Load_Nat_Bound_In_Hex (Index : Integer; Actual_Type : Irep)
                                return String
    is
       Bit_Width : constant Pos := Pos (Get_Width (Actual_Type));
@@ -225,7 +225,7 @@ package body Range_Check is
       return Convert_Uint_To_Hex (
                  Value     => Bound,
                  Bit_Width => Bit_Width);
-   end Load_Bound_In_Hex;
+   end Load_Nat_Bound_In_Hex;
 
    ----------------------------
    -- Load_Real_Bound_In_Hex --

--- a/gnat2goto/driver/range_check.adb
+++ b/gnat2goto/driver/range_check.adb
@@ -107,6 +107,9 @@ package body Range_Check is
       Call_Args : constant Irep := New_Irep (I_Argument_List);
       Actual_Type : constant Irep := Follow_Symbol_Type (Get_Type (Value),
                                                          Global_Symbol_Table);
+      Followed_Bound_Type : constant Irep := Follow_Symbol_Type (Bounds_Type,
+                                                         Global_Symbol_Table);
+      Source_Loc : constant Source_Ptr := Sloc (N);
 
       function Build_Assert_Function return Symbol;
 
@@ -115,9 +118,9 @@ package body Range_Check is
       ---------------------------
 
       --  Build a symbol for the following function
-      --  Actual_Type range_check(Actual_Type value) {
-      --    assert (value >= Bounds_Type.lower_bound
-      --         && value <= Bounds_Type.upper_bound);
+      --  Actual_Type range_check(Actual_Type value, Actual_Type lower_bound,
+      --                          Actual_Type upper_bound) {
+      --    assert (value >= lower_bound && value <= upper_bound);
       --    return value;
       --  }
       function Build_Assert_Function return Symbol
@@ -125,7 +128,7 @@ package body Range_Check is
          Func_Name : constant String := Fresh_Var_Name ("range_check");
          Body_Block : constant Irep := Make_Code_Block (Sloc (N));
          Description : constant Irep := Make_String_Constant_Expr (
-                                             Source_Location => Sloc (N),
+                                             Source_Location => Source_Loc,
                                              I_Type          => Ireps.Empty,
                                              Range_Check     => False,
                                              Value           => "Range Check");
@@ -136,7 +139,21 @@ package body Range_Check is
                                  Param_Type      => Actual_Type,
                                  Param_List      => Func_Params,
                                  A_Symbol_Table  => Global_Symbol_Table,
-                                 Source_Location => Sloc (N));
+                                 Source_Location => Source_Loc);
+         Lower_Bound_Arg : constant Irep :=
+           Create_Fun_Parameter (Fun_Name        => Func_Name,
+                                 Param_Name      => "low",
+                                 Param_Type      => Bounds_Type,
+                                 Param_List      => Func_Params,
+                                 A_Symbol_Table  => Global_Symbol_Table,
+                                 Source_Location => Source_Loc);
+         Upper_Bound_Arg : constant Irep :=
+           Create_Fun_Parameter (Fun_Name        => Func_Name,
+                                 Param_Name      => "high",
+                                 Param_Type      => Bounds_Type,
+                                 Param_List      => Func_Params,
+                                 A_Symbol_Table  => Global_Symbol_Table,
+                                 Source_Location => Source_Loc);
          Func_Type : constant Irep := Make_Code_Type (
                             --  Function parameters should only be created via
                             --  Create_Fun_Parameter
@@ -146,16 +163,18 @@ package body Range_Check is
                             Inlined     => False,
                             Knr         => False);
          Value_Param : constant Irep := Param_Symbol (Value_Arg);
+         Lower_Bound_Param : constant Irep := Param_Symbol (Lower_Bound_Arg);
+         Upper_Bound_Param : constant Irep := Param_Symbol (Upper_Bound_Arg);
          --
-         Return_Inst : constant Irep := Make_Code_Return (
-                                               Return_Value    => Value_Param,
-                                               Source_Location => Sloc (N),
-                                               I_Type          => Ireps.Empty);
+         Return_Inst : constant Irep :=
+           Make_Code_Return (Return_Value    => Value_Param,
+                             Source_Location => Sloc (N),
+                             I_Type          => Ireps.Empty);
       begin
          Append_Op (Body_Block,
                     Make_Assert_Call (Expression (N),
                       Make_Range_Expression
-                        (Value_Param, Bounds_Type),
+                        (Value_Param, Lower_Bound_Param, Upper_Bound_Param),
                       Description));
          Append_Op (Body_Block, Return_Inst);
 
@@ -165,8 +184,14 @@ package body Range_Check is
                                         A_Symbol_Table => Global_Symbol_Table);
       end Build_Assert_Function;
 
+      Lower_Bound : constant Irep :=
+        Get_Bound (Followed_Bound_Type, Bound_Low);
+      Upper_Bound : constant Irep :=
+        Get_Bound (Followed_Bound_Type, Bound_High);
    begin
       Append_Argument (Call_Args, Value);
+      Append_Argument (Call_Args, Lower_Bound);
+      Append_Argument (Call_Args, Upper_Bound);
 
       Set_Function (I     => Call_Inst,
                     Value => Symbol_Expr (Build_Assert_Function));
@@ -183,94 +208,62 @@ package body Range_Check is
    -- Make_Range_Expression --
    -------------------------------
 
-   function Make_Range_Expression (Value_Expr : Irep; Val_Type : Irep)
+   function Make_Range_Expression (Value_Expr : Irep;
+                                   Lower_Bound : Irep;
+                                   Upper_Bound : Irep)
                                    return Irep
    is
-      --  Sym_Type : Irep := Get_Type (I);
-      Bound_Type : constant Irep := Follow_Symbol_Type (Val_Type,
-                                                        Global_Symbol_Table);
-      Value_Expr_Type : constant Irep := Follow_Symbol_Type (
-                                                         Get_Type (Value_Expr),
-                                                         Global_Symbol_Table);
+      Bound_Type : constant Irep :=
+        Follow_Symbol_Type (Get_Type (Lower_Bound), Global_Symbol_Table);
+      Value_Expr_Type : constant Irep :=
+        Follow_Symbol_Type (Get_Type (Value_Expr), Global_Symbol_Table);
+
+      Op_Geq : constant Irep := New_Irep (I_Op_Geq);
+      Op_Leq : constant Irep := New_Irep (I_Op_Leq);
+
+      Adjusted_Value_Expr : Irep;
+      Adjusted_Lower_Bound : Irep;
+      Adjusted_Upper_Bound : Irep;
+      Source_Location : constant Source_Ptr := Get_Source_Location
+        (Value_Expr);
    begin
-      if Kind (Bound_Type) in I_Bounded_Signedbv_Type | I_Bounded_Floatbv_Type
+      pragma Assert (Kind (Bound_Type) in
+                       I_Bounded_Signedbv_Type | I_Bounded_Floatbv_Type);
+      --  The compared expressions (value and bound) have to be of the
+      --  same type
+      if Get_Width (Bound_Type) > Get_Width (Value_Expr_Type)
       then
-         declare
-            Op_Geq : constant Irep := New_Irep (I_Op_Geq);
-            Op_Leq : constant Irep := New_Irep (I_Op_Leq);
-            Lower_Bound : constant Irep := New_Irep (I_Constant_Expr);
-            Upper_Bound : constant Irep := New_Irep (I_Constant_Expr);
-            Adjusted_Value_Expr : Irep;
-            Adjusted_Lower_Bound : Irep;
-            Adjusted_Upper_Bound : Irep;
-            Source_Location : constant Source_Ptr := Get_Source_Location
-              (Value_Expr);
-
-            function Get_Bound_In_Hex (Bound_Index : Integer) return String;
-            function Get_Bound_In_Hex (Bound_Index : Integer) return String is
-            begin
-               if Kind (Bound_Type) = I_Bounded_Signedbv_Type then
-                  return Load_Bound_In_Hex (Bound_Index, Bound_Type);
-               elsif Kind (Bound_Type) = I_Bounded_Floatbv_Type then
-                  return Load_Real_Bound_In_Hex (Bound_Index, Bound_Type);
-               else
-                  --  cannot happen (precondition)
-                  raise Program_Error;
-               end if;
-            end Get_Bound_In_Hex;
-
-         begin
-            --  The compared expressions (value and bound) have to be of the
-            --  same type
-            if Get_Width (Bound_Type) > Get_Width (Value_Expr_Type)
-            then
-               --  If the value checked for being in the range is of smaller
-               --  type then we need to cast it to the type of the bounds
-               Adjusted_Value_Expr :=
-                 Typecast_If_Necessary (Expr     => Value_Expr,
-                                        New_Type => Bound_Type);
-               Adjusted_Lower_Bound := Lower_Bound;
-               Adjusted_Upper_Bound := Upper_Bound;
-            else
-               --  If the bounds are of smaller type then we cast the bounds
-               --  to the type of the value being checked
-               Adjusted_Value_Expr := Value_Expr;
-               Adjusted_Lower_Bound :=
-                 Typecast_If_Necessary (Expr     => Lower_Bound,
-                                        New_Type => Value_Expr_Type);
-               Adjusted_Upper_Bound :=
-                 Typecast_If_Necessary (Expr     => Upper_Bound,
-                                        New_Type => Value_Expr_Type);
-            end if;
-            Set_Lhs (Op_Geq, Adjusted_Value_Expr);
-            Set_Type (I     => Lower_Bound,
-                      Value => Bound_Type);
-            Set_Rhs (Op_Geq, Adjusted_Lower_Bound);
-            Set_Type (Op_Geq, Make_Bool_Type);
-            Set_Lhs (Op_Leq, Adjusted_Value_Expr);
-            Set_Type (I     => Upper_Bound,
-                      Value => Bound_Type);
-
-            Set_Value (Lower_Bound,
-                       Get_Bound_In_Hex (Get_Lower_Bound (Bound_Type)));
-            Set_Value (Upper_Bound,
-                       Get_Bound_In_Hex (Get_Upper_Bound (Bound_Type)));
-
-            Set_Rhs (Op_Leq, Adjusted_Upper_Bound);
-            Set_Type (Op_Leq, Make_Bool_Type);
-            return R : constant Irep := New_Irep (I_Op_And) do
-               Append_Op (R, Op_Geq);
-               Append_Op (R, Op_Leq);
-               Set_Type (R, Make_Bool_Type);
-               Set_Source_Location (R, Source_Location);
-            end return;
-         end;
+         --  If the value checked for being in the range is of smaller
+         --  type then we need to cast it to the type of the bounds
+         Adjusted_Value_Expr :=
+           Typecast_If_Necessary (Expr     => Value_Expr,
+                                  New_Type => Bound_Type);
+         Adjusted_Lower_Bound := Lower_Bound;
+         Adjusted_Upper_Bound := Upper_Bound;
       else
-         return R : constant Irep := New_Irep (I_Constant_Expr) do
-            Set_Value (R, "true");
-            Set_Type (R, Make_Bool_Type);
-         end return;
+         --  If the bounds are of smaller type then we cast the bounds
+         --  to the type of the value being checked
+         Adjusted_Value_Expr := Value_Expr;
+         Adjusted_Lower_Bound :=
+           Typecast_If_Necessary (Expr     => Lower_Bound,
+                                  New_Type => Value_Expr_Type);
+         Adjusted_Upper_Bound :=
+           Typecast_If_Necessary (Expr     => Upper_Bound,
+                                  New_Type => Value_Expr_Type);
       end if;
+      Set_Lhs (Op_Geq, Adjusted_Value_Expr);
+      Set_Rhs (Op_Geq, Adjusted_Lower_Bound);
+      Set_Type (Op_Geq, Make_Bool_Type);
+      Set_Lhs (Op_Leq, Adjusted_Value_Expr);
+
+      Set_Rhs (Op_Leq, Adjusted_Upper_Bound);
+      Set_Type (Op_Leq, Make_Bool_Type);
+      return R : constant Irep := New_Irep (I_Op_And) do
+         Append_Op (R, Op_Geq);
+         Append_Op (R, Op_Leq);
+         Set_Type (R, Make_Bool_Type);
+         Set_Source_Location (R, Source_Location);
+      end return;
    end Make_Range_Expression;
 
    -----------------------

--- a/gnat2goto/driver/range_check.ads
+++ b/gnat2goto/driver/range_check.ads
@@ -9,6 +9,7 @@ with Ireps;                     use Ireps;
 
 package Range_Check is
 
+   type Bound_Low_Or_High is (Bound_Low, Bound_High);
 
    type Bound_Type_Nat is new Uint;
    type Bound_Type_Real is new Ureal;
@@ -17,6 +18,11 @@ package Range_Check is
    function Store_Nat_Bound (Number : Bound_Type_Nat) return Integer;
    function Store_Real_Bound (Number : Bound_Type_Real) return Integer;
    function Store_Symbol_Bound (Number : Bound_Type_Symbol) return Integer;
+
+   function Get_Bound (Bound_Type : Irep; Pos : Bound_Low_Or_High) return Irep
+     with Pre => Kind (Bound_Type) in
+     I_Bounded_Signedbv_Type | I_Bounded_Floatbv_Type,
+     Post => Kind (Get_Bound'Result) in Class_Expr;
 
    function Make_Range_Assert_Expr (N : Node_Id; Value : Irep;
                                     Bounds_Type : Irep) return Irep;

--- a/gnat2goto/driver/range_check.ads
+++ b/gnat2goto/driver/range_check.ads
@@ -8,7 +8,6 @@ with Ireps;                     use Ireps;
 
 package Range_Check is
 
-   type Bound_Type is new Uint;
    type Bound_Type_Real is new Ureal;
 
    package Integer_Bounds_Vector is new
@@ -17,8 +16,9 @@ package Range_Check is
    package Integer_Bounds_Real_Vector is new
      Ada.Containers.Vectors (Index_Type   => Natural,
                              Element_Type => Bound_Type_Real);
+   type Bound_Type_Nat is new Uint;
 
-   function Store_Bound (Number : Bound_Type) return Integer;
+   function Store_Nat_Bound (Number : Bound_Type_Nat) return Integer;
    function Store_Real_Bound (Number : Bound_Type_Real) return Integer;
 
    function Make_Range_Assert_Expr (N : Node_Id; Value : Irep;
@@ -32,7 +32,7 @@ private
    Integer_Bounds_Table : Integer_Bounds_Vector.Vector;
    Integer_Bounds_Real_Table : Integer_Bounds_Real_Vector.Vector;
 
-   function Load_Bound_In_Hex (Index : Integer; Actual_Type : Irep)
+   function Load_Nat_Bound_In_Hex (Index : Integer; Actual_Type : Irep)
                                return String
      with Pre => (Kind (Actual_Type) = I_Bounded_Signedbv_Type
                   and then

--- a/gnat2goto/driver/range_check.ads
+++ b/gnat2goto/driver/range_check.ads
@@ -3,23 +3,20 @@ with Ada.Containers.Vectors;    use Ada.Containers;
 with Types;                     use Types;
 with Uintp;                     use Uintp;
 with Urealp;                    use Urealp;
+with Ada.Containers.Ordered_Maps;
 
 with Ireps;                     use Ireps;
 
 package Range_Check is
 
-   type Bound_Type_Real is new Ureal;
 
-   package Integer_Bounds_Vector is new
-     Ada.Containers.Vectors (Index_Type   => Natural,
-                             Element_Type => Bound_Type);
-   package Integer_Bounds_Real_Vector is new
-     Ada.Containers.Vectors (Index_Type   => Natural,
-                             Element_Type => Bound_Type_Real);
    type Bound_Type_Nat is new Uint;
+   type Bound_Type_Real is new Ureal;
+   type Bound_Type_Symbol is new Irep;
 
    function Store_Nat_Bound (Number : Bound_Type_Nat) return Integer;
    function Store_Real_Bound (Number : Bound_Type_Real) return Integer;
+   function Store_Symbol_Bound (Number : Bound_Type_Symbol) return Integer;
 
    function Make_Range_Assert_Expr (N : Node_Id; Value : Irep;
                                     Bounds_Type : Irep) return Irep;
@@ -29,20 +26,39 @@ package Range_Check is
      with Post => Kind (Make_Range_Expression'Result) in Class_Expr;
 
 private
-   Integer_Bounds_Table : Integer_Bounds_Vector.Vector;
-   Integer_Bounds_Real_Table : Integer_Bounds_Real_Vector.Vector;
+   type Bound_Type is (Nat_Bound, Real_Bound, Symb_Bound);
+
+   package All_Bounds_Vector is new
+     Ada.Containers.Vectors (Index_Type   => Natural,
+                             Element_Type => Bound_Type);
+
+   package Nat_Bounds_Map is new
+     Ada.Containers.Ordered_Maps (Key_Type     => Natural,
+                                  Element_Type => Bound_Type_Nat);
+   package Real_Bounds_Map is new
+     Ada.Containers.Ordered_Maps (Key_Type     => Natural,
+                                  Element_Type => Bound_Type_Real);
+   package Symbol_Bounds_Map is new
+     Ada.Containers.Ordered_Maps (Key_Type     => Natural,
+                                  Element_Type => Bound_Type_Symbol);
+
+   All_Bounds_Table : All_Bounds_Vector.Vector;
+   Nat_Bounds_Table : Nat_Bounds_Map.Map;
+   Real_Bounds_Table : Real_Bounds_Map.Map;
+   Expr_Bounds_Table : Symbol_Bounds_Map.Map;
+
+   function Get_Bound_Type (Bound_Index : Integer) return Bound_Type
+     with Pre => Integer (All_Bounds_Table.Length) >= Bound_Index;
 
    function Load_Nat_Bound_In_Hex (Index : Integer; Actual_Type : Irep)
                                return String
-     with Pre => (Kind (Actual_Type) = I_Bounded_Signedbv_Type
-                  and then
-                    Integer (Integer_Bounds_Table.Length) >= Index);
+     with Pre => Kind (Actual_Type) = I_Bounded_Signedbv_Type;
 
    function Load_Real_Bound_In_Hex (Index : Integer; Actual_Type : Irep)
                                     return String
-     with Pre => (Kind (Actual_Type) = I_Bounded_Floatbv_Type
-                  and then
-                    Integer (Integer_Bounds_Real_Table.Length) >= Index);
+     with Pre => Kind (Actual_Type) = I_Bounded_Floatbv_Type;
+
+   function Load_Symbol_Bound (Index : Integer) return Irep;
 
    --  might be best if this is moved to a utility package in future
    --  atm placement documents it is only used by range_check

--- a/gnat2goto/driver/range_check.ads
+++ b/gnat2goto/driver/range_check.ads
@@ -25,11 +25,15 @@ package Range_Check is
      Post => Kind (Get_Bound'Result) in Class_Expr;
 
    function Make_Range_Assert_Expr (N : Node_Id; Value : Irep;
-                                    Bounds_Type : Irep) return Irep;
+                                    Bounds_Type : Irep) return Irep
+     with Pre => Kind (Bounds_Type) in
+     I_Bounded_Signedbv_Type | I_Bounded_Floatbv_Type | I_Symbol_Type;
 
-   function Make_Range_Expression (Value_Expr : Irep; Val_Type : Irep)
+   function Make_Range_Expression (Value_Expr : Irep; Lower_Bound : Irep;
+                                   Upper_Bound : Irep)
                                    return Irep
-     with Post => Kind (Make_Range_Expression'Result) in Class_Expr;
+     with Pre => Kind (Get_Type (Lower_Bound)) = Kind (Get_Type (Lower_Bound)),
+       Post => Kind (Make_Range_Expression'Result) in Class_Expr;
 
 private
    type Bound_Type is (Nat_Bound, Real_Bound, Symb_Bound);

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -694,31 +694,63 @@ package body Tree_Walk is
       Resolved_Underlying : constant Irep :=
         Follow_Symbol_Type (Underlying, Global_Symbol_Table);
       --  ??? why not get this from the entity
+
+      function Get_Array_Attr_Bound_Symbol (Bound_Node : Node_Id)
+                                            return Bound_Type_Symbol
+        with Pre => Get_Attribute_Id (Attribute_Name (Bound_Node))
+          in Attribute_First | Attribute_Last;
+      function Get_Array_Attr_Bound_Symbol (Bound_Node : Node_Id)
+                                            return Bound_Type_Symbol
+      is
+      begin
+         if Get_Attribute_Id (Attribute_Name (Bound_Node)) = Attribute_First
+         then
+            return Bound_Type_Symbol (Do_Array_First (Bound_Node));
+         else
+            return Bound_Type_Symbol (Do_Array_Last (Bound_Node));
+         end if;
+      end Get_Array_Attr_Bound_Symbol;
+
+      Lower_Bound : constant Node_Id := Low_Bound (Range_Expr);
+      Upper_Bound : constant Node_Id := High_Bound (Range_Expr);
+
+      Lower_Bound_Value : Integer;
+      Upper_Bound_Value : Integer;
+
+      Result_Type : constant Irep := New_Irep (I_Bounded_Signedbv_Type);
    begin
       if not (Kind (Resolved_Underlying) in Class_Bitvector_Type) then
-         Report_Unhandled_Node_Empty (Range_Expr, "Do_Base_Range_Constraint",
-                                      "range expression not bitvector type");
-         return R : constant Irep := New_Irep (I_Bounded_Signedbv_Type);
+         return Report_Unhandled_Node_Type (Range_Expr,
+                                            "Do_Base_Range_Constraint",
+                                        "range expression not bitvector type");
       end if;
-      if Nkind (Low_Bound (Range_Expr)) /= N_Integer_Literal then
-         Report_Unhandled_Node_Empty (Range_Expr, "Do_Base_Range_Constraint",
-                                     "low bound range expression not literal");
-         return R : constant Irep := New_Irep (I_Bounded_Signedbv_Type);
-      end if;
-      if Nkind (High_Bound (Range_Expr)) /= N_Integer_Literal then
-         Report_Unhandled_Node_Empty (Range_Expr, "Do_Base_Range_Constraint",
-                                    "high bound range expression not literal");
-         return R : constant Irep := New_Irep (I_Bounded_Signedbv_Type);
-      end if;
-      return R : constant Irep := New_Irep (I_Bounded_Signedbv_Type) do
-         Set_Width (R, Get_Width (Resolved_Underlying));
-         Set_Lower_Bound (I     => R,
-                          Value => Store_Bound (Bound_Type (Intval (
-                            Low_Bound (Range_Expr)))));
-         Set_Upper_Bound (I     => R,
-                          Value => Store_Bound (Bound_Type (Intval (
-                            High_Bound (Range_Expr)))));
-      end return;
+
+      case Nkind (Lower_Bound) is
+         when N_Integer_Literal => Lower_Bound_Value :=
+              Store_Nat_Bound (Bound_Type_Nat (Intval (Lower_Bound)));
+         when N_Attribute_Reference => Lower_Bound_Value :=
+              Store_Symbol_Bound (Get_Array_Attr_Bound_Symbol (Lower_Bound));
+         when others =>
+            Report_Unhandled_Node_Empty (Lower_Bound,
+                                         "Do_Base_Range_Constraint",
+                                         "unsupported lower range kind");
+      end case;
+
+      case Nkind (Upper_Bound) is
+         when N_Integer_Literal => Upper_Bound_Value :=
+              Store_Nat_Bound (Bound_Type_Nat (Intval (Upper_Bound)));
+         when N_Attribute_Reference => Upper_Bound_Value :=
+              Store_Symbol_Bound (Get_Array_Attr_Bound_Symbol (Upper_Bound));
+         when others =>
+            Report_Unhandled_Node_Empty (Upper_Bound,
+                                         "Do_Base_Range_Constraint",
+                                         "unsupported upper range kind");
+      end case;
+
+      Set_Width (Result_Type, Get_Width (Resolved_Underlying));
+      Set_Lower_Bound (Result_Type, Lower_Bound_Value);
+      Set_Upper_Bound (Result_Type, Upper_Bound_Value);
+      return Result_Type;
    end Do_Bare_Range_Constraint;
 
    ------------------------

--- a/testsuite/gnat2goto/tests/arrays_range/arrays_range.adb
+++ b/testsuite/gnat2goto/tests/arrays_range/arrays_range.adb
@@ -5,7 +5,12 @@ procedure Arrays_Range is
       subtype My_Index is Integer range Arr'Range;
       An_Index : My_Index := 1;
    begin
-      pragma Assert(An_Index = 1);
+      An_Index := An_Index + 1; -- to invoke the range check
+      pragma Assert(An_Index = 2);
+      An_Index := An_Index + 2;
+      pragma Assert(An_Index = 4);
+      An_Index := An_Index - 5;
+      pragma Assert(An_Index = -1);
    end Array_Consumer;
 
    My_Arr : Indet_Array(1..2) := (others => 0);

--- a/testsuite/gnat2goto/tests/arrays_range/test.opt
+++ b/testsuite/gnat2goto/tests/arrays_range/test.opt
@@ -1,1 +1,0 @@
-ALL XFAIL gnat2goto fails with low bound range not literal

--- a/testsuite/gnat2goto/tests/arrays_range/test.out
+++ b/testsuite/gnat2goto/tests/arrays_range/test.out
@@ -1,0 +1,10 @@
+[assertion.1] Range Check: FAILURE
+[assertion.2] Range Check: SUCCESS
+[assertion.3] Range Check: FAILURE
+[precondition_instance.1] memcpy src/dst overlap: SUCCESS
+[precondition_instance.2] memcpy source region readable: SUCCESS
+[precondition_instance.3] memcpy destination region writeable: SUCCESS
+[1] file arrays_range.adb line 9 assertion: SUCCESS
+[2] file arrays_range.adb line 11 assertion: SUCCESS
+[3] file arrays_range.adb line 13 assertion: SUCCESS
+VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/dynamic_range_variable/dynamic_range_variable.adb
+++ b/testsuite/gnat2goto/tests/dynamic_range_variable/dynamic_range_variable.adb
@@ -1,0 +1,9 @@
+procedure Dynamic_Range_Variable is
+   type Static_Range_Type is range 1..100;
+   Range_Bound : Static_Range_Type := 50;
+   subtype Dynamic_Range_Type is Static_Range_Type range 1..Range_Bound;
+   Var : Dynamic_Range_Type := 20;
+begin
+   Var := 2 * Var; -- to invoke range check
+   pragma Assert(Var = 40);
+end Dynamic_Range_Variable;

--- a/testsuite/gnat2goto/tests/dynamic_range_variable/test.opt
+++ b/testsuite/gnat2goto/tests/dynamic_range_variable/test.opt
@@ -1,0 +1,1 @@
+ALL XFAIL gnat2goto fails with unsupported upper range kind: N_Identifier "dynamic_range_type_LAST"

--- a/testsuite/gnat2goto/tests/dynamic_range_variable/test.py
+++ b/testsuite/gnat2goto/tests/dynamic_range_variable/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()

--- a/testsuite/gnat2goto/tests/loop_array_range/loop_array_range.adb
+++ b/testsuite/gnat2goto/tests/loop_array_range/loop_array_range.adb
@@ -1,0 +1,12 @@
+procedure Loop_Array_Range is
+   type Indet_Array is array(Integer range <>) of Integer;
+
+   My_Arr : Indet_Array(1..10) := (1,2,3,4, others => 0);
+   Sum : Integer := 0;
+begin
+   for I in My_Arr'Range loop
+      Sum := Sum + My_Arr(I);
+   end loop;
+
+   pragma Assert(Sum=6);
+end Loop_Array_Range;

--- a/testsuite/gnat2goto/tests/loop_array_range/test.opt
+++ b/testsuite/gnat2goto/tests/loop_array_range/test.opt
@@ -1,0 +1,1 @@
+ALL XFAIL gnat2goto fails with contraint_error (loop_array_range__TTmy_arrSP1 is not is symbol table)

--- a/testsuite/gnat2goto/tests/loop_array_range/test.py
+++ b/testsuite/gnat2goto/tests/loop_array_range/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()

--- a/testsuite/gnat2goto/tests/ranges/test.out
+++ b/testsuite/gnat2goto/tests/ranges/test.out
@@ -1,4 +1,4 @@
-[assertion.1] Range Check: SUCCESS
-[assertion.2] Range Check: FAILURE
+[assertion.1] Range Check: FAILURE
+[assertion.2] Range Check: SUCCESS
 [assertion.3] Range Check: FAILURE
 VERIFICATION FAILED


### PR DESCRIPTION
Works for using `'range` to define a subtype. Does not work for dynamic type ranges in general. Failing tests show the scope.