### PR TITLE
tests for newly found array declaration failure modes

### DIFF
--- a/testsuite/gnat2goto/tests/arrays_declaration_failure1/arrays_declaration_failure1.adb
+++ b/testsuite/gnat2goto/tests/arrays_declaration_failure1/arrays_declaration_failure1.adb
@@ -1,0 +1,10 @@
+--  see also test "arrays_multidimensional_declaration_failure1"
+procedure Arrays_Declaration_Failure1 is
+   --  ERROR, "GNAT BUG DETECTED" " GNU Ada (ada2goto) Constraint_Error Symbol_Table_Info.Symbol_Maps.Constant_Reference: key not in map|"
+   A1 : Array (1..3) of Integer;
+
+   --  ERROR, "GNAT BUG DETECTED" " GNU Ada (ada2goto) Constraint_Error Symbol_Table_Info.Symbol_Maps.Constant_Reference: key not in map|"
+   A2 : Array (1..3) of Integer := (1,2,3);
+begin
+   null;
+end Arrays_Declaration_Failure1;

--- a/testsuite/gnat2goto/tests/arrays_declaration_failure1/test.opt
+++ b/testsuite/gnat2goto/tests/arrays_declaration_failure1/test.opt
@@ -1,0 +1,1 @@
+ALL XFAIL gnat2goto fails with "GNU Ada (ada2goto) Constraint_Error Symbol_Table_Info.Symbol_Maps.Constant_Reference: key not in map"

--- a/testsuite/gnat2goto/tests/arrays_declaration_failure1/test.py
+++ b/testsuite/gnat2goto/tests/arrays_declaration_failure1/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()

--- a/testsuite/gnat2goto/tests/arrays_declaration_failure2/arrays_declaration_failure2.adb
+++ b/testsuite/gnat2goto/tests/arrays_declaration_failure2/arrays_declaration_failure2.adb
@@ -1,0 +1,7 @@
+--  see also test  "arrays_multidimensional_declaration_failure2"
+procedure Arrays_Declaration_Failure2 is
+   --  ERROR, "GNAT BUG DETECTED" "GNU Ada (ada2goto) Assert_Failure sinfo.adb:2232"
+   A1 : array (Integer range 1..3) of Integer;
+begin
+   null;
+end Arrays_Declaration_Failure2;

--- a/testsuite/gnat2goto/tests/arrays_declaration_failure2/test.opt
+++ b/testsuite/gnat2goto/tests/arrays_declaration_failure2/test.opt
@@ -1,0 +1,1 @@
+ALL XFAIL gnat2goto fails with "GNU Ada (ada2goto) Assert_Failure sinfo.adb:2232"

--- a/testsuite/gnat2goto/tests/arrays_declaration_failure2/test.py
+++ b/testsuite/gnat2goto/tests/arrays_declaration_failure2/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
Key purpose of this PR is to document a way of declaring arrays that causes errors. This also happens for multidimensional arrays (#176).
Potentially independent failure modes are in separate tests - for clarity and ease of debugging.
