### PR TITLE
Add XFAIL test to demonstrate issues with our string handling

### DIFF
--- a/testsuite/gnat2goto/tests/string_equality/string_equality.adb
+++ b/testsuite/gnat2goto/tests/string_equality/string_equality.adb
@@ -1,0 +1,6 @@
+procedure String_Equality is
+  function Constant_String return String is
+    ("sensor");
+begin
+  pragma Assert (Constant_String = "sensor");
+end String_Equality;

--- a/testsuite/gnat2goto/tests/string_equality/test.opt
+++ b/testsuite/gnat2goto/tests/string_equality/test.opt
@@ -1,0 +1,1 @@
+ALL XFAIL CBMC fails a precondition in can_cast_type<array_typet> in to_array_type in util/std_types.h

--- a/testsuite/gnat2goto/tests/string_equality/test.py
+++ b/testsuite/gnat2goto/tests/string_equality/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
During implementation of the case_statement #171 , while authoring some tests for that, I found out that the tests were misbehaving because of our partial support for strings. This wasn't covered by any of the tests already existing, so I added one for documentation.