### PR TITLE
Feature modular type with power of two boundary

### DIFF
--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -71,6 +71,11 @@ package body Tree_Walk is
    with Pre => Nkind (N) = N_Real_Literal,
         Post => Kind (Do_Real_Constant'Result) = I_Constant_Expr;
 
+   function Do_Modular_Type_Definition (N : Node_Id) return Irep
+   with Pre => Nkind (N) = N_Modular_Type_Definition,
+        Post => Kind (Do_Modular_Type_Definition'Result)
+                in Class_Type;
+
    function Do_Defining_Identifier (E : Entity_Id) return Irep
    with Pre  => Nkind (E) = N_Defining_Identifier,
         Post => Kind (Do_Defining_Identifier'Result) in
@@ -3628,7 +3633,7 @@ package body Tree_Walk is
          when N_Unconstrained_Array_Definition =>
             return Do_Unconstrained_Array_Definition (N);
          when N_Modular_Type_Definition =>
-            return Create_Dummy_Irep;
+            return Do_Modular_Type_Definition (N);
          when N_Floating_Point_Definition =>
             return Do_Floating_Point_Definition (N);
          when others =>
@@ -4191,6 +4196,31 @@ package body Tree_Walk is
 
       return Reps;
    end Process_Statements;
+
+   function Do_Modular_Type_Definition (N : Node_Id) return Irep is
+      Mod_Max : constant Uint := Intval (Expression (N));
+      --  We start at 1, not 0, because our bitvectors
+      --  can't be smaller than 1 bit
+      Mod_Max_Binary_Logarithm : Integer := 1;
+      Power_Of_Two : Uint := Uint_2;
+   begin
+      while Power_Of_Two < Mod_Max loop
+         Mod_Max_Binary_Logarithm := Mod_Max_Binary_Logarithm + 1;
+         Power_Of_Two := Power_Of_Two * 2;
+      end loop;
+      --  If the max value is 2^w (for w > 0) then we can just
+      --  use an unsignedbv of width w
+      if Mod_Max = Power_Of_Two then
+         return Make_Unsignedbv_Type
+           (I_Subtype => Make_Nil_Type,
+            Width => Mod_Max_Binary_Logarithm);
+      end if;
+      return Report_Unhandled_Node_Type
+        (N,
+         "Do_Modular_Type_Definition",
+         "can not handle modular types "
+         & "with non-power-of-2 bounds at the moment");
+   end Do_Modular_Type_Definition;
 
    ---------------------------------------
    -- Register_Subprogram_Specification --

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -418,6 +418,14 @@ package body Tree_Walk is
       return I_Empty;
    end Report_Unhandled_Node_Kind;
 
+   function Report_Unhandled_Node_Type (N : Node_Id;
+                                        Fun_Name : String;
+                                        Message : String) return Irep
+   is begin
+      Report_Unhandled_Node_Empty (N, Fun_Name, Message);
+      return Make_Nil_Type;
+   end Report_Unhandled_Node_Type;
+
    -----------------------------
    -- Add_Entity_Substitution --
    -----------------------------

--- a/gnat2goto/driver/tree_walk.ads
+++ b/gnat2goto/driver/tree_walk.ads
@@ -127,6 +127,10 @@ package Tree_Walk is
                                         Fun_Name : String;
                                         Message : String) return Irep_Kind;
 
+   function Report_Unhandled_Node_Type (N : Node_Id;
+                                        Fun_Name : String;
+                                        Message : String) return Irep;
+
    function Do_Bare_Range_Constraint (Range_Expr : Node_Id; Underlying : Irep)
                                       return Irep
      with Pre => Nkind (Range_Expr) = N_Range;

--- a/testsuite/gnat2goto/tests/type_modular/modular.adb
+++ b/testsuite/gnat2goto/tests/type_modular/modular.adb
@@ -1,0 +1,14 @@
+procedure Modular is
+  type Eight_Bit is mod 256;
+  function Next (X : Eight_Bit) return Eight_Bit is (X + 1);
+  Byte : constant Eight_Bit := 255;
+
+  type Two_Bit is mod 4;
+  function Next (X : Two_Bit) return Two_Bit is (X + 1);
+  Number : constant Two_Bit := 3;
+begin
+  pragma Assert (Next (Byte) = 0);
+  pragma Assert (Next (Next (Byte)) = 1);
+  pragma Assert (Next (Number) = 0);
+  pragma Assert (Next (Next (Number)) = 1);
+end Modular;

--- a/testsuite/gnat2goto/tests/type_modular/test.out
+++ b/testsuite/gnat2goto/tests/type_modular/test.out
@@ -1,0 +1,5 @@
+[1] file modular.adb line 10 assertion: SUCCESS
+[2] file modular.adb line 11 assertion: SUCCESS
+[3] file modular.adb line 12 assertion: SUCCESS
+[4] file modular.adb line 13 assertion: SUCCESS
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/type_modular/test.py
+++ b/testsuite/gnat2goto/tests/type_modular/test.py
@@ -1,0 +1,3 @@
+from test_support import prove
+
+prove()


### PR DESCRIPTION
Adds initial support for modular types. If the boundary is a power of 2 we can
represent the mod type as an unsignedbv without any special handling, but the
boundary value wouldn't fit into that unsignedbv, hence why we're handling this
case specially. The "not power of 2" case requires special arithmetic operators
and explicit tracking of the boundary value, which is why it's going to be
handled seperately in the future.

Also adds a helper for reporting unsupported type declarations.