### PR TITLE
Add support for mod type with arbitrary boundaries

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -104,11 +104,6 @@ Error message: Unknown expression kind
 Nkind: N_Freeze_Entity
 --
 Occurs: 5 times
-Calling function: Do_Constant
-Error message: Constant Type not in Class_Bitvector_Type
-Nkind: N_Integer_Literal
---
-Occurs: 5 times
 Calling function: Do_Operator_General
 Error message: Concat unsupported
 Nkind: N_Op_Concat
@@ -149,9 +144,9 @@ Error message: Unknown tree node
 Nkind: N_Compilation_Unit
 --
 Occurs: 1 times
-Calling function: Do_Modular_Type_Definition
-Error message: can not handle modular types with non-power-of-2 bounds at the moment
-Nkind: N_Modular_Type_Definition
+Calling function: Do_Constant
+Error message: Constant Type not in Class_Bitvector_Type
+Nkind: N_Integer_Literal
 --
 Occurs: 1 times
 Calling function: Do_Pragma

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -4294,11 +4294,12 @@ package body Tree_Walk is
            (I_Subtype => Make_Nil_Type,
             Width => Mod_Max_Binary_Logarithm);
       end if;
-      return Report_Unhandled_Node_Type
-        (N,
-         "Do_Modular_Type_Definition",
-         "can not handle modular types "
-         & "with non-power-of-2 bounds at the moment");
+
+      return Make_Ada_Mod_Type
+        (I_Subtype => Make_Nil_Type,
+         Width => Mod_Max_Binary_Logarithm,
+         Ada_Mod_Max => Convert_Uint_To_Hex
+           (Mod_Max, Pos (Mod_Max_Binary_Logarithm)));
    end Do_Modular_Type_Definition;
 
    ---------------------------------------

--- a/gnat2goto/ireps/irep_specs/ada_mod_type.json
+++ b/gnat2goto/ireps/irep_specs/ada_mod_type.json
@@ -1,0 +1,7 @@
+{
+   "parent": "bitvector_type",
+   "id": "ada_mod_type",
+   "namedSub": {
+      "ada_mod_max": {"type": "string"}
+   }
+}

--- a/testsuite/gnat2goto/tests/type_modular_non_power_of_two_decl/modular_type.adb
+++ b/testsuite/gnat2goto/tests/type_modular_non_power_of_two_decl/modular_type.adb
@@ -1,0 +1,9 @@
+procedure Modular_Type is
+  type Less_Than_Ten is mod 10;
+  procedure Assert_Val (X : Less_Than_Ten) is
+  begin
+    pragma Assert (X = 5);
+  end Assert_Val;
+begin
+  Assert_Val (5);
+end Modular_Type;

--- a/testsuite/gnat2goto/tests/type_modular_non_power_of_two_decl/test.out
+++ b/testsuite/gnat2goto/tests/type_modular_non_power_of_two_decl/test.out
@@ -1,0 +1,2 @@
+[1] file modular_type.adb line 5 assertion: SUCCESS
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/type_modular_non_power_of_two_decl/test.py
+++ b/testsuite/gnat2goto/tests/type_modular_non_power_of_two_decl/test.py
@@ -1,0 +1,3 @@
+from test_support import prove
+
+prove()


### PR DESCRIPTION
This allows us to represent modular types with non-power-of 2
boundaries.

Note: No actual runtime support for any of the operators yet, we will
do this by adding our own implementations and rewriting ada-mod-type to
unsignedbv in a postprocessing step before writing the symbol table.

Also note:

I have no idea how or why the tests pass, considering this isn't actually
replacing the type with something CBMC could be reasonable expected to handle
yet, but I'll take it.