### PR TITLE
Return nil type where type is expected [ADA-273]

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -23,14 +23,9 @@ Calling function: Do_Expression
 Error message: Unknown attribute
 Nkind: N_Attribute_Reference
 --
-Occurs: 47 times
-Calling function: Do_Full_Type_Declaration
-Error message: Identifier not in class type. Type definition failed.
-Nkind: N_Full_Type_Declaration
---
 Occurs: 42 times
 Calling function: Do_Type_Definition
-Error message: Unknown expression kind
+Error message: Access type unsupported
 Nkind: N_Access_To_Object_Definition
 --
 Occurs: 29 times

--- a/experiments/golden-results/Tokeneer-summary.txt
+++ b/experiments/golden-results/Tokeneer-summary.txt
@@ -24,11 +24,6 @@ Error message: range expression not bitvector type
 Nkind: N_Range
 --
 Occurs: 12 times
-Calling function: Do_Full_Type_Declaration
-Error message: Identifier not in class type. Type definition failed.
-Nkind: N_Full_Type_Declaration
---
-Occurs: 12 times
 Calling function: Do_Type_Definition
 Error message: Unknown expression kind
 Nkind: N_Access_Function_Definition

--- a/experiments/golden-results/ksum-summary.txt
+++ b/experiments/golden-results/ksum-summary.txt
@@ -1,9 +1,4 @@
 Occurs: 2 times
-Calling function: Do_Full_Type_Declaration
-Error message: Identifier not in class type. Type definition failed.
-Nkind: N_Full_Type_Declaration
---
-Occurs: 2 times
 Calling function: Process_Declaration
 Error message: Private type declaration unsupported
 Nkind: N_Private_Type_Declaration
@@ -15,13 +10,13 @@ Nkind: N_Null
 --
 Occurs: 1 times
 Calling function: Do_Type_Definition
-Error message: Unknown expression kind
-Nkind: N_Access_Function_Definition
+Error message: Access type unsupported
+Nkind: N_Access_To_Object_Definition
 --
 Occurs: 1 times
 Calling function: Do_Type_Definition
 Error message: Unknown expression kind
-Nkind: N_Access_To_Object_Definition
+Nkind: N_Access_Function_Definition
 --
 Occurs: 41 times
 Redacted compiler error message:

--- a/experiments/golden-results/libkeccak-summary.txt
+++ b/experiments/golden-results/libkeccak-summary.txt
@@ -3,14 +3,9 @@ Calling function: Process_Declaration
 Error message: Private type declaration unsupported
 Nkind: N_Private_Type_Declaration
 --
-Occurs: 25 times
-Calling function: Do_Full_Type_Declaration
-Error message: Identifier not in class type. Type definition failed.
-Nkind: N_Full_Type_Declaration
---
 Occurs: 19 times
 Calling function: Do_Type_Definition
-Error message: Unknown expression kind
+Error message: Access type unsupported
 Nkind: N_Access_To_Object_Definition
 --
 Occurs: 9 times

--- a/experiments/golden-results/muen-summary.txt
+++ b/experiments/golden-results/muen-summary.txt
@@ -1,11 +1,6 @@
-Occurs: 117 times
-Calling function: Do_Full_Type_Declaration
-Error message: Identifier not in class type. Type definition failed.
-Nkind: N_Full_Type_Declaration
---
 Occurs: 105 times
 Calling function: Do_Type_Definition
-Error message: Unknown expression kind
+Error message: Access type unsupported
 Nkind: N_Access_To_Object_Definition
 --
 Occurs: 97 times

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -3715,8 +3715,11 @@ package body Tree_Walk is
             return Do_Modular_Type_Definition (N);
          when N_Floating_Point_Definition =>
             return Do_Floating_Point_Definition (N);
+         when N_Access_To_Object_Definition =>
+            return Report_Unhandled_Node_Type (N, "Do_Type_Definition",
+                                               "Access type unsupported");
          when others =>
-            return Report_Unhandled_Node_Irep (N, "Do_Type_Definition",
+            return Report_Unhandled_Node_Type (N, "Do_Type_Definition",
                                                "Unknown expression kind");
       end case;
    end Do_Type_Definition;


### PR DESCRIPTION
Especially do_full_type_declaration didn't like working with a non-type. Also highlights the fact that access types are still unsupported.