### PR TITLE
Replace mod type with unsignedbv before writing JSON symtab

### DIFF
--- a/gnat2goto/driver/driver.adb
+++ b/gnat2goto/driver/driver.adb
@@ -608,9 +608,11 @@ package body Driver is
             Value : constant Irep := Current_Symbol.Value;
          begin
             Modified_Symbol.SymType :=
-              Remove_Bounds (Follow_Irep (SymType, Follow_Symbol'Access));
+              Remove_Extra_Type_Information
+              (Follow_Irep (SymType, Follow_Symbol'Access));
             Modified_Symbol.Value :=
-              Remove_Bounds (Follow_Irep (Value, Follow_Symbol'Access));
+              Remove_Extra_Type_Information
+              (Follow_Irep (Value, Follow_Symbol'Access));
 
             New_Table.Insert
                  (Key      => Symbol_Maps.Key (Sym_Iter),

--- a/gnat2goto/ireps/ireps-remove_extra_type_information.adb
+++ b/gnat2goto/ireps/ireps-remove_extra_type_information.adb
@@ -2,10 +2,10 @@
 --  Separate definition for removing type bounds throughout Irep_Lists(s)
 --  Implementation is adopted from ireps-to_json.adb
 --  The rationale is to create a new list only when a new irep was created
---  by the respective Remove_Bounds.
+--  by the respective Remove_Extra_Type_Information.
 -------------------------------------------------------------------------------
 separate (Ireps)
-function Remove_Bounds (L : Irep_List) return Irep_List
+function Remove_Extra_Type_Information (L : Irep_List) return Irep_List
 is
    The_List : Irep_List_Node;
    Ptr      : Internal_Irep_List;
@@ -18,7 +18,8 @@ begin
       while Ptr /= 0 loop
          declare
             Orig_Irep : constant Irep := Irep (Irep_List_Table.Table (Ptr).A);
-            New_Irep  : constant Irep := Remove_Bounds (Orig_Irep);
+            New_Irep  : constant Irep := Remove_Extra_Type_Information
+              (Orig_Irep);
          begin
             if Orig_Irep /= New_Irep then
                Append (Arr, New_Irep);
@@ -37,4 +38,4 @@ begin
    else
       return L;
    end if;
-end Remove_Bounds;
+end Remove_Extra_Type_Information;


### PR DESCRIPTION
For some reason CBMC seems to be able to handle the Ada mod type well enough,
but there is no particular reason to keep the ada-specific irep around, we
really only use it to keep track of type information we don't need at 'runtime'.

Note that this is done by just expanding the scope of the existing `Remove_Bounds` function and appropriately renaming it, I figured it'd make more sense to do it this way considering it was doing more or less the same thing.