### PR TITLE
Replace Make_Signedbv with Make_Signedint and Make_Int

### DIFF
--- a/gnat2goto/driver/driver.adb
+++ b/gnat2goto/driver/driver.adb
@@ -143,7 +143,7 @@ package body Driver is
    end GNAT_To_Goto;
 
    procedure Initialize_CProver_Internal_Variables (Start_Body : Irep) is
-      Int_32_T : constant Irep := Make_Signedbv_Type (Ireps.Empty, 32);
+      Int_32_T : constant Irep := Make_Signedint_Type (32);
 
       procedure Initialize_CProver_Rounding_Mode;
       procedure Initialize_CProver_Rounding_Mode is
@@ -579,7 +579,8 @@ package body Driver is
          Global_Symbol_Table.Insert (Name, Sym);
       end Add_Global_Sym;
 
-      Int_32_T : constant Irep := Make_Signedbv_Type (Ireps.Empty, 32);
+      --  must be int type or error when using __CPROVER_rounded_mode
+      Int_32_T : constant Irep := Make_Int_Type (32);
    begin
       Add_Global_Sym (Intern ("__CPROVER_rounding_mode"), Int_32_T);
    end Add_CProver_Internal_Symbols;

--- a/gnat2goto/driver/goto_utils.adb
+++ b/gnat2goto/driver/goto_utils.adb
@@ -40,6 +40,21 @@ package body GOTO_Utils is
       return I;
    end Make_Int_Type;
 
+   function Make_Signedint_Type (Width : Positive) return Irep is
+   begin
+      return Make_Signedbv_Type (I_Subtype => Make_Nil_Type, Width => Width);
+   end Make_Signedint_Type;
+
+   function Make_Signedbv_Type (Width : Positive) return Irep is
+   begin
+      return Make_Signedbv_Type (I_Subtype => Make_Nil_Type, Width => Width);
+   end Make_Signedbv_Type;
+
+   function Make_Unsignedbv_Type (Width : Positive) return Irep is
+   begin
+      return Make_Unsignedbv_Type (I_Subtype => Make_Nil_Type, Width => Width);
+   end Make_Unsignedbv_Type;
+
    -----------------------
    -- Make_Pointer_Type --
    -----------------------

--- a/gnat2goto/driver/goto_utils.ads
+++ b/gnat2goto/driver/goto_utils.ads
@@ -21,6 +21,12 @@ package GOTO_Utils is
 
    function Make_Int_Type (Width : Positive) return Irep;
 
+   function Make_Signedint_Type (Width : Positive) return Irep;
+
+   function Make_Signedbv_Type (Width : Positive) return Irep;
+
+   function Make_Unsignedbv_Type (Width : Positive) return Irep;
+
    function Make_Pointer_Type (Base : Irep) return Irep;
 
    function Make_Address_Of (Base : Irep) return Irep;

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -983,7 +983,7 @@ package body Tree_Walk is
       -- Dummy value initialisation --
       -- To be removed once the Unsupported reports are removed --
       Set_Source_Location (Ret, Sloc (N));
-      Set_Type (Ret, Make_Signedbv_Type (Ireps.Empty, 32));
+      Set_Type (Ret, Make_Signedint_Type (32));
       Set_Value (Ret, "00000000000000000000000000000000");
 
       if Is_Integer_Literal then
@@ -2875,11 +2875,11 @@ package body Tree_Walk is
       Cast_LHS_To_Integer : constant Irep :=
         Make_Op_Typecast (Op0 => LHS_Bool_Value,
                           Source_Location => Sloc (N),
-                          I_Type => Make_Signedbv_Type (Make_Nil_Type, 32));
+                          I_Type => Make_Signedint_Type (32));
       Cast_RHS_To_Integer : constant Irep :=
         Make_Op_Typecast (Op0 => RHS_Bool_Value,
                           Source_Location => Sloc (N),
-                          I_Type => Make_Signedbv_Type (Make_Nil_Type, 32));
+                          I_Type => Make_Signedint_Type (32));
       R : constant Irep := Operator (Lhs => Cast_LHS_To_Integer,
                                      Rhs => Cast_RHS_To_Integer,
                                      Source_Location => Sloc (N),
@@ -4303,9 +4303,7 @@ package body Tree_Walk is
       --  If the max value is 2^w (for w > 0) then we can just
       --  use an unsignedbv of width w
       if Mod_Max = Power_Of_Two then
-         return Make_Unsignedbv_Type
-           (I_Subtype => Make_Nil_Type,
-            Width => Mod_Max_Binary_Logarithm);
+         return Make_Unsignedbv_Type (Width => Mod_Max_Binary_Logarithm);
       end if;
 
       return Make_Ada_Mod_Type


### PR DESCRIPTION
This enforces appropriate initialisation for these two types
[For I : I_Signedbv_Type, then Set_Subtype (I, Make_Nil_Type) ] for signed int
and no subtype initialisation for int.

This removes the use of 'Make_Signedbv_Type (Ireps.Empty, 32)' for an int,
and Make_Signedbv_Type (Make_Nil_Type, 32)) for a signed int.

-----------------------------

NB If 'Make_Int_Type is replaced with 'Make_Signed_Int' type in
Add_CProver_Internal_Symbols, then the following error occurs (always in the
arrays tests):

+Error from cbmc arrays_access:
+file <built-in-additions> line 21: error: conflicting types for variable `__CPROVER_rounding_mode'
+old definition in module `'
+int
+new definition in module `<built-in-library>' file <built-in-additions> line 21
+signed int
