### PR TITLE
Add a test that demonstrates support added for modular types

### DIFF
--- a/testsuite/gnat2goto/tests/modular_type/modular_type_support.adb
+++ b/testsuite/gnat2goto/tests/modular_type/modular_type_support.adb
@@ -1,0 +1,7 @@
+procedure Modular_Type_Support is
+  type Unsigned_64 is mod 2**64;
+  A : constant Unsigned_64 := 0;
+begin
+  pragma Assert (A = 0);
+  pragma Assert (A /= 10);
+end Modular_Type_Support;

--- a/testsuite/gnat2goto/tests/modular_type/test.out
+++ b/testsuite/gnat2goto/tests/modular_type/test.out
@@ -1,0 +1,3 @@
+[1] file modular_type_support.adb line 5 assertion: SUCCESS
+[2] file modular_type_support.adb line 6 assertion: SUCCESS
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/modular_type/test.py
+++ b/testsuite/gnat2goto/tests/modular_type/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
Add a test that demonstrates support added for modular types. This test doesn't demonstrate support for modular type arithmetic, and it's literally just the code that was demonstrated earlier to be problematic as part of a bug report, so that we can show it's working.