### PR TITLE
Fix undefined behavior in Irep_List append

### DIFF
--- a/gnat2goto/ireps/ireps-append.adb
+++ b/gnat2goto/ireps/ireps-append.adb
@@ -3,19 +3,18 @@ procedure Append (L : Irep_List; I : Irep)
 is
    New_Head : constant Irep_List_Node := (A => Integer (I),
                                           B => 0);
-   The_List : Irep_List_Node renames
-     Irep_List_Table.Table (To_Internal_List (L));
-
    New_Ptr : Internal_Irep_List;
 begin
    Irep_List_Table.Append (New_Head);
    New_Ptr := Irep_List_Table.Last;
 
-   if The_List.A = 0 then
-      The_List.A := Integer (To_List (New_Ptr));
-      The_List.B := New_Ptr;
+   if Irep_List_Table.Table (To_Internal_List (L)).A = 0 then
+      Irep_List_Table.Table (To_Internal_List (L)).A :=
+        Integer (To_List (New_Ptr));
+      Irep_List_Table.Table (To_Internal_List (L)).B := New_Ptr;
    else
-      Irep_List_Table.Table (The_List.B).B := New_Ptr;
-      The_List.B := New_Ptr;
+      Irep_List_Table.Table
+        (Irep_List_Table.Table (To_Internal_List (L)).B).B := New_Ptr;
+      Irep_List_Table.Table (To_Internal_List (L)).B := New_Ptr;
    end if;
 end Append;


### PR DESCRIPTION
Previously this used a pointer into the list table. This leads to undefined
behaviour if the subsequent append operation leads to an allocation of the
table.