### PR TITLE
Feature modular arithmetic expon

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -144,11 +144,6 @@ Error message: Generic declaration
 Nkind: N_Generic_Package_Declaration
 --
 Occurs: 3 times
-Calling function: Do_Operator_Simple
-Error message: Unsupported operand
-Nkind: N_Op_Expon
---
-Occurs: 3 times
 Calling function: Process_Declaration
 Error message: Generic instantiation declaration
 Nkind: N_Procedure_Instantiation

--- a/experiments/golden-results/muen-summary.txt
+++ b/experiments/golden-results/muen-summary.txt
@@ -164,8 +164,8 @@ Error message: function entity not defining identifier
 Nkind: N_Function_Call
 --
 Occurs: 1 times
-Calling function: Do_Operator_Simple
-Error message: Unsupported operand
+Calling function: Do_Op_Expon
+Error message: Exponentiation unhandled for non mod types at the moment
 Nkind: N_Op_Expon
 --
 Occurs: 1 times

--- a/gnat2goto/driver/arrays.adb
+++ b/gnat2goto/driver/arrays.adb
@@ -1,7 +1,6 @@
 with Nlists;                use Nlists;
 with Uintp;                 use Uintp;
 
-with GOTO_Utils;            use GOTO_Utils;
 with Tree_Walk;             use Tree_Walk;
 with Follow;                use Follow;
 

--- a/gnat2goto/driver/arrays.ads
+++ b/gnat2goto/driver/arrays.ads
@@ -6,10 +6,9 @@ with Ireps;             use Ireps;
 with Types;             use Types;
 
 with Symbol_Table_Info; use Symbol_Table_Info;
+with GOTO_Utils;        use GOTO_Utils;
 
 package Arrays is
-
-   type Irep_Array is array (Positive range <>) of Irep;
 
    function Do_Aggregate_Literal_Array (N : Node_Id) return Irep
      with Pre  => Nkind (N) = N_Aggregate;

--- a/gnat2goto/driver/goto_utils.adb
+++ b/gnat2goto/driver/goto_utils.adb
@@ -442,4 +442,35 @@ package body GOTO_Utils is
       return False;
    end Has_GNAT2goto_Annotation;
 
+   function Integer_Constant_To_Expr
+     (Value : Uint;
+      Expr_Type : Irep;
+      Source_Location : Source_Ptr)
+   return Irep is
+      Value_Hex : constant String := Convert_Uint_To_Hex
+        (Value => Value,
+         Bit_Width => Pos (Get_Width (Expr_Type)));
+   begin
+      return Make_Constant_Expr
+        (Source_Location => Source_Location,
+         I_Type => Expr_Type,
+         Value => Value_Hex);
+   end Integer_Constant_To_Expr;
+
+   function Make_Simple_Side_Effect_Expr_Function_Call
+     (Arguments : Irep_Array;
+      Function_Expr : Irep;
+      Source_Location : Source_Ptr) return Irep is
+      Argument_List : constant Irep := Make_Argument_List;
+   begin
+      for Argument of Arguments loop
+         Append_Argument (Argument_List, Argument);
+      end loop;
+      return Make_Side_Effect_Expr_Function_Call
+        (Arguments => Argument_List,
+         I_Function => Function_Expr,
+         I_Type => Get_Return_Type
+           (Get_Type (Function_Expr)),
+         Source_Location => Source_Location);
+   end Make_Simple_Side_Effect_Expr_Function_Call;
 end GOTO_Utils;

--- a/gnat2goto/driver/goto_utils.ads
+++ b/gnat2goto/driver/goto_utils.ads
@@ -7,6 +7,8 @@ with Uintp;                 use Uintp;
 
 package GOTO_Utils is
 
+   type Irep_Array is array (Integer range <>) of Irep;
+
    function CProver_Size_T return Irep;
 
    --  Utility routines for high-level GOTO AST construction
@@ -122,5 +124,18 @@ package GOTO_Utils is
    with Pre => Nkind (Def_Id) = N_Defining_Identifier;
    --  checks whether an entity has a certain GNAT2goto annotation.
    --  This can be either an aspect, or a pragma.
+
+   function Integer_Constant_To_Expr
+     (Value : Uint;
+      Expr_Type : Irep;
+      Source_Location : Source_Ptr)
+   return Irep
+   with Pre => Kind (Expr_Type) in Class_Bitvector_Type,
+        Post => Kind (Integer_Constant_To_Expr'Result) = I_Constant_Expr;
+
+   function Make_Simple_Side_Effect_Expr_Function_Call
+     (Arguments : Irep_Array;
+      Function_Expr : Irep;
+      Source_Location : Source_Ptr) return Irep;
 
 end GOTO_Utils;

--- a/testsuite/gnat2goto/tests/op_expon_mod/op_mod_expon.adb
+++ b/testsuite/gnat2goto/tests/op_expon_mod/op_mod_expon.adb
@@ -1,0 +1,21 @@
+procedure Op_Mod_Expon is
+  type Mod13 is mod 13;
+  procedure Test (Six : Mod13) is
+  begin
+    pragma Assert (Six ** 1 = 6);
+    pragma Assert (Six ** 2 = 10);
+    pragma Assert (Six ** 3 = 8);
+    pragma Assert (Six ** 4 = 9);
+    pragma Assert (Six ** 5 = 2);
+    pragma Assert (Six ** 6 = 12);
+    pragma Assert (Six ** 7 = 7);
+    pragma Assert (Six ** 8 = 3);
+    pragma Assert (Six ** 9 = 5);
+    pragma Assert (Six ** 10 = 4);
+    pragma Assert (Six ** 11 = 11);
+    pragma Assert (Six ** 12 = 1);
+    pragma Assert (Six ** 13 = 6);
+  end Test;
+begin
+  Test (6);
+end Op_Mod_Expon;

--- a/testsuite/gnat2goto/tests/op_expon_mod/test.out
+++ b/testsuite/gnat2goto/tests/op_expon_mod/test.out
@@ -1,0 +1,14 @@
+[1] file op_mod_expon.adb line 5 assertion: SUCCESS
+[2] file op_mod_expon.adb line 6 assertion: SUCCESS
+[3] file op_mod_expon.adb line 7 assertion: SUCCESS
+[4] file op_mod_expon.adb line 8 assertion: SUCCESS
+[5] file op_mod_expon.adb line 9 assertion: SUCCESS
+[6] file op_mod_expon.adb line 10 assertion: SUCCESS
+[7] file op_mod_expon.adb line 11 assertion: SUCCESS
+[8] file op_mod_expon.adb line 12 assertion: SUCCESS
+[9] file op_mod_expon.adb line 13 assertion: SUCCESS
+[10] file op_mod_expon.adb line 14 assertion: SUCCESS
+[11] file op_mod_expon.adb line 15 assertion: SUCCESS
+[12] file op_mod_expon.adb line 16 assertion: SUCCESS
+[13] file op_mod_expon.adb line 17 assertion: SUCCESS
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/op_expon_mod/test.py
+++ b/testsuite/gnat2goto/tests/op_expon_mod/test.py
@@ -1,0 +1,3 @@
+from test_support import prove
+
+prove()


### PR DESCRIPTION
Adds support for the `**` operator for `mod` types, also some more utility functions for creating integer constants and function calls.

Golden results might be out of date, but I don't understand what exactly causes the differences (they seem unrelated to the new functionality?)