### PR TITLE
Failing tests for private type declarations

### DIFF
--- a/testsuite/gnat2goto/tests/private_type_dec_abstract/private_dec_abstract.adb
+++ b/testsuite/gnat2goto/tests/private_type_dec_abstract/private_dec_abstract.adb
@@ -1,0 +1,6 @@
+package body Private_Dec_Abstract is
+   procedure P (X : in out Dec) is
+   begin
+      X.A := X.A + 1;
+   end P;
+end Private_Dec_Abstract;

--- a/testsuite/gnat2goto/tests/private_type_dec_abstract/private_dec_abstract.ads
+++ b/testsuite/gnat2goto/tests/private_type_dec_abstract/private_dec_abstract.ads
@@ -1,0 +1,10 @@
+package Private_Dec_Abstract is
+   type Dec is abstract tagged private;
+
+   procedure P (X : in out Dec);
+
+private
+   type Dec is abstract tagged record
+      A : Integer;
+   end record;
+end Private_Dec_Abstract;

--- a/testsuite/gnat2goto/tests/private_type_dec_abstract/test.opt
+++ b/testsuite/gnat2goto/tests/private_type_dec_abstract/test.opt
@@ -1,0 +1,1 @@
+ALL XFAIL gnat2goto fails with abstract type declaration unsupported

--- a/testsuite/gnat2goto/tests/private_type_dec_abstract/test.py
+++ b/testsuite/gnat2goto/tests/private_type_dec_abstract/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()

--- a/testsuite/gnat2goto/tests/private_type_dec_array/private_dec_array.adb
+++ b/testsuite/gnat2goto/tests/private_type_dec_array/private_dec_array.adb
@@ -1,0 +1,7 @@
+package body Private_Dec_Array is
+   procedure P (X : in out Integer) is
+      MyArray : Buffer_Element_Array;
+   begin
+      MyArray(1) := 5;
+   end P;
+end Private_Dec_Array;

--- a/testsuite/gnat2goto/tests/private_type_dec_array/private_dec_array.ads
+++ b/testsuite/gnat2goto/tests/private_type_dec_array/private_dec_array.ads
@@ -1,0 +1,6 @@
+package Private_Dec_Array is
+   type Buffer_Element_Array is private;
+   procedure P (X : in out Integer);
+private
+   type Buffer_Element_Array is array (1..10) of Integer;
+end Private_Dec_Array;

--- a/testsuite/gnat2goto/tests/private_type_dec_array/test.opt
+++ b/testsuite/gnat2goto/tests/private_type_dec_array/test.opt
@@ -1,0 +1,1 @@
+ALL XFAIL gnat2goto fails because private type is not array type

--- a/testsuite/gnat2goto/tests/private_type_dec_array/test.py
+++ b/testsuite/gnat2goto/tests/private_type_dec_array/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()

--- a/testsuite/gnat2goto/tests/private_type_dec_extension/private_dec_extension.adb
+++ b/testsuite/gnat2goto/tests/private_type_dec_extension/private_dec_extension.adb
@@ -1,0 +1,6 @@
+package body Private_Dec_Extension is
+   procedure P (X : in out String_Input) is
+   begin
+      X.Index := 0;
+   end P;
+end Private_Dec_Extension;

--- a/testsuite/gnat2goto/tests/private_type_dec_extension/private_dec_extension.ads
+++ b/testsuite/gnat2goto/tests/private_type_dec_extension/private_dec_extension.ads
@@ -1,0 +1,15 @@
+package Private_Dec_Extension is
+   type Input_Source is abstract tagged limited private;
+   type String_Input is new Input_Source with private;
+   procedure P (X : in out String_Input);
+
+private
+   type Input_Source is abstract tagged limited record
+      Prolog_Size : Natural := 0;
+   end record;
+
+   type String_Input is new Input_Source with
+      record
+         Index    : Natural;
+      end record;
+end Private_Dec_Extension;

--- a/testsuite/gnat2goto/tests/private_type_dec_extension/test.opt
+++ b/testsuite/gnat2goto/tests/private_type_dec_extension/test.opt
@@ -1,0 +1,1 @@
+ALL XFAIL gnat2goto fails private extension declaration

--- a/testsuite/gnat2goto/tests/private_type_dec_extension/test.py
+++ b/testsuite/gnat2goto/tests/private_type_dec_extension/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
There are 3 cases in our golden results where we still do not support private type declarations:

1: abstract type declaration
2: using private type as array type
3: private type extension