### PR TITLE
Add support for qualified expressions

### DIFF
--- a/experiments/golden-results/Tokeneer-summary.txt
+++ b/experiments/golden-results/Tokeneer-summary.txt
@@ -1,54 +1,39 @@
-Occurs: 411 times
+Occurs: 347 times
 Calling function: Process_Declaration
 Error message: Pragmas in declaration
 Nkind: N_Pragma
 --
-Occurs: 192 times
-Calling function: Process_Declaration
-Error message: Exception declaration
-Nkind: N_Exception_Declaration
---
-Occurs: 176 times
+Occurs: 152 times
 Calling function: Process_Declaration
 Error message: Representation clause declaration
 Nkind: N_Attribute_Definition_Clause
 --
-Occurs: 94 times
-Calling function: Do_Expression
-Error message: Qualified
-Nkind: N_Qualified_Expression
---
-Occurs: 82 times
+Occurs: 116 times
 Calling function: Process_Declaration
-Error message: Number declaration
-Nkind: N_Number_Declaration
+Error message: Exception declaration
+Nkind: N_Exception_Declaration
 --
-Occurs: 62 times
+Occurs: 43 times
 Calling function: Process_Declaration
 Error message: Private type declaration unsupported
 Nkind: N_Private_Type_Declaration
 --
-Occurs: 36 times
-Calling function: Process_Declaration
-Error message: Abstract subprogram declaration
-Nkind: N_Abstract_Subprogram_Declaration
---
-Occurs: 32 times
+Occurs: 38 times
 Calling function: Do_Expression
 Error message: Unknown expression kind
 Nkind: N_Expanded_Name
 --
-Occurs: 28 times
-Calling function: Do_Base_Range_Constraint
-Error message: unsupported upper range kind
-Nkind: N_Identifier
+Occurs: 37 times
+Calling function: Process_Declaration
+Error message: Number declaration
+Nkind: N_Number_Declaration
 --
-Occurs: 15 times
-Calling function: Do_Base_Range_Constraint
-Error message: range expression not bitvector type
-Nkind: N_Range
+Occurs: 18 times
+Calling function: Process_Declaration
+Error message: Abstract subprogram declaration
+Nkind: N_Abstract_Subprogram_Declaration
 --
-Occurs: 12 times
+Occurs: 11 times
 Calling function: Do_Type_Definition
 Error message: Unknown expression kind
 Nkind: N_Access_Function_Definition
@@ -58,15 +43,30 @@ Calling function: Process_Declaration
 Error message: Representation clause declaration
 Nkind: N_Enumeration_Representation_Clause
 --
+Occurs: 8 times
+Calling function: Do_Aggregate_Literal
+Error message: Unhandled aggregate kind
+Nkind: N_Aggregate
+--
+Occurs: 8 times
+Calling function: Do_Base_Range_Constraint
+Error message: range expression not bitvector type
+Nkind: N_Range
+--
+Occurs: 8 times
+Calling function: Do_Base_Range_Constraint
+Error message: unsupported upper range kind
+Nkind: N_Identifier
+--
+Occurs: 4 times
+Calling function: Do_Aggregate_Literal_Array
+Error message: More than one named operand
+Nkind: N_Aggregate
+--
 Occurs: 4 times
 Calling function: Do_Expression
 Error message: Unknown attribute
 Nkind: N_Attribute_Reference
---
-Occurs: 3 times
-Calling function: Do_While_Statement
-Error message: Wrong Nkind spec
-Nkind: N_Loop_Statement
 --
 Occurs: 3 times
 Calling function: Process_Statement
@@ -74,19 +74,19 @@ Error message: Unknown expression kind
 Nkind: N_Object_Declaration
 --
 Occurs: 2 times
-Calling function: Do_Itype_Integer_Subtype
-Error message: Non-literal bound unsupported
-Nkind: N_Defining_Identifier
---
-Occurs: 2 times
 Calling function: Do_Operator_General
 Error message: Concat unsupported
 Nkind: N_Op_Concat
 --
 Occurs: 2 times
-Calling function: Process_Declaration
-Error message: Private extension declaration unsupported
-Nkind: N_Private_Extension_Declaration
+Calling function: Do_While_Statement
+Error message: Wrong Nkind spec
+Nkind: N_Loop_Statement
+--
+Occurs: 1 times
+Calling function: Do_Itype_Integer_Subtype
+Error message: Non-literal bound unsupported
+Nkind: N_Defining_Identifier
 --
 Occurs: 159 times
 Redacted compiler error message:

--- a/experiments/golden-results/UKNI-Information-Barrier-summary.txt
+++ b/experiments/golden-results/UKNI-Information-Barrier-summary.txt
@@ -1,9 +1,9 @@
-Occurs: 573 times
+Occurs: 424 times
 Calling function: Process_Declaration
 Error message: Pragmas in declaration
 Nkind: N_Pragma
 --
-Occurs: 265 times
+Occurs: 202 times
 Calling function: Process_Declaration
 Error message: Number declaration
 Nkind: N_Number_Declaration
@@ -13,50 +13,25 @@ Calling function: Process_Declaration
 Error message: Representation clause declaration
 Nkind: N_Attribute_Definition_Clause
 --
-Occurs: 26 times
-Calling function: Do_Expression
-Error message: Qualified
-Nkind: N_Qualified_Expression
---
-Occurs: 7 times
-Calling function: Process_Declaration
-Error message: Subprogram body stub declaration
-Nkind: N_Subprogram_Body_Stub
---
-Occurs: 6 times
-Calling function: Do_Expression
-Error message: Unknown expression kind
-Nkind: N_Expanded_Name
---
 Occurs: 6 times
 Calling function: Process_Declaration
 Error message: Private type declaration unsupported
 Nkind: N_Private_Type_Declaration
 --
-Occurs: 5 times
+Occurs: 3 times
 Calling function: Do_Itype_Definition
 Error message: Unknown Ekind
 Nkind: N_Defining_Identifier
 --
-Occurs: 5 times
-Calling function: Do_Procedure_Call_Statement
-Error message: sym id not in symbol table
-Nkind: N_Procedure_Call_Statement
---
-Occurs: 4 times
+Occurs: 2 times
 Calling function: Do_Base_Range_Constraint
 Error message: range expression not bitvector type
 Nkind: N_Range
 --
-Occurs: 2 times
-Calling function: Do_While_Statement
-Error message: Wrong Nkind spec
-Nkind: N_Loop_Statement
---
 Occurs: 1 times
-Calling function: Do_Operator_General
-Error message: Mod of unsupported type
-Nkind: N_Op_Not
+Calling function: Do_Aggregate_Literal_Array
+Error message: More than one named operand
+Nkind: N_Aggregate
 --
 Occurs: 1 times
 Calling function: Process_Declaration

--- a/experiments/golden-results/muen-summary.txt
+++ b/experiments/golden-results/muen-summary.txt
@@ -1,9 +1,9 @@
-Occurs: 1508 times
+Occurs: 1488 times
 Calling function: Process_Declaration
 Error message: Pragmas in declaration
 Nkind: N_Pragma
 --
-Occurs: 852 times
+Occurs: 838 times
 Calling function: Process_Declaration
 Error message: Representation clause declaration
 Nkind: N_Attribute_Definition_Clause
@@ -18,17 +18,17 @@ Calling function: Process_Declaration
 Error message: Exception declaration
 Nkind: N_Exception_Declaration
 --
-Occurs: 105 times
+Occurs: 102 times
 Calling function: Do_Type_Definition
 Error message: Access type unsupported
 Nkind: N_Access_To_Object_Definition
 --
-Occurs: 97 times
+Occurs: 94 times
 Calling function: Process_Declaration
 Error message: Private type declaration unsupported
 Nkind: N_Private_Type_Declaration
 --
-Occurs: 32 times
+Occurs: 30 times
 Calling function: Process_Declaration
 Error message: Abstract subprogram declaration
 Nkind: N_Abstract_Subprogram_Declaration
@@ -38,22 +38,12 @@ Calling function: Process_Declaration
 Error message: Representation clause declaration
 Nkind: N_Record_Representation_Clause
 --
-Occurs: 14 times
-Calling function: Do_Expression
-Error message: Qualified
-Nkind: N_Qualified_Expression
---
-Occurs: 13 times
+Occurs: 12 times
 Calling function: Do_Derived_Type_Definition
 Error message: record extension unsupported
 Nkind: N_Derived_Type_Definition
 --
-Occurs: 13 times
-Calling function: Process_Declaration
-Error message: Package declaration
-Nkind: N_Package_Declaration
---
-Occurs: 13 times
+Occurs: 12 times
 Calling function: Process_Declaration
 Error message: Private extension declaration unsupported
 Nkind: N_Private_Extension_Declaration
@@ -62,6 +52,11 @@ Occurs: 10 times
 Calling function: Do_Type_Definition
 Error message: Unknown expression kind
 Nkind: N_Access_Function_Definition
+--
+Occurs: 10 times
+Calling function: Process_Declaration
+Error message: Package declaration
+Nkind: N_Package_Declaration
 --
 Occurs: 9 times
 Calling function: Do_Function_Call
@@ -93,11 +88,6 @@ Calling function: Do_Constant
 Error message: Constant Type not in symbol table
 Nkind: N_Integer_Literal
 --
-Occurs: 6 times
-Calling function: Process_Declaration
-Error message: Generic instantiation declaration
-Nkind: N_Procedure_Instantiation
---
 Occurs: 4 times
 Calling function: Do_Expression
 Error message: Unknown expression kind
@@ -109,24 +99,34 @@ Error message: Package body declaration
 Nkind: N_Package_Body
 --
 Occurs: 3 times
-Calling function: Do_Address_Of
-Error message: Kind not in class type
-Nkind: N_Attribute_Reference
---
-Occurs: 3 times
 Calling function: Do_Aggregate_Literal_Array
 Error message: More than one named operand
 Nkind: N_Aggregate
 --
 Occurs: 3 times
-Calling function: Do_Identifier
-Error message: Etype not a type
-Nkind: N_Identifier
---
-Occurs: 3 times
 Calling function: Process_Declaration
 Error message: Generic declaration
 Nkind: N_Generic_Subprogram_Declaration
+--
+Occurs: 3 times
+Calling function: Process_Declaration
+Error message: Generic instantiation declaration
+Nkind: N_Procedure_Instantiation
+--
+Occurs: 2 times
+Calling function: Do_Address_Of
+Error message: Kind not in class type
+Nkind: N_Attribute_Reference
+--
+Occurs: 2 times
+Calling function: Do_Aggregate_Literal
+Error message: Unhandled aggregate kind
+Nkind: N_Aggregate
+--
+Occurs: 2 times
+Calling function: Do_Identifier
+Error message: Etype not a type
+Nkind: N_Identifier
 --
 Occurs: 2 times
 Calling function: Do_Procedure_Call_Statement

--- a/testsuite/gnat2goto/tests/qualified_expression/qualified_expr.adb
+++ b/testsuite/gnat2goto/tests/qualified_expression/qualified_expr.adb
@@ -1,0 +1,16 @@
+procedure Qualified_Expr is
+  type Int10 is range 0..10;
+  subtype Int25 is Int10 range 2..5;
+
+  procedure Do_Loop (LB : Int10; UB: Int10) is
+  begin
+    for J in Int25'(LB) .. Int25'(UB) loop
+      null;
+    end loop;
+  end Do_Loop;
+begin
+  --  We expect one of the lower bound to fail
+  --  the range assertion check because of the
+  --  qualified type.
+  Do_Loop (1, 4);
+end Qualified_Expr;

--- a/testsuite/gnat2goto/tests/qualified_expression/test.out
+++ b/testsuite/gnat2goto/tests/qualified_expression/test.out
@@ -1,0 +1,3 @@
+[assertion.1] Range Check: FAILURE
+[assertion.2] Range Check: SUCCESS
+VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/qualified_expression/test.py
+++ b/testsuite/gnat2goto/tests/qualified_expression/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
Add support for qualified expressions. They look like this:

```ada
type MASK is (FIX, DEC, EXP, SIGNIF);
type CODE is (FIX, CLA, DEC, TNZ, SUB); 

PRINT (MASK'(DEC));  --  DEC is of type MASK
PRINT (CODE'(DEC));  --  DEC is of type CODE 
```
