### PR TITLE
Derived type tests

### DIFF
--- a/test.opt
+++ b/test.opt
@@ -1,0 +1,1 @@
+ALL XFAIL gnat2goto fails with private type declarations unsupported

--- a/test.opt
+++ b/test.opt
@@ -1,1 +1,0 @@
-ALL XFAIL gnat2goto fails with private type declarations unsupported

--- a/testsuite/gnat2goto/tests/derived_private_type/derived_private_type.adb
+++ b/testsuite/gnat2goto/tests/derived_private_type/derived_private_type.adb
@@ -1,0 +1,9 @@
+with Private_Type; use Private_Type;
+procedure Derived_Private_Type is
+   type Derived_Priv is new Priv;
+   V_Priv : Priv := Priv_Const;
+   V_D_Priv : Derived_Priv := Derived_Priv (Priv_Const);
+begin
+   pragma Assert (Derived_Priv (V_Priv) = V_D_Priv);
+   null;
+end Derived_Private_Type;

--- a/testsuite/gnat2goto/tests/derived_private_type/private_type.ads
+++ b/testsuite/gnat2goto/tests/derived_private_type/private_type.ads
@@ -1,0 +1,7 @@
+package Private_Type is
+   type Priv is private;
+   Priv_Const : constant Priv;
+private
+   type Priv is new Integer range 1 .. 23;
+   Priv_Const : constant Priv := 17;
+end Private_Type;

--- a/testsuite/gnat2goto/tests/derived_private_type/test.opt
+++ b/testsuite/gnat2goto/tests/derived_private_type/test.opt
@@ -1,0 +1,2 @@
+ALL XFAIL gnat2goto aborts with Symbol_Table_Info.Symbol_Maps.Constant_Reference key not in map
+

--- a/testsuite/gnat2goto/tests/derived_private_type/test.py
+++ b/testsuite/gnat2goto/tests/derived_private_type/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()

--- a/testsuite/gnat2goto/tests/derived_types/derived_types.adb
+++ b/testsuite/gnat2goto/tests/derived_types/derived_types.adb
@@ -1,0 +1,11 @@
+with Private_Type; use Private_Type;
+procedure Derived_Types is
+   type My_Int is range -23 .. 23;
+   type My_Real is new Float;
+   type Derived_Priv is new Priv;
+begin
+   pragma Assert (0 in My_Int);
+   pragma Assert (11.0 in My_Real);
+   pragma Assert (My_Int'Succ (22) = 23);
+   null;
+end Derived_Types;

--- a/testsuite/gnat2goto/tests/derived_types/derived_types.adb
+++ b/testsuite/gnat2goto/tests/derived_types/derived_types.adb
@@ -1,8 +1,7 @@
-with Private_Type; use Private_Type;
 procedure Derived_Types is
    type My_Int is range -23 .. 23;
    type My_Real is new Float;
-   type Derived_Priv is new Priv;
+   
 begin
    pragma Assert (0 in My_Int);
    pragma Assert (11.0 in My_Real);

--- a/testsuite/gnat2goto/tests/derived_types/private_type.ads
+++ b/testsuite/gnat2goto/tests/derived_types/private_type.ads
@@ -1,7 +1,0 @@
-package Private_Type is
-   type Priv is private;
-   Priv_Const : constant Priv;
-private
-   type Priv is new Integer range 1 .. 23;
-   Priv_Const : constant Priv := 17;
-end Private_Type;

--- a/testsuite/gnat2goto/tests/derived_types/private_type.ads
+++ b/testsuite/gnat2goto/tests/derived_types/private_type.ads
@@ -1,0 +1,7 @@
+package Private_Type is
+   type Priv is private;
+   Priv_Const : constant Priv;
+private
+   type Priv is new Integer range 1 .. 23;
+   Priv_Const : constant Priv := 17;
+end Private_Type;

--- a/testsuite/gnat2goto/tests/derived_types/test.out
+++ b/testsuite/gnat2goto/tests/derived_types/test.out
@@ -1,0 +1,4 @@
+[1] file derived_types.adb line 7 assertion: SUCCESS
+[2] file derived_types.adb line 8 assertion: SUCCESS
+[3] file derived_types.adb line 9 assertion: SUCCESS
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/derived_types/test.out
+++ b/testsuite/gnat2goto/tests/derived_types/test.out
@@ -1,4 +1,4 @@
-[1] file derived_types.adb line 7 assertion: SUCCESS
-[2] file derived_types.adb line 8 assertion: SUCCESS
-[3] file derived_types.adb line 9 assertion: SUCCESS
+[1] file derived_types.adb line 6 assertion: SUCCESS
+[2] file derived_types.adb line 7 assertion: SUCCESS
+[3] file derived_types.adb line 8 assertion: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/derived_types/test.py
+++ b/testsuite/gnat2goto/tests/derived_types/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()

--- a/testsuite/gnat2goto/tests/divide/test.out
+++ b/testsuite/gnat2goto/tests/divide/test.out
@@ -1,3 +1,2 @@
 [1] file divide.adb line 7 assertion: SUCCESS
 VERIFICATION SUCCESSFUL
-

--- a/testsuite/gnat2goto/tests/forloop/test.out
+++ b/testsuite/gnat2goto/tests/forloop/test.out
@@ -1,3 +1,2 @@
 [1] file forloop.adb line 9 assertion: SUCCESS
 VERIFICATION SUCCESSFUL
-


### PR DESCRIPTION
Added some tests to test suite to check the processing of simple derived types (untagged types) in response to issue #56.

Test shows simple derived types are handled but a derived private type causes a gnat2goto failure.  Possibly due to not handling type conversions?
