### PR TITLE
Pragmas in declarations (volatile) [depends-on: #220]

### DIFF
--- a/experiments/golden-results/SPARK-tetris-summary.txt
+++ b/experiments/golden-results/SPARK-tetris-summary.txt
@@ -8,11 +8,6 @@ Calling function: Do_Base_Range_Constraint
 Error message: range expression not bitvector type
 Nkind: N_Range
 --
-Occurs: 9 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Volatile
-Nkind: N_Pragma
---
 Occurs: 2 times
 Calling function: Process_Declaration
 Error message: Representation clause declaration

--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -8,7 +8,7 @@ Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Postcondition
 Nkind: N_Pragma
 --
-Occurs: 168 times
+Occurs: 134 times
 Calling function: Process_Declaration
 Error message: Unknown declaration kind
 Nkind: N_Freeze_Generic_Entity
@@ -23,25 +23,20 @@ Calling function: Process_Declaration
 Error message: Generic declaration
 Nkind: N_Generic_Subprogram_Declaration
 --
-Occurs: 99 times
+Occurs: 60 times
 Calling function: Do_Function_Call
 Error message: func name not in symbol table
 Nkind: N_Function_Call
---
-Occurs: 62 times
-Calling function: Do_Expression
-Error message: Unknown attribute
-Nkind: N_Attribute_Reference
 --
 Occurs: 49 times
 Calling function: Do_Type_Definition
 Error message: Access type unsupported
 Nkind: N_Access_To_Object_Definition
 --
-Occurs: 39 times
-Calling function: Process_Statement
-Error message: Raise statement
-Nkind: N_Raise_Statement
+Occurs: 48 times
+Calling function: Do_Expression
+Error message: Unknown attribute
+Nkind: N_Attribute_Reference
 --
 Occurs: 35 times
 Calling function: Process_Declaration
@@ -53,7 +48,7 @@ Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: No strict aliasing
 Nkind: N_Pragma
 --
-Occurs: 28 times
+Occurs: 26 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Check
 Nkind: N_Pragma
@@ -83,16 +78,6 @@ Calling function: Process_Declaration
 Error message: Unknown declaration kind
 Nkind: N_Null_Statement
 --
-Occurs: 13 times
-Calling function: Do_Constant
-Error message: Constant Type not in symbol table
-Nkind: N_Integer_Literal
---
-Occurs: 13 times
-Calling function: Do_Procedure_Call_Statement
-Error message: sym id not in symbol table
-Nkind: N_Procedure_Call_Statement
---
 Occurs: 12 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Global
@@ -103,15 +88,15 @@ Calling function: Do_Expression
 Error message: In
 Nkind: N_In
 --
-Occurs: 11 times
-Calling function: Make_Array_First_Expr
-Error message: Base type not array type
-Nkind: N_Defining_Identifier
+Occurs: 10 times
+Calling function: Process_Statement
+Error message: Raise statement
+Nkind: N_Raise_Statement
 --
-Occurs: 11 times
-Calling function: Make_Array_Index_Op
-Error message: Base type not array type
-Nkind: N_Defining_Identifier
+Occurs: 9 times
+Calling function: Do_Procedure_Call_Statement
+Error message: sym id not in symbol table
+Nkind: N_Procedure_Call_Statement
 --
 Occurs: 9 times
 Calling function: Process_Declaration
@@ -154,11 +139,6 @@ Error message: Unsupported pragma: Unreferenced
 Nkind: N_Pragma
 --
 Occurs: 5 times
-Calling function: Do_Operator_General
-Error message: Concat unsupported
-Nkind: N_Op_Concat
---
-Occurs: 5 times
 Calling function: Do_Type_Definition
 Error message: Unknown expression kind
 Nkind: N_Access_Procedure_Definition
@@ -177,6 +157,11 @@ Occurs: 4 times
 Calling function: Do_Expression
 Error message: Unknown expression kind
 Nkind: N_Expanded_Name
+--
+Occurs: 4 times
+Calling function: Do_Operator_General
+Error message: Concat unsupported
+Nkind: N_Op_Concat
 --
 Occurs: 4 times
 Calling function: Process_Declaration
@@ -214,9 +199,9 @@ Error message: Constant Type not in Class_Bitvector_Type
 Nkind: N_Integer_Literal
 --
 Occurs: 2 times
-Calling function: Do_Function_Call
-Error message: function entity not defining identifier
-Nkind: N_Function_Call
+Calling function: Do_Constant
+Error message: Constant Type not in symbol table
+Nkind: N_Integer_Literal
 --
 Occurs: 2 times
 Calling function: Do_Itype_Integer_Subtype
@@ -257,6 +242,16 @@ Occurs: 1 times
 Calling function: Do_Pragma
 Error message: Unsupported pragma: Unreferenced
 Nkind: N_Pragma
+--
+Occurs: 1 times
+Calling function: Make_Array_First_Expr
+Error message: Base type not array type
+Nkind: N_Defining_Identifier
+--
+Occurs: 1 times
+Calling function: Make_Array_Index_Op
+Error message: Base type not array type
+Nkind: N_Defining_Identifier
 --
 Occurs: 1 times
 Calling function: Process_Declaration

--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -215,11 +215,6 @@ Nkind: N_Pragma
 --
 Occurs: 2 times
 Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Volatile
-Nkind: N_Pragma
---
-Occurs: 2 times
-Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Warnings
 Nkind: N_Pragma
 --

--- a/experiments/golden-results/UKNI-Information-Barrier-summary.txt
+++ b/experiments/golden-results/UKNI-Information-Barrier-summary.txt
@@ -3,11 +3,6 @@ Calling function: Process_Declaration
 Error message: Representation clause declaration
 Nkind: N_Attribute_Definition_Clause
 --
-Occurs: 36 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Volatile
-Nkind: N_Pragma
---
 Occurs: 3 times
 Calling function: Do_Itype_Definition
 Error message: Unknown Ekind

--- a/experiments/golden-results/muen-summary.txt
+++ b/experiments/golden-results/muen-summary.txt
@@ -59,11 +59,6 @@ Error message: Unsupported pragma: Abstract state
 Nkind: N_Pragma
 --
 Occurs: 11 times
-Calling function: Do_Constant
-Error message: Constant Type not in symbol table
-Nkind: N_Integer_Literal
---
-Occurs: 11 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Initializes
 Nkind: N_Pragma
@@ -159,14 +154,14 @@ Error message: Unhandled aggregate kind
 Nkind: N_Aggregate
 --
 Occurs: 2 times
+Calling function: Do_Constant
+Error message: Constant Type not in symbol table
+Nkind: N_Integer_Literal
+--
+Occurs: 2 times
 Calling function: Do_Identifier
 Error message: Etype not a type
 Nkind: N_Identifier
---
-Occurs: 2 times
-Calling function: Do_Procedure_Call_Statement
-Error message: sym id not in symbol table
-Nkind: N_Procedure_Call_Statement
 --
 Occurs: 2 times
 Calling function: Do_Type_Definition

--- a/experiments/golden-results/muen-summary.txt
+++ b/experiments/golden-results/muen-summary.txt
@@ -223,11 +223,6 @@ Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Unreferenced
 Nkind: N_Pragma
 --
-Occurs: 1 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Volatile
-Nkind: N_Pragma
---
 Occurs: 291 times
 Redacted compiler error message:
 violation of restriction "REDACTED"

--- a/experiments/golden-results/vct-summary.txt
+++ b/experiments/golden-results/vct-summary.txt
@@ -3,11 +3,6 @@ Calling function: Process_Declaration
 Error message: Exception declaration
 Nkind: N_Exception_Declaration
 --
-Occurs: 61 times
-Calling function: Process_Declaration
-Error message: Pragmas in declaration
-Nkind: N_Pragma
---
 Occurs: 32 times
 Calling function: Do_Base_Range_Constraint
 Error message: unsupported upper range kind
@@ -33,6 +28,11 @@ Calling function: Do_Private_Type_Declaration
 Error message: Abstract type declaration unsupported
 Nkind: N_Private_Type_Declaration
 --
+Occurs: 8 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Preelaborable Initialization
+Nkind: N_Pragma
+--
 Occurs: 7 times
 Calling function: Do_Aggregate_Literal_Array
 Error message: More than one named operand
@@ -42,6 +42,11 @@ Occurs: 7 times
 Calling function: Process_Declaration
 Error message: Representation clause declaration
 Nkind: N_Attribute_Definition_Clause
+--
+Occurs: 3 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Suppress initialization
+Nkind: N_Pragma
 --
 Occurs: 1 times
 Calling function: Do_Aggregate_Literal

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -4682,6 +4682,28 @@ package body Tree_Walk is
    end Process_Declaration;
 
    procedure Process_Pragma_Declaration (N : Node_Id) is
+      procedure Handle_Pragma_Volatile (N : Node_Id);
+
+      procedure Handle_Pragma_Volatile (N : Node_Id) is
+         Argument_Associations : constant List_Id :=
+           Pragma_Argument_Associations (N);
+         First_Argument_Expression : constant Node_Id :=
+           Expression (First (Argument_Associations));
+         Expression_Id : constant Symbol_Id :=
+           Intern (Unique_Name (Entity (First_Argument_Expression)));
+
+         procedure Set_Volatile (Key : Symbol_Id; Element : in out Symbol);
+         procedure Set_Volatile (Key : Symbol_Id; Element : in out Symbol) is
+         begin
+            pragma Assert (Unintern (Key) = Unintern (Expression_Id));
+            Element.IsVolatile := True;
+         end Set_Volatile;
+      begin
+         pragma Assert (Global_Symbol_Table.Contains (Expression_Id));
+         Global_Symbol_Table.Update_Element (
+                          Position => Global_Symbol_Table.Find (Expression_Id),
+                          Process  => Set_Volatile'Access);
+      end Handle_Pragma_Volatile;
    begin
       case Pragma_Name (N) is
          when Name_Assert |
@@ -4740,8 +4762,7 @@ package body Tree_Walk is
             --  they may be modified by the environment. Effectively, they need
             --  to be modelled as non-deterministic input in every state. It
             --  changes the semantics wrt to thread interleavings.
-            Report_Unhandled_Node_Empty (N, "Process_Pragma_Declaration",
-                                         "Unsupported pragma: Volatile");
+            Handle_Pragma_Volatile (N);
          when Name_Attach_Handler =>
             --  The expression in the Attach_Handler pragma as evaluated at
             --  object creation time specifies an interrupt. As part of the

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -1137,6 +1137,7 @@ package body Tree_Walk is
    function Do_Defining_Identifier (E : Entity_Id) return Irep is
       Sym          : constant Irep := New_Irep (I_Symbol_Expr);
       Result_Type  : constant Irep := Do_Type_Reference (Etype (E));
+      Sym_Id       : constant Symbol_Id := Intern (Unique_Name (E));
 
       Is_Out_Param : constant Boolean :=
         Ekind (E) in E_In_Out_Parameter | E_Out_Parameter;
@@ -1150,6 +1151,20 @@ package body Tree_Walk is
       Set_Source_Location (Sym, Sloc (E));
       Set_Identifier      (Sym, Unique_Name (E));
       Set_Type            (Sym, Symbol_Type);
+
+      if not Global_Symbol_Table.Contains (Sym_Id) then
+         declare
+            Variable_Symbol : Symbol;
+         begin
+            Variable_Symbol.Name       := Sym_Id;
+            Variable_Symbol.BaseName   := Sym_Id;
+            Variable_Symbol.PrettyName := Intern (Get_Name_String (Chars (E)));
+            Variable_Symbol.SymType    := Symbol_Type;
+            Variable_Symbol.Mode       := Intern ("C");
+            Variable_Symbol.Value      := Make_Nil (Sloc (E));
+            Global_Symbol_Table.Insert (Sym_Id, Variable_Symbol);
+         end;
+      end if;
 
       if Is_Out_Param then
          return Deref : constant Irep := New_Irep (I_Dereference_Expr) do

--- a/testsuite/gnat2goto/tests/volatile/test.out
+++ b/testsuite/gnat2goto/tests/volatile/test.out
@@ -1,0 +1,2 @@
+[1] file volatile_type.adb line 14 assertion: SUCCESS
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/volatile/test.py
+++ b/testsuite/gnat2goto/tests/volatile/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()

--- a/testsuite/gnat2goto/tests/volatile/volatile_type.adb
+++ b/testsuite/gnat2goto/tests/volatile/volatile_type.adb
@@ -1,0 +1,16 @@
+procedure Volatile_Type is
+   Data: Integer;
+   pragma Volatile(Data);
+   Flag: Boolean;
+   pragma Volatile(Flag);
+begin
+   Data := 42;
+   Flag := True;
+
+   if not Flag then
+      Data := 0;
+   end if;
+
+   pragma Assert (Data=42);
+
+end Volatile_Type;


### PR DESCRIPTION
Handle volatile pragmas by updating the symbol in symbol table. Turned out the symbol wasn't there yet. Extended the `Do_Defining_Identifier` to insert the symbol.

The first commit is a squash of the prerequisite PR #220 -- no need to review it here.