### PR TITLE
Check type is known when building reference

### DIFF
--- a/experiments/golden-results/SPARK-tetris-summary.txt
+++ b/experiments/golden-results/SPARK-tetris-summary.txt
@@ -3,6 +3,11 @@ Calling function: Process_Declaration
 Error message: Package declaration
 Nkind: N_Package_Declaration
 --
+Occurs: 11 times
+Calling function: Do_Type_Reference
+Error message: Unsupported declaration of unknown type
+Nkind: N_Defining_Identifier
+--
 Occurs: 10 times
 Calling function: Do_Base_Range_Constraint
 Error message: range expression not bitvector type

--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -1,3 +1,8 @@
+Occurs: 1359 times
+Calling function: Do_Type_Reference
+Error message: Unsupported declaration of unknown type
+Nkind: N_Defining_Identifier
+--
 Occurs: 1272 times
 Calling function: Process_Declaration
 Error message: Representation clause declaration

--- a/experiments/golden-results/Tokeneer-summary.txt
+++ b/experiments/golden-results/Tokeneer-summary.txt
@@ -13,6 +13,11 @@ Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Ada 05
 Nkind: N_Pragma
 --
+Occurs: 43 times
+Calling function: Do_Type_Reference
+Error message: Unsupported declaration of unknown type
+Nkind: N_Defining_Identifier
+--
 Occurs: 38 times
 Calling function: Do_Expression
 Error message: Unknown expression kind

--- a/experiments/golden-results/UKNI-Information-Barrier-summary.txt
+++ b/experiments/golden-results/UKNI-Information-Barrier-summary.txt
@@ -3,6 +3,11 @@ Calling function: Process_Declaration
 Error message: Representation clause declaration
 Nkind: N_Attribute_Definition_Clause
 --
+Occurs: 88 times
+Calling function: Do_Type_Reference
+Error message: Unsupported declaration of unknown type
+Nkind: N_Defining_Identifier
+--
 Occurs: 36 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Volatile

--- a/experiments/golden-results/ksum-summary.txt
+++ b/experiments/golden-results/ksum-summary.txt
@@ -39,6 +39,11 @@ Error message: Unknown expression kind
 Nkind: N_Access_Function_Definition
 --
 Occurs: 1 times
+Calling function: Do_Type_Reference
+Error message: Unsupported declaration of unknown type
+Nkind: N_Defining_Identifier
+--
+Occurs: 1 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Ada 2012
 Nkind: N_Pragma

--- a/experiments/golden-results/libkeccak-summary.txt
+++ b/experiments/golden-results/libkeccak-summary.txt
@@ -49,6 +49,11 @@ Error message: Unknown expression kind
 Nkind: N_Access_Function_Definition
 --
 Occurs: 6 times
+Calling function: Do_Type_Reference
+Error message: Unsupported declaration of unknown type
+Nkind: N_Defining_Identifier
+--
+Occurs: 6 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Ada 05
 Nkind: N_Pragma

--- a/experiments/golden-results/muen-summary.txt
+++ b/experiments/golden-results/muen-summary.txt
@@ -3,6 +3,11 @@ Calling function: Process_Declaration
 Error message: Representation clause declaration
 Nkind: N_Attribute_Definition_Clause
 --
+Occurs: 314 times
+Calling function: Do_Type_Reference
+Error message: Unsupported declaration of unknown type
+Nkind: N_Defining_Identifier
+--
 Occurs: 112 times
 Calling function: Process_Declaration
 Error message: Exception declaration
@@ -107,6 +112,11 @@ Occurs: 6 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Precondition
 Nkind: N_Pragma
+--
+Occurs: 5 times
+Calling function: Do_Itype_Definition
+Error message: Unknown Ekind
+Nkind: N_Defining_Identifier
 --
 Occurs: 5 times
 Calling function: Process_Pragma_Declaration

--- a/experiments/golden-results/vct-summary.txt
+++ b/experiments/golden-results/vct-summary.txt
@@ -39,6 +39,11 @@ Error message: More than one named operand
 Nkind: N_Aggregate
 --
 Occurs: 7 times
+Calling function: Do_Type_Reference
+Error message: Unsupported declaration of unknown type
+Nkind: N_Defining_Identifier
+--
+Occurs: 7 times
 Calling function: Process_Declaration
 Error message: Representation clause declaration
 Nkind: N_Attribute_Definition_Clause

--- a/gnat2goto/driver/arrays.adb
+++ b/gnat2goto/driver/arrays.adb
@@ -351,12 +351,6 @@ package body Arrays is
               Number_Str_Raw (2 .. Number_Str_Raw'Last);
             First_Name : constant String := "first" & Number_Str;
             Last_Name : constant String := "last" & Number_Str;
-            Dimension_Type : constant Irep :=
-              Do_Type_Reference (Etype (Dimension_Iter));
-            First_Comp : constant Irep :=
-              Make_Struct_Component (First_Name, Dimension_Type);
-            Last_Comp : constant Irep :=
-              Make_Struct_Component (Last_Name, Dimension_Type);
          begin
 
             --  Declare the dimension index type if required:
@@ -371,8 +365,17 @@ package body Arrays is
                   null;
             end case;
 
-            Append_Component (Ret_Components, First_Comp);
-            Append_Component (Ret_Components, Last_Comp);
+            declare
+               Dimension_Type : constant Irep :=
+                 Do_Type_Reference (Etype (Dimension_Iter));
+               First_Comp : constant Irep :=
+                 Make_Struct_Component (First_Name, Dimension_Type);
+               Last_Comp : constant Irep :=
+                 Make_Struct_Component (Last_Name, Dimension_Type);
+            begin
+               Append_Component (Ret_Components, First_Comp);
+               Append_Component (Ret_Components, Last_Comp);
+            end;
 
          end;
          Dimension_Number := Dimension_Number + 1;

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -4258,7 +4258,21 @@ package body Tree_Walk is
    -----------------------
 
    function Do_Type_Reference (E : Entity_Id) return Irep is
-      (Make_Symbol_Type (Identifier => Unique_Name (E)));
+   begin
+      declare
+         Sym_Id : constant Symbol_Id := Intern (Unique_Name (E));
+      begin
+         if not Global_Symbol_Table.Contains (Sym_Id) and Is_Itype (E) then
+            Declare_Itype (E);
+         end if;
+         if not Global_Symbol_Table.Contains (Sym_Id) then
+            Report_Unhandled_Node_Empty (E, "Do_Type_Reference",
+                                    "Unsupported declaration of unknown type");
+         end if;
+      end;
+
+      return Make_Symbol_Type (Identifier => Unique_Name (E));
+   end Do_Type_Reference;
 
    -------------------------
    -- Do_Withed_Unit_Spec --


### PR DESCRIPTION
Regression tests already exist, e.g. `arrays_access` would fail the test if we did not upgrade the construction of constrained arrays, and `arrays_static_attribute` would fail if we did not declare the implicit type.