### PR TITLE
Conditional range check in qualified expression [maybe depends on #228 ?]

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -329,6 +329,11 @@ Error message: Non-literal bound unsupported
 Nkind: N_Defining_Identifier
 --
 Occurs: 4 times
+Calling function: Do_Qualified_Expression
+Error message: Unsupported range check for non-numeric types
+Nkind: N_Qualified_Expression
+--
+Occurs: 4 times
 Calling function: Do_Selected_Component
 Error message: Parent not full type declaration
 Nkind: N_Selected_Component

--- a/experiments/golden-results/Tokeneer-summary.txt
+++ b/experiments/golden-results/Tokeneer-summary.txt
@@ -1,147 +1,157 @@
-Occurs: 157 times
+Occurs: 185 times
 Calling function: Process_Declaration
 Error message: Representation clause declaration
 Nkind: N_Attribute_Definition_Clause
 --
-Occurs: 116 times
+Occurs: 176 times
 Calling function: Process_Declaration
 Error message: Exception declaration
 Nkind: N_Exception_Declaration
 --
-Occurs: 99 times
+Occurs: 152 times
 Calling function: Do_Expression
 Error message: Unknown expression kind
 Nkind: N_Expanded_Name
 --
-Occurs: 75 times
+Occurs: 119 times
+Calling function: Do_Qualified_Expression
+Error message: Unsupported range check for non-numeric types
+Nkind: N_Qualified_Expression
+--
+Occurs: 84 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Ada 05
 Nkind: N_Pragma
 --
-Occurs: 65 times
+Occurs: 78 times
 Calling function: Do_Expression
 Error message: Unknown expression kind
 Nkind: N_Null
 --
-Occurs: 53 times
+Occurs: 76 times
 Calling function: Do_Expression
 Error message: Unknown attribute
 Nkind: N_Attribute_Reference
 --
-Occurs: 41 times
+Occurs: 52 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Preelaborable Initialization
 Nkind: N_Pragma
 --
-Occurs: 38 times
+Occurs: 42 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Suppress initialization
 Nkind: N_Pragma
 --
-Occurs: 30 times
+Occurs: 38 times
+Calling function: Process_Declaration
+Error message: Abstract subprogram declaration
+Nkind: N_Abstract_Subprogram_Declaration
+--
+Occurs: 36 times
 Calling function: Do_Constant
 Error message: Constant Type not in symbol table
 Nkind: N_Integer_Literal
 --
-Occurs: 30 times
+Occurs: 36 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: No return
 Nkind: N_Pragma
+--
+Occurs: 32 times
+Calling function: Do_Base_Range_Constraint
+Error message: unsupported upper range kind
+Nkind: N_Identifier
+--
+Occurs: 28 times
+Calling function: Do_Aggregate_Literal
+Error message: Unhandled aggregate kind
+Nkind: N_Aggregate
 --
 Occurs: 27 times
 Calling function: Do_Function_Call
 Error message: func name not in symbol table
 Nkind: N_Function_Call
 --
+Occurs: 26 times
+Calling function: Process_Statement
+Error message: Unknown expression kind
+Nkind: N_Object_Declaration
+--
+Occurs: 24 times
+Calling function: Do_Base_Range_Constraint
+Error message: range expression not bitvector type
+Nkind: N_Range
+--
 Occurs: 23 times
-Calling function: Process_Declaration
-Error message: Abstract subprogram declaration
-Nkind: N_Abstract_Subprogram_Declaration
+Calling function: Do_Private_Type_Declaration
+Error message: Abstract type declaration unsupported
+Nkind: N_Private_Type_Declaration
 --
-Occurs: 15 times
-Calling function: Do_Type_Definition
-Error message: Access type unsupported
-Nkind: N_Access_To_Object_Definition
---
-Occurs: 14 times
+Occurs: 20 times
 Calling function: Do_Operator_General
 Error message: Concat unsupported
 Nkind: N_Op_Concat
 --
-Occurs: 13 times
-Calling function: Do_Aggregate_Literal
-Error message: Unhandled aggregate kind
-Nkind: N_Aggregate
+Occurs: 18 times
+Calling function: Do_Type_Definition
+Error message: Access type unsupported
+Nkind: N_Access_To_Object_Definition
 --
-Occurs: 11 times
+Occurs: 12 times
 Calling function: Do_Type_Definition
 Error message: Unknown expression kind
 Nkind: N_Access_Function_Definition
 --
-Occurs: 11 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Ada 2012
-Nkind: N_Pragma
---
-Occurs: 10 times
+Occurs: 12 times
 Calling function: Process_Pragma_Declaration
 Error message: Unknown pragma
 Nkind: N_Pragma
 --
+Occurs: 12 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Ada 2012
+Nkind: N_Pragma
+--
 Occurs: 9 times
-Calling function: Do_Private_Type_Declaration
-Error message: Abstract type declaration unsupported
-Nkind: N_Private_Type_Declaration
+Calling function: Process_Declaration
+Error message: Generic instantiation declaration
+Nkind: N_Function_Instantiation
+--
+Occurs: 9 times
+Calling function: Process_Declaration
+Error message: Package declaration
+Nkind: N_Package_Declaration
 --
 Occurs: 9 times
 Calling function: Process_Declaration
 Error message: Representation clause declaration
 Nkind: N_Enumeration_Representation_Clause
 --
-Occurs: 8 times
-Calling function: Do_Base_Range_Constraint
-Error message: range expression not bitvector type
-Nkind: N_Range
---
-Occurs: 8 times
-Calling function: Do_Base_Range_Constraint
-Error message: unsupported upper range kind
-Nkind: N_Identifier
---
-Occurs: 8 times
-Calling function: Process_Declaration
-Error message: Generic instantiation declaration
-Nkind: N_Function_Instantiation
---
-Occurs: 8 times
-Calling function: Process_Declaration
-Error message: Package declaration
-Nkind: N_Package_Declaration
---
-Occurs: 8 times
+Occurs: 9 times
 Calling function: Process_Declaration
 Error message: Unknown declaration kind
 Nkind: N_Validate_Unchecked_Conversion
 --
-Occurs: 7 times
-Calling function: Process_Statement
-Error message: Unknown expression kind
-Nkind: N_Object_Declaration
+Occurs: 6 times
+Calling function: Do_Aggregate_Literal_Array
+Error message: More than one named operand
+Nkind: N_Aggregate
 --
-Occurs: 5 times
+Occurs: 6 times
 Calling function: Do_Type_Definition
 Error message: Unknown expression kind
 Nkind: N_Access_Procedure_Definition
 --
-Occurs: 5 times
+Occurs: 6 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Atomic
 Nkind: N_Pragma
 --
-Occurs: 4 times
-Calling function: Do_Aggregate_Literal_Array
-Error message: More than one named operand
-Nkind: N_Aggregate
+Occurs: 5 times
+Calling function: Do_While_Statement
+Error message: Wrong Nkind spec
+Nkind: N_Loop_Statement
 --
 Occurs: 3 times
 Calling function: Do_Itype_Integer_Subtype
@@ -149,14 +159,14 @@ Error message: Non-literal bound unsupported
 Nkind: N_Defining_Identifier
 --
 Occurs: 2 times
-Calling function: Do_While_Statement
-Error message: Wrong Nkind spec
-Nkind: N_Loop_Statement
---
-Occurs: 2 times
 Calling function: Process_Statement
 Error message: Unknown expression kind
 Nkind: N_Freeze_Entity
+--
+Occurs: 1 times
+Calling function: Do_Expression
+Error message: Unknown expression kind
+Nkind: N_Unchecked_Type_Conversion
 --
 Occurs: 159 times
 Redacted compiler error message:

--- a/experiments/golden-results/UKNI-Information-Barrier-summary.txt
+++ b/experiments/golden-results/UKNI-Information-Barrier-summary.txt
@@ -1,22 +1,47 @@
-Occurs: 136 times
+Occurs: 138 times
 Calling function: Process_Declaration
 Error message: Representation clause declaration
 Nkind: N_Attribute_Definition_Clause
 --
-Occurs: 36 times
+Occurs: 97 times
+Calling function: Do_Qualified_Expression
+Error message: Unsupported range check for non-numeric types
+Nkind: N_Qualified_Expression
+--
+Occurs: 37 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Volatile
 Nkind: N_Pragma
 --
-Occurs: 3 times
+Occurs: 7 times
+Calling function: Process_Declaration
+Error message: Subprogram body stub declaration
+Nkind: N_Subprogram_Body_Stub
+--
+Occurs: 6 times
+Calling function: Do_Expression
+Error message: Unknown expression kind
+Nkind: N_Expanded_Name
+--
+Occurs: 5 times
 Calling function: Do_Itype_Definition
 Error message: Unknown Ekind
 Nkind: N_Defining_Identifier
 --
-Occurs: 2 times
+Occurs: 5 times
+Calling function: Do_Procedure_Call_Statement
+Error message: sym id not in symbol table
+Nkind: N_Procedure_Call_Statement
+--
+Occurs: 4 times
 Calling function: Do_Base_Range_Constraint
 Error message: range expression not bitvector type
 Nkind: N_Range
+--
+Occurs: 2 times
+Calling function: Do_While_Statement
+Error message: Wrong Nkind spec
+Nkind: N_Loop_Statement
 --
 Occurs: 2 times
 Calling function: Process_Pragma_Declaration

--- a/experiments/golden-results/libsparkcrypto-summary.txt
+++ b/experiments/golden-results/libsparkcrypto-summary.txt
@@ -1,4 +1,4 @@
-Occurs: 475 times
+Occurs: 961 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Precondition
 Nkind: N_Pragma
@@ -8,17 +8,17 @@ Calling function: Process_Declaration
 Error message: Representation clause declaration
 Nkind: N_Attribute_Definition_Clause
 --
-Occurs: 205 times
+Occurs: 229 times
 Calling function: Process_Pragma_Declaration
 Error message: Unknown pragma
 Nkind: N_Pragma
 --
-Occurs: 110 times
+Occurs: 126 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Postcondition
 Nkind: N_Pragma
 --
-Occurs: 77 times
+Occurs: 85 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Global
 Nkind: N_Pragma
@@ -83,6 +83,11 @@ Calling function: Do_Aggregate_Literal_Array
 Error message: Wrong kind of other choice
 Nkind: N_Aggregate
 --
+Occurs: 4 times
+Calling function: Do_Qualified_Expression
+Error message: Unsupported range check for non-numeric types
+Nkind: N_Qualified_Expression
+--
 Occurs: 3 times
 Calling function: Do_Op_Expon
 Error message: Exponentiation unhandled for non mod types at the moment
@@ -92,6 +97,11 @@ Occurs: 3 times
 Calling function: Process_Statement
 Error message: Unknown expression kind
 Nkind: N_Object_Declaration
+--
+Occurs: 1 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Warnings
+Nkind: N_Pragma
 --
 Occurs: 32 times
 Redacted compiler error message:

--- a/experiments/golden-results/muen-summary.txt
+++ b/experiments/golden-results/muen-summary.txt
@@ -1,167 +1,242 @@
-Occurs: 861 times
+Occurs: 1059 times
 Calling function: Process_Declaration
 Error message: Representation clause declaration
 Nkind: N_Attribute_Definition_Clause
 --
-Occurs: 172 times
+Occurs: 231 times
+Calling function: Process_Pragma_Declaration
+Error message: Unknown pragma
+Nkind: N_Pragma
+--
+Occurs: 213 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Global
+Nkind: N_Pragma
+--
+Occurs: 203 times
+Calling function: Process_Declaration
+Error message: Representation clause declaration
+Nkind: N_Record_Representation_Clause
+--
+Occurs: 190 times
 Calling function: Process_Declaration
 Error message: Use type clause declaration
 Nkind: N_Use_Type_Clause
+--
+Occurs: 165 times
+Calling function: Do_Qualified_Expression
+Error message: Unsupported range check for non-numeric types
+Nkind: N_Qualified_Expression
 --
 Occurs: 117 times
 Calling function: Process_Declaration
 Error message: Exception declaration
 Nkind: N_Exception_Declaration
 --
-Occurs: 102 times
+Occurs: 105 times
 Calling function: Do_Type_Definition
 Error message: Access type unsupported
 Nkind: N_Access_To_Object_Definition
 --
-Occurs: 80 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Warnings
-Nkind: N_Pragma
---
-Occurs: 68 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Implementation defined
-Nkind: N_Pragma
---
-Occurs: 66 times
-Calling function: Do_Private_Type_Declaration
-Error message: Abstract type declaration unsupported
-Nkind: N_Private_Type_Declaration
---
-Occurs: 39 times
+Occurs: 92 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Precondition
 Nkind: N_Pragma
 --
-Occurs: 32 times
+Occurs: 84 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Warnings
+Nkind: N_Pragma
+--
+Occurs: 69 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Implementation defined
+Nkind: N_Pragma
+--
+Occurs: 67 times
+Calling function: Do_Private_Type_Declaration
+Error message: Abstract type declaration unsupported
+Nkind: N_Private_Type_Declaration
+--
+Occurs: 45 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Postcondition
+Nkind: N_Pragma
+--
+Occurs: 35 times
+Calling function: Do_Expression
+Error message: Unknown expression kind
+Nkind: N_Expanded_Name
+--
+Occurs: 34 times
 Calling function: Process_Declaration
 Error message: Abstract subprogram declaration
 Nkind: N_Abstract_Subprogram_Declaration
+--
+Occurs: 34 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Initializes
+Nkind: N_Pragma
+--
+Occurs: 33 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Abstract state
+Nkind: N_Pragma
 --
 Occurs: 32 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Preelaborable Initialization
 Nkind: N_Pragma
 --
-Occurs: 31 times
-Calling function: Process_Declaration
-Error message: Representation clause declaration
-Nkind: N_Record_Representation_Clause
---
-Occurs: 24 times
+Occurs: 28 times
 Calling function: Process_Pragma_Declaration
-Error message: Unknown pragma
+Error message: Unsupported pragma: Refine
 Nkind: N_Pragma
 --
-Occurs: 21 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Global
-Nkind: N_Pragma
+Occurs: 18 times
+Calling function: Do_Aggregate_Literal_Array
+Error message: More than one named operand
+Nkind: N_Aggregate
 --
 Occurs: 16 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Ada 05
 Nkind: N_Pragma
 --
-Occurs: 14 times
+Occurs: 15 times
 Calling function: Do_Itype_Integer_Subtype
 Error message: Non-literal bound unsupported
 Nkind: N_Defining_Identifier
 --
 Occurs: 14 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Refine
-Nkind: N_Pragma
+Calling function: Process_Declaration
+Error message: Package declaration
+Nkind: N_Package_Declaration
 --
 Occurs: 13 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Abstract state
-Nkind: N_Pragma
---
-Occurs: 12 times
 Calling function: Do_Derived_Type_Definition
 Error message: record extension unsupported
 Nkind: N_Derived_Type_Definition
 --
-Occurs: 12 times
+Occurs: 13 times
 Calling function: Process_Declaration
 Error message: Unknown declaration kind
 Nkind: N_Private_Extension_Declaration
 --
 Occurs: 12 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Initializes
-Nkind: N_Pragma
---
-Occurs: 11 times
 Calling function: Do_Constant
 Error message: Constant Type not in symbol table
 Nkind: N_Integer_Literal
+--
+Occurs: 12 times
+Calling function: Process_Declaration
+Error message: Representation clause declaration
+Nkind: N_Enumeration_Representation_Clause
 --
 Occurs: 11 times
 Calling function: Do_Type_Definition
 Error message: Unknown expression kind
 Nkind: N_Access_Function_Definition
 --
-Occurs: 11 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Postcondition
-Nkind: N_Pragma
---
 Occurs: 10 times
-Calling function: Process_Declaration
-Error message: Package declaration
-Nkind: N_Package_Declaration
---
-Occurs: 9 times
 Calling function: Do_Function_Call
 Error message: func name not in symbol table
 Nkind: N_Function_Call
+--
+Occurs: 10 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: No return
+Nkind: N_Pragma
+--
+Occurs: 10 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Volatile
+Nkind: N_Pragma
+--
+Occurs: 9 times
+Calling function: Do_Expression
+Error message: Unknown attribute
+Nkind: N_Attribute_Reference
+--
+Occurs: 9 times
+Calling function: Do_Procedure_Call_Statement
+Error message: sym id not in symbol table
+Nkind: N_Procedure_Call_Statement
+--
+Occurs: 9 times
+Calling function: Process_Declaration
+Error message: Generic declaration
+Nkind: N_Generic_Subprogram_Declaration
+--
+Occurs: 8 times
+Calling function: Do_Address_Of
+Error message: Kind not in class type
+Nkind: N_Attribute_Reference
 --
 Occurs: 8 times
 Calling function: Do_Base_Range_Constraint
 Error message: range expression not bitvector type
 Nkind: N_Range
 --
-Occurs: 7 times
-Calling function: Do_Expression
-Error message: Unknown expression kind
-Nkind: N_Expanded_Name
+Occurs: 8 times
+Calling function: Do_Identifier
+Error message: Etype not a type
+Nkind: N_Identifier
 --
-Occurs: 7 times
+Occurs: 8 times
 Calling function: Process_Declaration
 Error message: Generic instantiation declaration
 Nkind: N_Function_Instantiation
 --
-Occurs: 6 times
+Occurs: 8 times
 Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: No return
+Error message: Unsupported pragma: Check
 Nkind: N_Pragma
+--
+Occurs: 6 times
+Calling function: Do_Operator_General
+Error message: Mod of unsupported type
+Nkind: N_Op_Not
+--
+Occurs: 6 times
+Calling function: Do_Pragma
+Error message: Unknown pragma name
+Nkind: N_Pragma
+--
+Occurs: 6 times
+Calling function: Do_Record_Component
+Error message: Wrong component nkind
+Nkind: N_Pragma
+--
+Occurs: 6 times
+Calling function: Process_Declaration
+Error message: Generic instantiation declaration
+Nkind: N_Procedure_Instantiation
+--
+Occurs: 6 times
+Calling function: Process_Declaration
+Error message: Unknown declaration kind
+Nkind: N_Null_Statement
+--
+Occurs: 5 times
+Calling function: Do_Aggregate_Literal
+Error message: Unhandled aggregate kind
+Nkind: N_Aggregate
 --
 Occurs: 5 times
 Calling function: Do_Expression
 Error message: Unknown expression kind
 Nkind: N_Allocator
 --
-Occurs: 5 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Check
-Nkind: N_Pragma
---
 Occurs: 4 times
-Calling function: Do_Address_Of
-Error message: Kind not in class type
-Nkind: N_Attribute_Reference
---
-Occurs: 4 times
-Calling function: Do_Identifier
-Error message: Etype not a type
+Calling function: Do_Base_Range_Constraint
+Error message: unsupported lower range kind
 Nkind: N_Identifier
+--
+Occurs: 4 times
+Calling function: Do_Operator_General
+Error message: Concat unsupported
+Nkind: N_Op_Concat
 --
 Occurs: 4 times
 Calling function: Do_Type_Definition
@@ -175,8 +250,13 @@ Nkind: N_Package_Body
 --
 Occurs: 4 times
 Calling function: Process_Declaration
-Error message: Representation clause declaration
-Nkind: N_Enumeration_Representation_Clause
+Error message: Use package clause declaration
+Nkind: N_Use_Package_Clause
+--
+Occurs: 4 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Async readers
+Nkind: N_Pragma
 --
 Occurs: 4 times
 Calling function: Process_Statement
@@ -184,34 +264,19 @@ Error message: Unknown expression kind
 Nkind: N_Object_Declaration
 --
 Occurs: 3 times
-Calling function: Do_Aggregate_Literal_Array
-Error message: More than one named operand
-Nkind: N_Aggregate
+Calling function: Do_Base_Range_Constraint
+Error message: unsupported upper range kind
+Nkind: N_Identifier
 --
 Occurs: 3 times
-Calling function: Do_Procedure_Call_Statement
-Error message: sym id not in symbol table
-Nkind: N_Procedure_Call_Statement
---
-Occurs: 3 times
-Calling function: Process_Declaration
-Error message: Generic declaration
-Nkind: N_Generic_Subprogram_Declaration
---
-Occurs: 3 times
-Calling function: Process_Declaration
-Error message: Generic instantiation declaration
-Nkind: N_Procedure_Instantiation
---
-Occurs: 2 times
-Calling function: Do_Aggregate_Literal
-Error message: Unhandled aggregate kind
-Nkind: N_Aggregate
---
-Occurs: 2 times
 Calling function: Process_Declaration
 Error message: Unknown declaration kind
 Nkind: N_Validate_Unchecked_Conversion
+--
+Occurs: 2 times
+Calling function: Do_While_Statement
+Error message: Wrong Nkind spec
+Nkind: N_Loop_Statement
 --
 Occurs: 2 times
 Calling function: Process_Pragma_Declaration
@@ -219,19 +284,9 @@ Error message: Unsupported pragma: Ada 2012
 Nkind: N_Pragma
 --
 Occurs: 2 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Volatile
-Nkind: N_Pragma
---
-Occurs: 2 times
 Calling function: Process_Statement
 Error message: Unknown expression kind
 Nkind: N_Object_Renaming_Declaration
---
-Occurs: 1 times
-Calling function: Do_Base_Range_Constraint
-Error message: unsupported lower range kind
-Nkind: N_Identifier
 --
 Occurs: 1 times
 Calling function: Do_Base_Range_Constraint
@@ -244,11 +299,6 @@ Error message: Quantified
 Nkind: N_Quantified_Expression
 --
 Occurs: 1 times
-Calling function: Do_Expression
-Error message: Unknown attribute
-Nkind: N_Attribute_Reference
---
-Occurs: 1 times
 Calling function: Do_Function_Call
 Error message: function entity not defining identifier
 Nkind: N_Function_Call
@@ -259,9 +309,9 @@ Error message: Exponentiation unhandled for non mod types at the moment
 Nkind: N_Op_Expon
 --
 Occurs: 1 times
-Calling function: Process_Declaration
-Error message: Use package clause declaration
-Nkind: N_Use_Package_Clause
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Atomic
+Nkind: N_Pragma
 --
 Occurs: 1 times
 Calling function: Process_Pragma_Declaration

--- a/experiments/golden-results/vct-summary.txt
+++ b/experiments/golden-results/vct-summary.txt
@@ -1,47 +1,62 @@
-Occurs: 73 times
+Occurs: 91 times
+Calling function: Do_Qualified_Expression
+Error message: Unsupported range check for non-numeric types
+Nkind: N_Qualified_Expression
+--
+Occurs: 89 times
 Calling function: Process_Declaration
 Error message: Exception declaration
 Nkind: N_Exception_Declaration
 --
-Occurs: 32 times
+Occurs: 80 times
 Calling function: Do_Base_Range_Constraint
 Error message: unsupported upper range kind
 Nkind: N_Identifier
 --
-Occurs: 18 times
-Calling function: Do_Operator_General
-Error message: Concat unsupported
-Nkind: N_Op_Concat
---
-Occurs: 18 times
-Calling function: Process_Declaration
-Error message: Abstract subprogram declaration
-Nkind: N_Abstract_Subprogram_Declaration
---
-Occurs: 14 times
-Calling function: Do_Expression
-Error message: Unknown expression kind
-Nkind: N_Expanded_Name
---
-Occurs: 11 times
+Occurs: 37 times
 Calling function: Do_Aggregate_Literal_Array
 Error message: More than one named operand
 Nkind: N_Aggregate
 --
-Occurs: 9 times
+Occurs: 27 times
+Calling function: Do_Operator_General
+Error message: Concat unsupported
+Nkind: N_Op_Concat
+--
+Occurs: 22 times
+Calling function: Do_Expression
+Error message: Unknown expression kind
+Nkind: N_Expanded_Name
+--
+Occurs: 22 times
+Calling function: Process_Declaration
+Error message: Abstract subprogram declaration
+Nkind: N_Abstract_Subprogram_Declaration
+--
+Occurs: 17 times
+Calling function: Process_Declaration
+Error message: Representation clause declaration
+Nkind: N_Attribute_Definition_Clause
+--
+Occurs: 11 times
 Calling function: Do_Private_Type_Declaration
 Error message: Abstract type declaration unsupported
 Nkind: N_Private_Type_Declaration
 --
-Occurs: 9 times
+Occurs: 11 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Preelaborable Initialization
 Nkind: N_Pragma
 --
 Occurs: 8 times
-Calling function: Process_Declaration
-Error message: Representation clause declaration
-Nkind: N_Attribute_Definition_Clause
+Calling function: Do_Aggregate_Literal
+Error message: Unhandled aggregate kind
+Nkind: N_Aggregate
+--
+Occurs: 7 times
+Calling function: Do_While_Statement
+Error message: Wrong Nkind spec
+Nkind: N_Loop_Statement
 --
 Occurs: 3 times
 Calling function: Do_Procedure_Call_Statement
@@ -49,14 +64,19 @@ Error message: sym id not in symbol table
 Nkind: N_Procedure_Call_Statement
 --
 Occurs: 3 times
+Calling function: Process_Declaration
+Error message: Representation clause declaration
+Nkind: N_Record_Representation_Clause
+--
+Occurs: 3 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Suppress initialization
 Nkind: N_Pragma
 --
 Occurs: 1 times
-Calling function: Do_Aggregate_Literal
-Error message: Unhandled aggregate kind
-Nkind: N_Aggregate
+Calling function: Do_Base_Range_Constraint
+Error message: unsupported lower range kind
+Nkind: N_Identifier
 --
 Occurs: 1 times
 Calling function: Do_Function_Call
@@ -122,8 +142,3 @@ Occurs: 1 times
 Redacted compiler error message:
 non-visible declaration
 Raw compiler error message:
---
-Occurs: 1 times
-+===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:29|
-| Error detected at system.ads:156:5                                       |


### PR DESCRIPTION
This is a refactor of #228. Copy of its description:

This is a partial fix preventing gnat2goto aborting from an unsatisfied pre-condition when a qualified expression is not a numeric subtype.
The current changes work for record subtype qualifiers and numeric subtype qualifiers excluding Integer (and possibly Float - I have not checked this). It does not work for qualified enumeration subtypes. For type Integer and enumeration subtypes it still fails a pre-condition check.
For qualified array subtypes it does not currently perform a check but should not cause a pre-condition failure. Eventually a check of the array subtype must be implemented. At the moment I could not produce a simple test case which got as far as checking an array subtype qualified expression.

The important feature of the partial fix is that it facilitates running list_unsupported script on UKNI without gnat2goto aborting.

I think its shortcomings should be raised as issues.