### PR TITLE
Ignore preelaborate initialization and warnings

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -238,11 +238,6 @@ Calling function: Make_Array_Index_Op
 Error message: Base type not array type
 Nkind: N_Defining_Identifier
 --
-Occurs: 16 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Preelaborable Initialization
-Nkind: N_Pragma
---
 Occurs: 15 times
 Calling function: Process_Declaration
 Error message: Unknown declaration kind
@@ -297,11 +292,6 @@ Occurs: 6 times
 Calling function: Process_Statement
 Error message: Entry call statement
 Nkind: N_Entry_Call_Statement
---
-Occurs: 5 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Warnings
-Nkind: N_Pragma
 --
 Occurs: 4 times
 Calling function: Do_Address_Of

--- a/experiments/golden-results/Tokeneer-summary.txt
+++ b/experiments/golden-results/Tokeneer-summary.txt
@@ -28,11 +28,6 @@ Calling function: Do_Expression
 Error message: Unknown attribute
 Nkind: N_Attribute_Reference
 --
-Occurs: 41 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Preelaborable Initialization
-Nkind: N_Pragma
---
 Occurs: 38 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Suppress initialization

--- a/experiments/golden-results/ksum-summary.txt
+++ b/experiments/golden-results/ksum-summary.txt
@@ -18,11 +18,6 @@ Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Suppress initialization
 Nkind: N_Pragma
 --
-Occurs: 2 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Preelaborable Initialization
-Nkind: N_Pragma
---
 Occurs: 1 times
 Calling function: Do_Expression
 Error message: Unknown expression kind

--- a/experiments/golden-results/libkeccak-summary.txt
+++ b/experiments/golden-results/libkeccak-summary.txt
@@ -88,11 +88,6 @@ Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Suppress initialization
 Nkind: N_Pragma
 --
-Occurs: 16 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Preelaborable Initialization
-Nkind: N_Pragma
---
 Occurs: 12 times
 Calling function: Do_Private_Type_Declaration
 Error message: Abstract type declaration unsupported
@@ -172,11 +167,6 @@ Occurs: 2 times
 Calling function: Do_Expression
 Error message: Unknown expression kind
 Nkind: N_Expanded_Name
---
-Occurs: 2 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Warnings
-Nkind: N_Pragma
 --
 Occurs: 1 times
 Calling function: Do_Aggregate_Literal_Array

--- a/experiments/golden-results/muen-summary.txt
+++ b/experiments/golden-results/muen-summary.txt
@@ -18,11 +18,6 @@ Calling function: Do_Type_Definition
 Error message: Access type unsupported
 Nkind: N_Access_To_Object_Definition
 --
-Occurs: 80 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Warnings
-Nkind: N_Pragma
---
 Occurs: 68 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Implementation defined
@@ -42,11 +37,6 @@ Occurs: 32 times
 Calling function: Process_Declaration
 Error message: Abstract subprogram declaration
 Nkind: N_Abstract_Subprogram_Declaration
---
-Occurs: 32 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Preelaborable Initialization
-Nkind: N_Pragma
 --
 Occurs: 31 times
 Calling function: Process_Declaration

--- a/experiments/golden-results/vct-summary.txt
+++ b/experiments/golden-results/vct-summary.txt
@@ -33,11 +33,6 @@ Calling function: Do_Private_Type_Declaration
 Error message: Abstract type declaration unsupported
 Nkind: N_Private_Type_Declaration
 --
-Occurs: 9 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Preelaborable Initialization
-Nkind: N_Pragma
---
 Occurs: 8 times
 Calling function: Process_Declaration
 Error message: Representation clause declaration

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -4856,9 +4856,6 @@ package body Tree_Walk is
          when Name_Unreferenced =>
             Report_Unhandled_Node_Empty (N, "Process_Pragma_Declaration",
                                          "Unsupported pragma: Unreferenced");
-         when Name_Preelaborable_Initialization =>
-            Report_Unhandled_Node_Empty (N, "Process_Pragma_Declaration",
-                           "Unsupported pragma: Preelaborable Initialization");
          when Name_Ada_05 =>
             Report_Unhandled_Node_Empty (N, "Process_Pragma_Declaration",
                                          "Unsupported pragma: Ada 05");
@@ -4874,9 +4871,6 @@ package body Tree_Walk is
          when Name_Obsolescent =>
             Report_Unhandled_Node_Empty (N, "Process_Pragma_Declaration",
                                          "Unsupported pragma: Obsolescent");
-         when Name_Warnings =>
-            Report_Unhandled_Node_Empty (N, "Process_Pragma_Declaration",
-                                         "Unsupported pragma: Warnings");
          when Name_Initializes =>
             Report_Unhandled_Node_Empty (N, "Process_Pragma_Declaration",
                                          "Unsupported pragma: Initializes");
@@ -4946,8 +4940,12 @@ package body Tree_Walk is
             --  Ignored for now
               Name_No_Elaboration_Code_All |
             --  Only affects elaboration and linking so can be ignored for now
-              Name_Universal_Aliasing =>
+              Name_Universal_Aliasing |
             --  Optimisation control, should be ignored
+              Name_Preelaborable_Initialization |
+            --  Same as the above preelaborations.
+              Name_Warnings =>
+            --  Ignoring pragma warnings means that all warnings are on.
             null;
          when others =>
             Report_Unhandled_Node_Empty (N, "Process_Pragma_Declaration",


### PR DESCRIPTION
Two more pragmas to ignore. These two need to be handled if we want to process `System` package.