### PR TITLE
Do not analyse children of system

### DIFF
--- a/testsuite/gnat2goto/tests/divide/test.out
+++ b/testsuite/gnat2goto/tests/divide/test.out
@@ -1,3 +1,2 @@
 [1] file divide.adb line 7 assertion: SUCCESS
 VERIFICATION SUCCESSFUL
-

--- a/testsuite/gnat2goto/tests/forloop/test.out
+++ b/testsuite/gnat2goto/tests/forloop/test.out
@@ -1,3 +1,2 @@
 [1] file forloop.adb line 9 assertion: SUCCESS
 VERIFICATION SUCCESSFUL
-


### PR DESCRIPTION
Rather than re-instate the analysis of package system, this change inhibits the analysis of packages standard and system and all their children.

I don't this is a final solution and I would like to put out a message of unsupported node but every unit automatically with's Standard and some units implicitly with System even though it is not explicitly used.

Open for discussion.