### PR TITLE
Subprogram body stub

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -154,6 +154,11 @@ Error message: Unsupported pragma: No return
 Nkind: N_Pragma
 --
 Occurs: 5 times
+Calling function: Do_Expression
+Error message: Unknown expression kind
+Nkind: N_Expanded_Name
+--
+Occurs: 5 times
 Calling function: Do_Operator_General
 Error message: Concat unsupported
 Nkind: N_Op_Concat
@@ -184,11 +189,6 @@ Error message: Generic declaration
 Nkind: N_Generic_Package_Declaration
 --
 Occurs: 3 times
-Calling function: Do_Expression
-Error message: Unknown expression kind
-Nkind: N_Expanded_Name
---
-Occurs: 3 times
 Calling function: Do_Procedure_Call_Statement
 Error message: sym id not in symbol table
 Nkind: N_Procedure_Call_Statement
@@ -217,11 +217,6 @@ Occurs: 1 times
 Calling function: Do_Pragma
 Error message: Unsupported pragma: Unreferenced
 Nkind: N_Pragma
---
-Occurs: 1 times
-Calling function: Process_Declaration
-Error message: Subprogram body stub declaration
-Nkind: N_Subprogram_Body_Stub
 --
 Occurs: 1 times
 Calling function: Process_Statement

--- a/experiments/golden-results/UKNI-Information-Barrier-summary.txt
+++ b/experiments/golden-results/UKNI-Information-Barrier-summary.txt
@@ -1,19 +1,9 @@
-Occurs: 7 times
-Calling function: Process_Declaration
-Error message: Subprogram body stub declaration
-Nkind: N_Subprogram_Body_Stub
---
-Occurs: 6 times
+Occurs: 27 times
 Calling function: Do_Expression
 Error message: Unknown expression kind
 Nkind: N_Expanded_Name
 --
-Occurs: 5 times
-Calling function: Do_Procedure_Call_Statement
-Error message: sym id not in symbol table
-Nkind: N_Procedure_Call_Statement
---
-Occurs: 2 times
+Occurs: 3 times
 Calling function: Do_While_Statement
 Error message: Wrong Nkind spec
 Nkind: N_Loop_Statement
@@ -27,6 +17,11 @@ Occurs: 1 times
 Calling function: Do_Base_Range_Constraint
 Error message: unsupported upper range kind
 Nkind: N_Attribute_Reference
+--
+Occurs: 1 times
+Calling function: Do_Expression
+Error message: Unknown expression kind
+Nkind: N_Range
 --
 Occurs: 5 times
 Redacted compiler error message:

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -4143,9 +4143,9 @@ package body Tree_Walk is
 
    procedure Do_Subprogram_Body_Stub (N : Node_Id) is
    begin
-      --  The Gnat compilation model requires that a file containing the
-      --  which is the separate subprogram body is present otherwise
-      --  a compilation error is generated.
+      --  The Gnat compilation model requires that a file
+      --  containing the separate subprogram body is present
+      --  otherwise a compilation error is generated.
       --  Therefore, the subunit will always be present when gnat2goto
       --  encounters a Subprogram_Body_Stub.
       Do_Subprogram_Body (Proper_Body (Unit ((Library_Unit (N)))));
@@ -4779,8 +4779,6 @@ package body Tree_Walk is
             --  body_stub  --
 
          when N_Subprogram_Body_Stub =>
---            Report_Unhandled_Node_Empty (N, "Process_Declaration",
---                                         "Subprogram body stub declaration");
             Do_Subprogram_Body_Stub (N);
 
          when N_Package_Body_Stub =>

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -252,6 +252,9 @@ package body Tree_Walk is
    procedure Do_Subprogram_Body (N : Node_Id)
    with Pre => Nkind (N) = N_Subprogram_Body;
 
+   procedure Do_Subprogram_Body_Stub (N : Node_Id)
+   with Pre => Nkind (N) in N_Subprogram_Body_Stub;
+
    function Do_Subprogram_Or_Block (N : Node_Id) return Irep
    with Pre  => Nkind (N) in N_Subprogram_Body |
                              N_Task_Body       |
@@ -4134,7 +4137,21 @@ package body Tree_Walk is
       Global_Symbol_Table.Replace (Proc_Name, Proc_Symbol);
    end Do_Subprogram_Body;
 
-   -------------------------------
+   -----------------------------
+   -- Do_Subprogram_Body_Stub --
+   -----------------------------
+
+   procedure Do_Subprogram_Body_Stub (N : Node_Id) is
+   begin
+      --  The Gnat compilation model requires that a file containing the
+      --  which is the separate subprogram body is present otherwise
+      --  a compilation error is generated.
+      --  Therefore, the subunit will always be present when gnat2goto
+      --  encounters a Subprogram_Body_Stub.
+      Do_Subprogram_Body (Proper_Body (Unit ((Library_Unit (N)))));
+   end Do_Subprogram_Body_Stub;
+
+-------------------------------
    -- Do_Subprogram_Declaration --
    -------------------------------
 
@@ -4762,8 +4779,9 @@ package body Tree_Walk is
             --  body_stub  --
 
          when N_Subprogram_Body_Stub =>
-            Report_Unhandled_Node_Empty (N, "Process_Declaration",
-                                         "Subprogram body stub declaration");
+--            Report_Unhandled_Node_Empty (N, "Process_Declaration",
+--                                         "Subprogram body stub declaration");
+            Do_Subprogram_Body_Stub (N);
 
          when N_Package_Body_Stub =>
             Report_Unhandled_Node_Empty (N, "Process_Declaration",

--- a/testsuite/gnat2goto/tests/separate_subprog/p-inc.asu
+++ b/testsuite/gnat2goto/tests/separate_subprog/p-inc.asu
@@ -1,0 +1,7 @@
+separate (P)
+procedure Inc (N : in out Integer) is
+   Old_N : constant Integer := N;
+begin
+   N := N + 1;
+   pragma Assert (N = Old_N + 1);
+end Inc;

--- a/testsuite/gnat2goto/tests/separate_subprog/p.adb
+++ b/testsuite/gnat2goto/tests/separate_subprog/p.adb
@@ -1,0 +1,15 @@
+--  Use *.asu file extension for a subunit so that it is not included as a
+--  a top level unit to be analysed using by the regression test system.
+--  The gnat front-end will automatically analyse the subunit when it
+--  encounters the sybprogram_body_stub.
+pragma Source_File_Name (
+			 Subunit_File_Name  => "*.asu",
+			Dot_Replacement => "-");
+
+procedure P (X : in out integer) is
+   procedure Inc (N : in out Integer) is separate;
+   Old_X : constant Integer := X;
+begin
+   Inc (X);
+   pragma Assert (X = Old_X + 1);
+end P;

--- a/testsuite/gnat2goto/tests/separate_subprog/p.adb
+++ b/testsuite/gnat2goto/tests/separate_subprog/p.adb
@@ -11,5 +11,7 @@ procedure P (X : in out integer) is
    Old_X : constant Integer := X;
 begin
    Inc (X);
+   --  The following assert should succeed if the possibility
+   --  overflow is ignored.
    pragma Assert (X = Old_X + 1);
 end P;

--- a/testsuite/gnat2goto/tests/separate_subprog/test.out
+++ b/testsuite/gnat2goto/tests/separate_subprog/test.out
@@ -1,0 +1,3 @@
+[2] file p-inc.asu line 6 assertion: SUCCESS
+[1] file p.adb line 14 assertion: FAILURE
+VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/separate_subprog/test.out
+++ b/testsuite/gnat2goto/tests/separate_subprog/test.out
@@ -1,3 +1,3 @@
 [2] file p-inc.asu line 6 assertion: SUCCESS
-[1] file p.adb line 14 assertion: FAILURE
+[1] file p.adb line 16 assertion: FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/separate_subprog/test.py
+++ b/testsuite/gnat2goto/tests/separate_subprog/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()

--- a/testsuite/gnat2goto/tests/separate_subprog_assert_check/p.adb
+++ b/testsuite/gnat2goto/tests/separate_subprog_assert_check/p.adb
@@ -1,0 +1,17 @@
+--  Use *.asu file extension for a subunit so that it is not included as a
+--  a top level unit to be analysed using by the regression test system.
+--  The gnat front-end will automatically analyse the subunit when it
+--  encounters the sybprogram_body_stub.
+pragma Source_File_Name (
+			 Subunit_File_Name  => "*.asu",
+			Dot_Replacement => "-");
+
+procedure P (X : in out integer) is
+   procedure Inc (N : in out Integer) is separate;
+   Old_X : constant Integer := X;
+begin
+   Inc (X);
+   --  The following assert should succeed if the possibility
+   --  overflow is ignored.
+   pragma Assert (X = Old_X + 1);
+end P;

--- a/testsuite/gnat2goto/tests/separate_subprog_assert_check/test.opt
+++ b/testsuite/gnat2goto/tests/separate_subprog_assert_check/test.opt
@@ -1,0 +1,1 @@
+ALL XFAIL Assert statement in p.adb should succeed.

--- a/testsuite/gnat2goto/tests/separate_subprog_assert_check/test.out
+++ b/testsuite/gnat2goto/tests/separate_subprog_assert_check/test.out
@@ -1,0 +1,3 @@
+[2] file p-inc.asu line 6 assertion: SUCCESS
+[1] file p.adb line 16 assertion: SUCCESS
+VERIFICATION SUCCEEDED

--- a/testsuite/gnat2goto/tests/separate_subprog_assert_check/test.py
+++ b/testsuite/gnat2goto/tests/separate_subprog_assert_check/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
UKNI has subprogram_body_stubs.  The changes on this branch facilitate handling of these stubs by gnat2goto.

The test program which has been added to the regression tests for this new feature, P, has an assertion I think should succeed (if overflows are ignored), but it seems at the moment that the assertion fails.  The action of the called subprogram, Inc, does not seem to be considered by cbmc.

Should I mark this with an XFAIL?  If so I think I should have another test without the assertion so that the subprogram_body_stub feature is always tested.