### PR TITLE
Add partial support for Rational APEX file naming conventions to list_unsupported.sh

### DIFF
--- a/experiments/rational-apex.adc
+++ b/experiments/rational-apex.adc
@@ -1,0 +1,4 @@
+pragma Source_File_Name
+  (Spec_File_Name => "*.1.ada", Dot_Replacement => "-");
+pragma Source_File_Name
+  (Body_File_Name => "*.2.ada", Dot_Replacement => "-");


### PR DESCRIPTION
These changes make the script work OK with .1.ada and .2.ada file naming
but at the moment gnat2goto still expects to import from .ads files.
We need to switch gnat2goto mode somehow when --apex is specified to this
script.