### PR TITLE
Fix for issue of gnat2goto crashing when handling a size that isn't a power of 2

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -1,6 +1,41 @@
-Occurs: 204 times
+Occurs: 374 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Precondition
+Nkind: N_Pragma
+--
+Occurs: 266 times
+Calling function: Do_Function_Call
+Error message: func name not in symbol table
+Nkind: N_Function_Call
+--
+Occurs: 266 times
+Calling function: Process_Declaration
+Error message: Package declaration
+Nkind: N_Package_Declaration
+--
+Occurs: 263 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Postcondition
+Nkind: N_Pragma
+--
+Occurs: 248 times
+Calling function: Process_Declaration
+Error message: Generic instantiation declaration
+Nkind: N_Function_Instantiation
+--
+Occurs: 233 times
+Calling function: Process_Declaration
+Error message: Unknown declaration kind
+Nkind: N_Validate_Unchecked_Conversion
+--
+Occurs: 209 times
+Calling function: Process_Declaration
+Error message: Representation clause unsupported: alignment
+Nkind: N_Attribute_Definition_Clause
+--
+Occurs: 208 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Suppress initialization
 Nkind: N_Pragma
 --
 Occurs: 134 times
@@ -8,52 +43,47 @@ Calling function: Process_Declaration
 Error message: Unknown declaration kind
 Nkind: N_Freeze_Generic_Entity
 --
-Occurs: 105 times
-Calling function: Do_Function_Call
-Error message: func name not in symbol table
-Nkind: N_Function_Call
---
-Occurs: 99 times
+Occurs: 107 times
 Calling function: Process_Declaration
 Error message: Generic declaration
 Nkind: N_Generic_Subprogram_Declaration
 --
-Occurs: 50 times
+Occurs: 72 times
+Calling function: Process_Pragma_Declaration
+Error message: Unknown pragma
+Nkind: N_Pragma
+--
+Occurs: 62 times
+Calling function: Do_Withed_Unit_Spec
+Error message: This type of library_unit is not yet handled
+Nkind: N_Generic_Subprogram_Declaration
+--
+Occurs: 56 times
 Calling function: Do_Type_Definition
 Error message: Access type unsupported
 Nkind: N_Access_To_Object_Definition
 --
-Occurs: 43 times
+Occurs: 51 times
 Calling function: Do_Expression
 Error message: Unknown attribute
 Nkind: N_Attribute_Reference
---
-Occurs: 36 times
-Calling function: Do_Withed_Unit_Spec
-Error message: This type of library_unit is not yet handled
-Nkind: N_Generic_Subprogram_Declaration
 --
 Occurs: 35 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: No strict aliasing
 Nkind: N_Pragma
 --
-Occurs: 31 times
+Occurs: 32 times
 Calling function: Do_Withed_Unit_Spec
 Error message: This type of library_unit is not yet handled
 Nkind: N_Generic_Package_Declaration
 --
-Occurs: 31 times
-Calling function: Process_Declaration
-Error message: Package declaration
-Nkind: N_Package_Declaration
---
-Occurs: 23 times
+Occurs: 27 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Check
 Nkind: N_Pragma
 --
-Occurs: 21 times
+Occurs: 22 times
 Calling function: Process_Declaration
 Error message: Package body declaration
 Nkind: N_Package_Body
@@ -63,10 +93,10 @@ Calling function: Process_Declaration
 Error message: Exception declaration
 Nkind: N_Exception_Declaration
 --
-Occurs: 20 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Precondition
-Nkind: N_Pragma
+Occurs: 17 times
+Calling function: Do_Expression
+Error message: Unknown expression kind
+Nkind: N_Expanded_Name
 --
 Occurs: 15 times
 Calling function: Process_Declaration
@@ -78,17 +108,12 @@ Calling function: Process_Statement
 Error message: Unknown expression kind
 Nkind: N_Object_Declaration
 --
-Occurs: 14 times
-Calling function: Process_Declaration
-Error message: Generic instantiation declaration
-Nkind: N_Function_Instantiation
---
-Occurs: 11 times
+Occurs: 12 times
 Calling function: Do_Expression
 Error message: In
 Nkind: N_In
 --
-Occurs: 11 times
+Occurs: 12 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Global
 Nkind: N_Pragma
@@ -100,23 +125,23 @@ Nkind: N_Raise_Statement
 --
 Occurs: 9 times
 Calling function: Process_Declaration
-Error message: Unknown declaration kind
-Nkind: N_Validate_Unchecked_Conversion
+Error message: Generic instantiation declaration
+Nkind: N_Package_Instantiation
 --
 Occurs: 9 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Elaborate Body
 Nkind: N_Pragma
 --
-Occurs: 8 times
-Calling function: Process_Declaration
-Error message: Generic instantiation declaration
-Nkind: N_Package_Instantiation
+Occurs: 9 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: No return
+Nkind: N_Pragma
 --
 Occurs: 8 times
-Calling function: Process_Declaration
-Error message: Representation clause unsupported: alignment
-Nkind: N_Attribute_Definition_Clause
+Calling function: Do_Constant
+Error message: Constant Type not in symbol table
+Nkind: N_Integer_Literal
 --
 Occurs: 8 times
 Calling function: Process_Pragma_Declaration
@@ -128,20 +153,15 @@ Calling function: Do_Expression
 Error message: Unknown expression kind
 Nkind: N_Null
 --
-Occurs: 7 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Suppress initialization
-Nkind: N_Pragma
---
-Occurs: 6 times
-Calling function: Do_Constant
-Error message: Constant Type not in symbol table
-Nkind: N_Integer_Literal
---
 Occurs: 6 times
 Calling function: Process_Declaration
 Error message: Generic instantiation declaration
 Nkind: N_Procedure_Instantiation
+--
+Occurs: 6 times
+Calling function: Process_Declaration
+Error message: Use package clause declaration
+Nkind: N_Use_Package_Clause
 --
 Occurs: 6 times
 Calling function: Process_Declaration
@@ -150,13 +170,8 @@ Nkind: N_Use_Type_Clause
 --
 Occurs: 6 times
 Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: No return
+Error message: Unsupported pragma: Unreferenced
 Nkind: N_Pragma
---
-Occurs: 5 times
-Calling function: Do_Expression
-Error message: Unknown expression kind
-Nkind: N_Expanded_Name
 --
 Occurs: 5 times
 Calling function: Do_Operator_General
@@ -169,18 +184,8 @@ Error message: Unknown expression kind
 Nkind: N_Access_Procedure_Definition
 --
 Occurs: 5 times
-Calling function: Process_Declaration
-Error message: Use package clause declaration
-Nkind: N_Use_Package_Clause
---
-Occurs: 5 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Ada 05
-Nkind: N_Pragma
---
-Occurs: 5 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Unreferenced
 Nkind: N_Pragma
 --
 Occurs: 4 times
@@ -194,9 +199,44 @@ Error message: sym id not in symbol table
 Nkind: N_Procedure_Call_Statement
 --
 Occurs: 2 times
+Calling function: Do_Base_Range_Constraint
+Error message: unsupported upper range kind
+Nkind: N_Op_Subtract
+--
+Occurs: 2 times
+Calling function: Do_Constant
+Error message: Constant Type not in Class_Bitvector_Type
+Nkind: N_Integer_Literal
+--
+Occurs: 2 times
+Calling function: Do_Derived_Type_Definition
+Error message: record extension unsupported
+Nkind: N_Derived_Type_Definition
+--
+Occurs: 2 times
 Calling function: Do_Function_Call
 Error message: function entity not defining identifier
 Nkind: N_Function_Call
+--
+Occurs: 2 times
+Calling function: Do_Itype_Definition
+Error message: Unknown Ekind
+Nkind: N_Defining_Identifier
+--
+Occurs: 2 times
+Calling function: Do_Itype_Integer_Subtype
+Error message: Non-literal bound unsupported
+Nkind: N_Defining_Identifier
+--
+Occurs: 1 times
+Calling function: Do_Base_Range_Constraint
+Error message: unsupported lower range kind
+Nkind: N_Real_Literal
+--
+Occurs: 1 times
+Calling function: Do_Base_Range_Constraint
+Error message: unsupported upper range kind
+Nkind: N_Real_Literal
 --
 Occurs: 1 times
 Calling function: Do_Compilation_Unit
@@ -204,18 +244,58 @@ Error message: Unknown tree node
 Nkind: N_Compilation_Unit
 --
 Occurs: 1 times
-Calling function: Do_Constant
-Error message: Constant Type not in Class_Bitvector_Type
-Nkind: N_Integer_Literal
+Calling function: Do_Op_Expon
+Error message: Exponentiation unhandled for non mod types at the moment
+Nkind: N_Op_Expon
 --
 Occurs: 1 times
-Calling function: Do_Itype_Integer_Subtype
-Error message: Non-literal bound unsupported
-Nkind: N_Defining_Identifier
+Calling function: Do_Operator_General
+Error message: Mod of unsupported type
+Nkind: N_Op_Not
 --
 Occurs: 1 times
 Calling function: Do_Pragma
 Error message: Unsupported pragma: Unreferenced
+Nkind: N_Pragma
+--
+Occurs: 1 times
+Calling function: Do_Record_Component
+Error message: Wrong component nkind
+Nkind: N_Pragma
+--
+Occurs: 1 times
+Calling function: Process_Declaration
+Error message: Having component sizes be different from the size of their underlying type is currently not supported
+Nkind: N_Attribute_Definition_Clause
+--
+Occurs: 1 times
+Calling function: Process_Declaration
+Error message: Representation clause unsupported: address
+Nkind: N_Attribute_Definition_Clause
+--
+Occurs: 1 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Abstract state
+Nkind: N_Pragma
+--
+Occurs: 1 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Async readers
+Nkind: N_Pragma
+--
+Occurs: 1 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Atomic
+Nkind: N_Pragma
+--
+Occurs: 1 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Effective writes
+Nkind: N_Pragma
+--
+Occurs: 1 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Refine
 Nkind: N_Pragma
 --
 Occurs: 1 times

--- a/experiments/golden-results/libkeccak-summary.txt
+++ b/experiments/golden-results/libkeccak-summary.txt
@@ -1,12 +1,57 @@
-Occurs: 48 times
+Occurs: 461 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Precondition
+Nkind: N_Pragma
+--
+Occurs: 441 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Global
+Nkind: N_Pragma
+--
+Occurs: 152 times
+Calling function: Do_Function_Call
+Error message: func name not in symbol table
+Nkind: N_Function_Call
+--
+Occurs: 140 times
+Calling function: Do_Withed_Unit_Spec
+Error message: This type of library_unit is not yet handled
+Nkind: N_Generic_Package_Declaration
+--
+Occurs: 71 times
+Calling function: Do_Constant
+Error message: Constant Type not in symbol table
+Nkind: N_Integer_Literal
+--
+Occurs: 61 times
+Calling function: Process_Declaration
+Error message: Use type clause declaration
+Nkind: N_Use_Type_Clause
+--
+Occurs: 58 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Postcondition
+Nkind: N_Pragma
+--
+Occurs: 56 times
 Calling function: Process_Declaration
 Error message: Exception declaration
 Nkind: N_Exception_Declaration
 --
-Occurs: 19 times
+Occurs: 29 times
+Calling function: Process_Statement
+Error message: Unknown expression kind
+Nkind: N_Freeze_Entity
+--
+Occurs: 25 times
 Calling function: Do_Type_Definition
 Error message: Access type unsupported
 Nkind: N_Access_To_Object_Definition
+--
+Occurs: 18 times
+Calling function: Do_Pragma
+Error message: Unknown pragma name
+Nkind: N_Pragma
 --
 Occurs: 18 times
 Calling function: Process_Declaration
@@ -18,35 +63,110 @@ Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Suppress initialization
 Nkind: N_Pragma
 --
+Occurs: 12 times
+Calling function: Do_Private_Type_Declaration
+Error message: Abstract type declaration unsupported
+Nkind: N_Private_Type_Declaration
+--
 Occurs: 9 times
 Calling function: Do_Expression
 Error message: Unknown expression kind
 Nkind: N_Null
 --
 Occurs: 8 times
-Calling function: Do_Private_Type_Declaration
-Error message: Abstract type declaration unsupported
-Nkind: N_Private_Type_Declaration
---
-Occurs: 6 times
 Calling function: Process_Declaration
 Error message: Abstract subprogram declaration
 Nkind: N_Abstract_Subprogram_Declaration
+--
+Occurs: 8 times
+Calling function: Process_Pragma_Declaration
+Error message: Unknown pragma
+Nkind: N_Pragma
 --
 Occurs: 6 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Ada 05
 Nkind: N_Pragma
 --
+Occurs: 6 times
+Calling function: Process_Statement
+Error message: Unknown expression kind
+Nkind: N_Object_Declaration
+--
+Occurs: 4 times
+Calling function: Do_Itype_Integer_Subtype
+Error message: Non-literal bound unsupported
+Nkind: N_Defining_Identifier
+--
+Occurs: 4 times
+Calling function: Process_Declaration
+Error message: Package declaration
+Nkind: N_Package_Declaration
+--
+Occurs: 3 times
+Calling function: Do_Op_Expon
+Error message: Exponentiation unhandled for non mod types at the moment
+Nkind: N_Op_Expon
+--
+Occurs: 3 times
+Calling function: Process_Declaration
+Error message: Generic instantiation declaration
+Nkind: N_Procedure_Instantiation
+--
+Occurs: 3 times
+Calling function: Process_Declaration
+Error message: Package body declaration
+Nkind: N_Package_Body
+--
+Occurs: 2 times
+Calling function: Do_Expression
+Error message: Unknown attribute
+Nkind: N_Attribute_Reference
+--
+Occurs: 2 times
+Calling function: Do_Procedure_Call_Statement
+Error message: sym id not in symbol table
+Nkind: N_Procedure_Call_Statement
+--
+Occurs: 2 times
+Calling function: Do_While_Statement
+Error message: Wrong Nkind spec
+Nkind: N_Loop_Statement
+--
 Occurs: 1 times
-Calling function: Do_Withed_Unit_Spec
-Error message: This type of library_unit is not yet handled
-Nkind: N_Generic_Package_Declaration
+Calling function: Do_Expression
+Error message: In
+Nkind: N_In
+--
+Occurs: 1 times
+Calling function: Do_Expression
+Error message: Unknown expression kind
+Nkind: N_Expanded_Name
+--
+Occurs: 1 times
+Calling function: Do_Itype_Definition
+Error message: Unknown Ekind
+Nkind: N_Defining_Identifier
 --
 Occurs: 1 times
 Calling function: Do_Withed_Unit_Spec
 Error message: This type of library_unit is not yet handled
 Nkind: N_Generic_Subprogram_Declaration
+--
+Occurs: 1 times
+Calling function: Process_Declaration
+Error message: Generic declaration
+Nkind: N_Generic_Subprogram_Declaration
+--
+Occurs: 1 times
+Calling function: Process_Declaration
+Error message: Generic instantiation declaration
+Nkind: N_Function_Instantiation
+--
+Occurs: 1 times
+Calling function: Process_Declaration
+Error message: Unknown declaration kind
+Nkind: N_Validate_Unchecked_Conversion
 --
 Occurs: 3 times
 Redacted compiler error message:

--- a/experiments/golden-results/libsparkcrypto-summary.txt
+++ b/experiments/golden-results/libsparkcrypto-summary.txt
@@ -1,7 +1,117 @@
+Occurs: 1089 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Precondition
+Nkind: N_Pragma
+--
+Occurs: 284 times
+Calling function: Process_Pragma_Declaration
+Error message: Unknown pragma
+Nkind: N_Pragma
+--
+Occurs: 146 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Postcondition
+Nkind: N_Pragma
+--
+Occurs: 105 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Global
+Nkind: N_Pragma
+--
+Occurs: 66 times
+Calling function: Do_Function_Call
+Error message: function entity not defining identifier
+Nkind: N_Function_Call
+--
+Occurs: 47 times
+Calling function: Do_Procedure_Call_Statement
+Error message: sym id not in symbol table
+Nkind: N_Procedure_Call_Statement
+--
+Occurs: 26 times
+Calling function: Do_Expression
+Error message: Quantified
+Nkind: N_Quantified_Expression
+--
+Occurs: 24 times
+Calling function: Do_Type_Definition
+Error message: Access type unsupported
+Nkind: N_Access_To_Object_Definition
+--
+Occurs: 20 times
+Calling function: Do_Itype_Integer_Subtype
+Error message: Non-literal bound unsupported
+Nkind: N_Defining_Identifier
+--
+Occurs: 20 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Ada 05
+Nkind: N_Pragma
+--
+Occurs: 18 times
+Calling function: Do_Pragma
+Error message: Unknown pragma name
+Nkind: N_Pragma
+--
+Occurs: 14 times
+Calling function: Do_Expression
+Error message: Unknown attribute
+Nkind: N_Attribute_Reference
+--
+Occurs: 6 times
+Calling function: Do_Function_Call
+Error message: func name not in symbol table
+Nkind: N_Function_Call
+--
+Occurs: 6 times
+Calling function: Process_Declaration
+Error message: Generic instantiation declaration
+Nkind: N_Function_Instantiation
+--
+Occurs: 6 times
+Calling function: Process_Declaration
+Error message: Package declaration
+Nkind: N_Package_Declaration
+--
+Occurs: 6 times
+Calling function: Process_Declaration
+Error message: Unknown declaration kind
+Nkind: N_Validate_Unchecked_Conversion
+--
+Occurs: 4 times
+Calling function: Do_Op_Expon
+Error message: Exponentiation unhandled for non mod types at the moment
+Nkind: N_Op_Expon
+--
+Occurs: 3 times
+Calling function: Do_Aggregate_Literal
+Error message: Unhandled aggregate kind
+Nkind: N_Aggregate
+--
+Occurs: 3 times
+Calling function: Process_Statement
+Error message: Unknown expression kind
+Nkind: N_Object_Declaration
+--
 Occurs: 2 times
 Calling function: Do_Withed_Unit_Spec
 Error message: This type of library_unit is not yet handled
 Nkind: N_Generic_Subprogram_Declaration
+--
+Occurs: 2 times
+Calling function: Process_Pragma_Declaration
+Error message: Known but unsupported pragma: Linker Options
+Nkind: N_Pragma
+--
+Occurs: 1 times
+Calling function: Do_Operator_General
+Error message: Concat unsupported
+Nkind: N_Op_Concat
+--
+Occurs: 1 times
+Calling function: Process_Declaration
+Error message: Exception declaration
+Nkind: N_Exception_Declaration
 --
 Occurs: 32 times
 Redacted compiler error message:

--- a/experiments/golden-results/muen-summary.txt
+++ b/experiments/golden-results/muen-summary.txt
@@ -1,7 +1,12 @@
-Occurs: 135 times
+Occurs: 173 times
 Calling function: Process_Declaration
 Error message: Representation clause unsupported: alignment
 Nkind: N_Attribute_Definition_Clause
+--
+Occurs: 160 times
+Calling function: Process_Declaration
+Error message: Use type clause declaration
+Nkind: N_Use_Type_Clause
 --
 Occurs: 112 times
 Calling function: Process_Declaration
@@ -57,11 +62,6 @@ Occurs: 9 times
 Calling function: Do_Withed_Unit_Spec
 Error message: This type of library_unit is not yet handled
 Nkind: N_Generic_Package_Declaration
---
-Occurs: 8 times
-Calling function: Process_Declaration
-Error message: Use type clause declaration
-Nkind: N_Use_Type_Clause
 --
 Occurs: 8 times
 Calling function: Process_Pragma_Declaration

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -4652,14 +4652,14 @@ package body Tree_Walk is
       begin
          pragma Assert (Kind (Target_Type_Irep) in Class_Type);
          if Attr_Id = "size" then
-
             --  Just check that the front-end already applied this size
             --  clause, i .e. that the size of type-irep we already had
             --  equals the entity type this clause is applied to (and the
             --  size specified in this clause).
             pragma Assert (Entity_Esize =
-                             UI_From_Int (Int (Get_Width (Target_Type_Irep)))
-                           and Entity_Esize = Expression_Value);
+                             UI_From_Int (Int
+                               (Get_Width (Target_Type_Irep))));
+            pragma Assert (Entity_Esize >= Expression_Value);
             return;
          elsif Attr_Id = "component_size" then
             if not Is_Array_Type (Entity (N)) then


### PR DESCRIPTION
In investigating the `gnat2goto : Do_Constant / Constant Type not in symbol table / N_Integer_Literal` error reported in another repository, I found myself unable to reproduce the issue discussed there, but I was able to make `gnat2goto` crash when it was loading a type from a gnat file called `interfac.ads` that contained an `unsigned_24` type with `'Size` equal to `24`.