### PR TITLE
Add test for enumeration out parameters

### DIFF
--- a/testsuite/gnat2goto/tests/enum_out_param/enum_out.adb
+++ b/testsuite/gnat2goto/tests/enum_out_param/enum_out.adb
@@ -1,0 +1,14 @@
+procedure Enum_Out is
+   type Enum is (One, Two, Three);
+
+   procedure P_Out (E : out Enum) is
+   begin
+      E := Two;
+   end P_Out;
+
+   Var_E : Enum;
+
+begin
+   P_Out (Var_E);
+   pragma Assert (Var_E = Two);
+end Enum_Out;

--- a/testsuite/gnat2goto/tests/enum_out_param/test.opt
+++ b/testsuite/gnat2goto/tests/enum_out_param/test.opt
@@ -1,0 +1,1 @@
+ALL XFAIL gnat2goto fails with "raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from ireps.ads:1875"

--- a/testsuite/gnat2goto/tests/enum_out_param/test.out
+++ b/testsuite/gnat2goto/tests/enum_out_param/test.out
@@ -1,0 +1,2 @@
+[1] file enum_out.adb line 13 assertion: SUCCESS
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/enum_out_param/test.py
+++ b/testsuite/gnat2goto/tests/enum_out_param/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
Test currently fails with gnat2goto raising:
SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from ireps.ads:1875

gnat2goto fails with above precondition failure when translating UKNI/main.adb line 247 which calls a procedure with an enumeration out parameter.  This small test program replicates the same fault.

The problem seems to lie in gnat2goto driver/tree_walk.adb procedure Handle_Parameter.  The function Wrap_Argument is called with a parameter obtained from the call of the function Handle_Enum_Symbol_Members which appears to return the wrong sort of Irep for the function Make_Address_Of called by Wrap_Argument.