### PR TITLE
Added missing file into test separate_subprog_assert_check

### DIFF
--- a/testsuite/gnat2goto/tests/separate_subprog_assert_check/p-inc.asu
+++ b/testsuite/gnat2goto/tests/separate_subprog_assert_check/p-inc.asu
@@ -1,0 +1,7 @@
+separate (P)
+procedure Inc (N : in out Integer) is
+   Old_N : constant Integer := N;
+begin
+   N := N + 1;
+   pragma Assert (N = Old_N + 1);
+end Inc;


### PR DESCRIPTION
In the regression tests added for testing separate subprograms I accidentally missed a file that should have been included.  The missing file was not apparent because of the XFAIL field in the test.opt file.

I only noticed it had not been checked in when I was creating the test case for enumeration out parameters.

Sorry.