### PR TITLE
Add a with a procedure "in" parameter which is an element of an array…

### DIFF
--- a/testsuite/gnat2goto/tests/enum_in_param/enum_in.adb
+++ b/testsuite/gnat2goto/tests/enum_in_param/enum_in.adb
@@ -1,0 +1,24 @@
+procedure Enum_In is
+   type Enum is (One, Two, Three, Four, Five, Six);
+
+   subtype More_Than_Two is Enum range Three .. Six;
+
+   type Number_Array_Type is array (1 .. 6) of Enum;
+
+   Number_Array : constant Number_Array_Type :=
+     (1 => One,
+      2 => Two,
+      3 => Three,
+      4 => Four,
+      5 => Five,
+      6 => Six);
+
+   procedure P_Enum_In (E : Enum) is
+   begin
+      if E > Two then
+         pragma Assert (E in More_Than_Two);
+      end if;
+   end P_Enum_In;
+begin
+   P_Enum_In (Number_Array (4));
+end Enum_In;

--- a/testsuite/gnat2goto/tests/enum_in_param/test.opt
+++ b/testsuite/gnat2goto/tests/enum_in_param/test.opt
@@ -1,0 +1,1 @@
+ALL XFAIL gnat2goto failed precondition from ireps.ads:1655

--- a/testsuite/gnat2goto/tests/enum_in_param/test.out
+++ b/testsuite/gnat2goto/tests/enum_in_param/test.out
@@ -1,0 +1,5 @@
+[precondition_instance.1] memcpy src/dst overlap: SUCCESS
+[precondition_instance.2] memcpy source region readable: SUCCESS
+[precondition_instance.3] memcpy destination region writeable: SUCCESS
+[1] file enum_in.adb line 19 assertion: SUCCESS
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/enum_in_param/test.py
+++ b/testsuite/gnat2goto/tests/enum_in_param/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
… of enumerations

gnat2goto currently fails precondition from reps.ads:1655

This fault occurs when translating UKNI and test case enum_in_param has displays the same fault in a small, simple program.

The problem seems to be that, when translating UKNI, function Get_Identifier is called from procedure Handle_Parameter with an Irep value of I_DEREFERENCE_EXPR but the precondition of Get_Identifier is:
Pre => Kind (I) in I_C_Enum_Member
                         | I_C_Enum_Tag_Type
                         | I_Code_Parameter
                         | I_Struct_Tag_Type
                         | I_Symbol_Expr
                         | I_Symbol_Type
                         | I_Union_Tag_Type;