### PR TITLE
Rhs array assign

### DIFF
--- a/gnat2goto/driver/arrays.ads
+++ b/gnat2goto/driver/arrays.ads
@@ -80,7 +80,7 @@ package Arrays is
 private
 
    function Do_RHS_Array_Assign (N : Node_Id) return Irep_Array
-     with Pre => Nkind (N) in N_Op_Concat | N_Slice | N_Function_Call;
+     with Pre => Nkind (N) in N_Subexpr;
 
    function Do_Array_Range (N : Node_Id) return Irep
      with Pre  => Nkind (N) = N_Range;

--- a/testsuite/gnat2goto/tests/rhs_array_assign/rhs_array_assign.adb
+++ b/testsuite/gnat2goto/tests/rhs_array_assign/rhs_array_assign.adb
@@ -1,0 +1,10 @@
+procedure RHS_Array_Assign is
+   type My_Array is array (1 .. 10) of Integer;
+
+   A : My_Array;
+
+begin
+   A := My_Array'(others => 0);
+   A (5) := 5;
+   pragma Assert (A (5) = 5 and A (1) = 0 );
+end RHS_Array_Assign;

--- a/testsuite/gnat2goto/tests/rhs_array_assign/test.out
+++ b/testsuite/gnat2goto/tests/rhs_array_assign/test.out
@@ -1,0 +1,11 @@
+[precondition_instance.1] memcpy src/dst overlap: SUCCESS
+[precondition_instance.2] memcpy source region readable: SUCCESS
+[precondition_instance.3] memcpy destination region writeable: SUCCESS
+[precondition_instance.4] memcpy src/dst overlap: SUCCESS
+[precondition_instance.5] memcpy source region readable: SUCCESS
+[precondition_instance.6] memcpy destination region writeable: SUCCESS
+[precondition_instance.7] memcpy src/dst overlap: SUCCESS
+[precondition_instance.8] memcpy source region readable: SUCCESS
+[precondition_instance.9] memcpy destination region writeable: SUCCESS
+[1] file rhs_array_assign.adb line 9 assertion: SUCCESS
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/rhs_array_assign/test.py
+++ b/testsuite/gnat2goto/tests/rhs_array_assign/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
The precondition on RHS_Array_Assign was too strict for all possibilities of a RHS.

This caused an exception to be raised due to a failed precondition at arrays.ads 83.

Relaxed the precondition to Kind (N) in N_Subexpr.
