### PR TITLE
Fix enum out param

### DIFF
--- a/testsuite/gnat2goto/tests/enum_out_param/test.opt
+++ b/testsuite/gnat2goto/tests/enum_out_param/test.opt
@@ -1,1 +1,0 @@
-ALL XFAIL gnat2goto fails with "raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from ireps.ads:1875"


### PR DESCRIPTION
The case when enum-value is used as a out parameter of a function. There already was a test for it, which is now enabled.