### PR TITLE
Low up bound

### DIFF
--- a/gnat2goto/driver/arrays.adb
+++ b/gnat2goto/driver/arrays.adb
@@ -384,24 +384,7 @@ package body Arrays is
    function Make_Array_Default_Initialiser (E : Entity_Id) return Irep is
       --  Note this function only works for one dimensional arrays at present.
       Idx : constant Node_Id := First_Index (E);
-      --  The Entity is an array object
-      --  The first index is a discrete_subtype_definition which
-      --  may be a subtype_indication or a range.
-      --  For determining the upper bounds and lower bounds a range is required
-      --  and if the first index is a subtype_indication, the constraints
-      --  of the subtype have to be obtained - which should be a range.
-      Bound_Range : constant Node_Id :=
-        (if Nkind (Idx) = N_Range
-         then
-            --  It is a range
-            Idx
-         elsif Nkind (Idx) = N_Subtype_Indication then
-            --  It is an anonymous subtype
-            Scalar_Range (Etype (Idx))
-         else
-            --  It is an explicitly declared subtype
-            Scalar_Range (Entity (Idx)));
-
+      Bound_Range : constant Node_Id := Get_Range (Idx);
       Lbound : constant Irep :=
         Typecast_If_Necessary (Do_Expression (Low_Bound (Bound_Range)),
                                CProver_Size_T, Global_Symbol_Table);
@@ -895,9 +878,11 @@ package body Arrays is
          Base : constant Irep := Param_Symbol (Array_Param);
          Idx_Type : constant Entity_Id :=
            Etype (First_Index (Etype (N)));
+         The_Range : constant Node_Id :=
+           Get_Range (Scalar_Range (Idx_Type));
          New_First_Expr : constant Irep :=
-           Typecast_If_Necessary (Do_Expression (Low_Bound (Scalar_Range
-                                  (Idx_Type))), CProver_Size_T,
+           Typecast_If_Necessary (Do_Expression (Low_Bound (The_Range)),
+                                  CProver_Size_T,
                                   Global_Symbol_Table);
          Old_First_Expr : constant Irep :=
            Make_Member_Expr (Compound         => Base,
@@ -907,8 +892,8 @@ package body Arrays is
                              Component_Name   => "first1");
 
          New_Last_Expr : constant Irep :=
-           Typecast_If_Necessary (Do_Expression (High_Bound (Scalar_Range
-                                  (Idx_Type))), CProver_Size_T,
+           Typecast_If_Necessary (Do_Expression (High_Bound (The_Range)),
+                                  CProver_Size_T,
                                   Global_Symbol_Table);
          Result_Block : constant Irep := New_Irep (I_Code_Block);
          Array_Temp : constant Irep :=

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -751,9 +751,9 @@ package body Tree_Walk is
          end if;
       end Get_Array_Attr_Bound_Symbol;
 
-      Range_Expr  : constant Node_Id := Get_Range (N);
-      Lower_Bound : constant Node_Id := Low_Bound (Range_Expr);
-      Upper_Bound : constant Node_Id := High_Bound (Range_Expr);
+      --  N must be a range node.  No need to use Get_Range function
+      Lower_Bound : constant Node_Id := Low_Bound (N);
+      Upper_Bound : constant Node_Id := High_Bound (N);
 
       Lower_Bound_Value : Integer;
       Upper_Bound_Value : Integer;
@@ -766,7 +766,7 @@ package body Tree_Walk is
       if not (Kind (Resolved_Underlying) in Class_Bitvector_Type or
               Kind (Resolved_Underlying) = I_C_Enum_Type)
       then
-         return Report_Unhandled_Node_Type (Range_Expr,
+         return Report_Unhandled_Node_Type (N,
                                             "Do_Base_Range_Constraint",
                                         "range expression not bitvector type");
       end if;

--- a/gnat2goto/driver/tree_walk.ads
+++ b/gnat2goto/driver/tree_walk.ads
@@ -110,6 +110,13 @@ package Tree_Walk is
      with Pre => Nkind (N) in N_In,
      Post => Kind (Do_In'Result) = I_Op_And;
 
+   function Get_Range (N : Node_Id) return Node_Id
+   --  Given a discrete_subtype_definition returns its range.
+     with Pre => Nkind (N) in N_Range |
+                   N_Subtype_Indication |
+                   N_Identifier,
+          Post => Nkind (Get_Range'Result) = N_Range;
+
    function Make_Memcpy_Function_Call_Expr (Destination : Irep;
                                             Source : Irep;
                                             Num_Elem : Irep;
@@ -136,9 +143,9 @@ package Tree_Walk is
                                         Fun_Name : String;
                                         Message : String) return Irep;
 
-   function Do_Bare_Range_Constraint (Range_Expr : Node_Id; Underlying : Irep)
+   function Do_Bare_Range_Constraint (N : Node_Id; Underlying : Irep)
                                       return Irep
-     with Pre => Nkind (Range_Expr) = N_Range;
+     with Pre => Nkind (N) = N_Range;
 
    procedure Append_Declare_And_Init
      (Symbol : Irep; Value : Irep; Block : Irep; Source_Loc : Source_Ptr)


### PR DESCRIPTION
Modified code now handles discrete_subtype_definitions that are not a range.

A function, Get_Range has been introduced to wrap calls to Low/High_Bound to
ensure that these are always called with a range node.
