### PR TITLE
Ignore N_Use_Package_Clause in Process_Declaration

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -154,11 +154,6 @@ Error message: Unknown expression kind
 Nkind: N_Access_Procedure_Definition
 --
 Occurs: 5 times
-Calling function: Process_Declaration
-Error message: Use package clause declaration
-Nkind: N_Use_Package_Clause
---
-Occurs: 5 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Ada 05
 Nkind: N_Pragma

--- a/experiments/golden-results/UKNI-Information-Barrier-summary.txt
+++ b/experiments/golden-results/UKNI-Information-Barrier-summary.txt
@@ -43,11 +43,6 @@ Calling function: Do_Operator_General
 Error message: Mod of unsupported type
 Nkind: N_Op_Not
 --
-Occurs: 1 times
-Calling function: Process_Declaration
-Error message: Use package clause declaration
-Nkind: N_Use_Package_Clause
---
 Occurs: 5 times
 Redacted compiler error message:
 "REDACTED" not declared in "REDACTED"

--- a/experiments/golden-results/muen-summary.txt
+++ b/experiments/golden-results/muen-summary.txt
@@ -159,11 +159,6 @@ Error message: Exponentiation unhandled for non mod types at the moment
 Nkind: N_Op_Expon
 --
 Occurs: 1 times
-Calling function: Process_Declaration
-Error message: Use package clause declaration
-Nkind: N_Use_Package_Clause
---
-Occurs: 1 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Postcondition
 Nkind: N_Pragma

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -4836,8 +4836,8 @@ package body Tree_Walk is
             Handle_Representation_Clause (N);
 
          when N_Use_Package_Clause =>
-            Report_Unhandled_Node_Empty (N, "Process_Declaration",
-                                         "Use package clause declaration");
+            --  do nothing, name resolution is done by frontend
+            null;
 
          when N_Use_Type_Clause =>
             Report_Unhandled_Node_Empty (N, "Process_Declaration",

--- a/testsuite/gnat2goto/tests/declaration_use_package/lib.ads
+++ b/testsuite/gnat2goto/tests/declaration_use_package/lib.ads
@@ -1,0 +1,3 @@
+package Lib is
+   procedure A;
+end Lib;

--- a/testsuite/gnat2goto/tests/declaration_use_package/test.adb
+++ b/testsuite/gnat2goto/tests/declaration_use_package/test.adb
@@ -1,0 +1,10 @@
+with Lib;
+procedure Test is
+   procedure Use_Lib is
+      use Lib;
+   begin
+      A;
+   end Use_Lib;
+begin
+   Use_Lib;
+end Test;

--- a/testsuite/gnat2goto/tests/declaration_use_package/test.out
+++ b/testsuite/gnat2goto/tests/declaration_use_package/test.out
@@ -1,0 +1,4 @@
+Error from cbmc test:
+**** WARNING: no body for function lib__a
+
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/declaration_use_package/test.py
+++ b/testsuite/gnat2goto/tests/declaration_use_package/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
`use` clauses only do namespace resolution which is already done by the
frontend, no action is required for us in the driver.