### PR TITLE
Fix "mod of unsupported type" error

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -1730,12 +1730,12 @@ Raw compiler error message:
 --
 Occurs: 29 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 5 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1046                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1049                     |
 Error detected at REDACTED
 --
 Occurs: 4 times
@@ -1750,27 +1750,27 @@ Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 2 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
@@ -1810,372 +1810,372 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1046                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1049                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
@@ -2250,5 +2250,5 @@ raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from ireps.ads:176
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 | Error detected at stm32-exti.adb:47:19                                   |

--- a/experiments/golden-results/UKNI-Information-Barrier-summary.txt
+++ b/experiments/golden-results/UKNI-Information-Barrier-summary.txt
@@ -38,11 +38,6 @@ Calling function: Do_Expression
 Error message: Unknown expression kind
 Nkind: N_Range
 --
-Occurs: 1 times
-Calling function: Do_Operator_General
-Error message: Mod of unsupported type
-Nkind: N_Op_Not
---
 Occurs: 5 times
 Redacted compiler error message:
 "REDACTED" not declared in "REDACTED"

--- a/experiments/golden-results/libkeccak-summary.txt
+++ b/experiments/golden-results/libkeccak-summary.txt
@@ -55,7 +55,7 @@ Raw compiler error message:
 --
 Occurs: 23 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 2 times
@@ -95,132 +95,132 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times

--- a/experiments/golden-results/libsparkcrypto-summary.txt
+++ b/experiments/golden-results/libsparkcrypto-summary.txt
@@ -255,20 +255,20 @@ Raw compiler error message:
 --
 Occurs: 20 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 2 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED

--- a/experiments/golden-results/muen-summary.txt
+++ b/experiments/golden-results/muen-summary.txt
@@ -3025,12 +3025,12 @@ Error detected at REDACTED
 --
 Occurs: 2 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1550                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1553                     |
 Error detected at REDACTED
 --
 Occurs: 2 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
@@ -3320,212 +3320,212 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1046                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1049                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1550                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1553                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1550                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1553                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times

--- a/experiments/golden-results/vct-summary.txt
+++ b/experiments/golden-results/vct-summary.txt
@@ -300,12 +300,12 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4739                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
 Error detected at REDACTED
 --
 Occurs: 2 times


### PR DESCRIPTION
Sometimes we'd get mod operations on mod types because they collapse to
unsignedbv. This adds a case handler for this.

No test case because while I can observe this happening in our projects I wasn't able to find a small reproducer.