### PR TITLE
Fix handled sequences of statements

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -1,32 +1,27 @@
-Occurs: 204 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Postcondition
-Nkind: N_Pragma
---
 Occurs: 134 times
 Calling function: Process_Declaration
 Error message: Unknown declaration kind
 Nkind: N_Freeze_Generic_Entity
---
-Occurs: 105 times
-Calling function: Do_Function_Call
-Error message: func name not in symbol table
-Nkind: N_Function_Call
 --
 Occurs: 99 times
 Calling function: Process_Declaration
 Error message: Generic declaration
 Nkind: N_Generic_Subprogram_Declaration
 --
+Occurs: 76 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Postcondition
+Nkind: N_Pragma
+--
+Occurs: 66 times
+Calling function: Do_Function_Call
+Error message: func name not in symbol table
+Nkind: N_Function_Call
+--
 Occurs: 50 times
 Calling function: Do_Type_Definition
 Error message: Access type unsupported
 Nkind: N_Access_To_Object_Definition
---
-Occurs: 43 times
-Calling function: Do_Expression
-Error message: Unknown attribute
-Nkind: N_Attribute_Reference
 --
 Occurs: 36 times
 Calling function: Do_Withed_Unit_Spec
@@ -38,47 +33,37 @@ Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: No strict aliasing
 Nkind: N_Pragma
 --
-Occurs: 31 times
+Occurs: 30 times
 Calling function: Do_Withed_Unit_Spec
 Error message: This type of library_unit is not yet handled
 Nkind: N_Generic_Package_Declaration
 --
-Occurs: 30 times
+Occurs: 22 times
 Calling function: Process_Declaration
 Error message: Package declaration
 Nkind: N_Package_Declaration
 --
-Occurs: 23 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Check
-Nkind: N_Pragma
---
-Occurs: 20 times
+Occurs: 18 times
 Calling function: Process_Declaration
 Error message: Exception declaration
 Nkind: N_Exception_Declaration
 --
-Occurs: 20 times
+Occurs: 17 times
+Calling function: Do_Expression
+Error message: Unknown attribute
+Nkind: N_Attribute_Reference
+--
+Occurs: 16 times
 Calling function: Process_Declaration
 Error message: Package body declaration
 Nkind: N_Package_Body
 --
-Occurs: 20 times
+Occurs: 16 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Precondition
 Nkind: N_Pragma
 --
-Occurs: 15 times
-Calling function: Process_Declaration
-Error message: Unknown declaration kind
-Nkind: N_Null_Statement
---
-Occurs: 15 times
-Calling function: Process_Statement
-Error message: Unknown expression kind
-Nkind: N_Object_Declaration
---
-Occurs: 14 times
+Occurs: 12 times
 Calling function: Process_Declaration
 Error message: Generic instantiation declaration
 Nkind: N_Function_Instantiation
@@ -88,15 +73,10 @@ Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Global
 Nkind: N_Pragma
 --
-Occurs: 10 times
-Calling function: Process_Statement
-Error message: Raise statement
-Nkind: N_Raise_Statement
---
 Occurs: 9 times
-Calling function: Process_Declaration
-Error message: Unknown declaration kind
-Nkind: N_Validate_Unchecked_Conversion
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Check
+Nkind: N_Pragma
 --
 Occurs: 9 times
 Calling function: Process_Pragma_Declaration
@@ -113,6 +93,11 @@ Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Obsolescent
 Nkind: N_Pragma
 --
+Occurs: 8 times
+Calling function: Process_Statement
+Error message: Raise statement
+Nkind: N_Raise_Statement
+--
 Occurs: 7 times
 Calling function: Do_Expression
 Error message: Unknown expression kind
@@ -120,8 +105,8 @@ Nkind: N_Null
 --
 Occurs: 7 times
 Calling function: Process_Declaration
-Error message: Generic instantiation declaration
-Nkind: N_Package_Instantiation
+Error message: Unknown declaration kind
+Nkind: N_Validate_Unchecked_Conversion
 --
 Occurs: 7 times
 Calling function: Process_Pragma_Declaration
@@ -143,10 +128,10 @@ Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: No return
 Nkind: N_Pragma
 --
-Occurs: 5 times
-Calling function: Do_Operator_General
-Error message: Concat unsupported
-Nkind: N_Op_Concat
+Occurs: 6 times
+Calling function: Process_Statement
+Error message: Object declaration statement unsupported.
+Nkind: N_Object_Declaration
 --
 Occurs: 5 times
 Calling function: Do_Type_Definition
@@ -168,15 +153,15 @@ Calling function: Process_Declaration
 Error message: Generic declaration
 Nkind: N_Generic_Package_Declaration
 --
-Occurs: 2 times
-Calling function: Do_Constant
-Error message: Constant Type not in symbol table
-Nkind: N_Integer_Literal
+Occurs: 3 times
+Calling function: Process_Declaration
+Error message: Generic instantiation declaration
+Nkind: N_Package_Instantiation
 --
 Occurs: 2 times
-Calling function: Do_Function_Call
-Error message: function entity not defining identifier
-Nkind: N_Function_Call
+Calling function: Process_Declaration
+Error message: Unknown declaration kind
+Nkind: N_Null_Statement
 --
 Occurs: 1 times
 Calling function: Do_Compilation_Unit
@@ -184,14 +169,9 @@ Error message: Unknown tree node
 Nkind: N_Compilation_Unit
 --
 Occurs: 1 times
-Calling function: Do_Constant
-Error message: Constant Type not in Class_Bitvector_Type
-Nkind: N_Integer_Literal
---
-Occurs: 1 times
-Calling function: Do_Itype_Integer_Subtype
-Error message: Non-literal bound unsupported
-Nkind: N_Defining_Identifier
+Calling function: Do_Function_Call
+Error message: function entity not defining identifier
+Nkind: N_Function_Call
 --
 Occurs: 1 times
 Calling function: Do_Pragma
@@ -1730,47 +1710,47 @@ Raw compiler error message:
 --
 Occurs: 29 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
-Occurs: 5 times
-+===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1053                     |
-Error detected at REDACTED
---
-Occurs: 4 times
+Occurs: 7 times
 +===========================GNAT BUG DETECTED==============================+
 | GNU Ada (ada2goto) Constraint_Error Symbol_Table_Info.Symbol_Maps.Constant_Reference: key not in map|
 Error detected at REDACTED
 --
-Occurs: 3 times
+Occurs: 6 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1620|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1597|
 Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1054                     |
 Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+Error detected at REDACTED
+--
+Occurs: 3 times
++===========================GNAT BUG DETECTED==============================+
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 2 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
@@ -1780,12 +1760,72 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:122|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from arrays.ads:51 |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:122|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from arrays.ads:51 |
+Error detected at REDACTED
+--
+Occurs: 1 times
++===========================GNAT BUG DETECTED==============================+
+| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:114|
+Error detected at REDACTED
+--
+Occurs: 1 times
++===========================GNAT BUG DETECTED==============================+
+| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:114|
+Error detected at REDACTED
+--
+Occurs: 1 times
++===========================GNAT BUG DETECTED==============================+
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1597|
+Error detected at REDACTED
+--
+Occurs: 1 times
++===========================GNAT BUG DETECTED==============================+
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1597|
+Error detected at REDACTED
+--
+Occurs: 1 times
++===========================GNAT BUG DETECTED==============================+
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1597|
+Error detected at REDACTED
+--
+Occurs: 1 times
++===========================GNAT BUG DETECTED==============================+
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1742|
+Error detected at REDACTED
+--
+Occurs: 1 times
++===========================GNAT BUG DETECTED==============================+
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:24|
+Error detected at REDACTED
+--
+Occurs: 1 times
++===========================GNAT BUG DETECTED==============================+
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:24|
+Error detected at REDACTED
+--
+Occurs: 1 times
++===========================GNAT BUG DETECTED==============================+
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:24|
+Error detected at REDACTED
+--
+Occurs: 1 times
++===========================GNAT BUG DETECTED==============================+
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:24|
+Error detected at REDACTED
+--
+Occurs: 1 times
++===========================GNAT BUG DETECTED==============================+
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:24|
+Error detected at REDACTED
+--
+Occurs: 1 times
++===========================GNAT BUG DETECTED==============================+
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:24|
 Error detected at REDACTED
 --
 Occurs: 1 times
@@ -1810,372 +1850,362 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1053                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
-Error detected at REDACTED
---
-Occurs: 1 times
-+===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
-Error detected at REDACTED
---
-Occurs: 1 times
-+===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
@@ -2213,42 +2243,22 @@ Occurs: 1 times
 | GNU Ada (ada2goto) Constraint_Error Symbol_Table_Info.Symbol_Maps.Constant_Reference: key not in map|
 Error detected at REDACTED
 --
-Occurs: 1 times
-+===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Constraint_Error Symbol_Table_Info.Symbol_Maps.Constant_Reference: key not in map|
-Error detected at REDACTED
---
-Occurs: 55 times
+Occurs: 20 times
 <========================>
-raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from ireps.ads:1620
+raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from ireps.ads:1597
 
 --
-Occurs: 51 times
-<========================>
-raised CONSTRAINT_ERROR : Symbol_Table_Info.Symbol_Maps.Constant_Reference: key not in map
-
---
-Occurs: 13 times
-<========================>
-raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from range_check.ads:24
-
---
-Occurs: 8 times
+Occurs: 2 times
 <========================>
 raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from arrays.ads:51
 
 --
-Occurs: 3 times
-<========================>
-raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from goto_utils.ads:122
-
---
 Occurs: 1 times
 <========================>
-raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from ireps.ads:1763
+raised CONSTRAINT_ERROR : Symbol_Table_Info.Symbol_Maps.Constant_Reference: key not in map
 
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 | Error detected at stm32-exti.adb:47:19                                   |

--- a/experiments/golden-results/UKNI-Information-Barrier-summary.txt
+++ b/experiments/golden-results/UKNI-Information-Barrier-summary.txt
@@ -3,11 +3,6 @@ Calling function: Process_Declaration
 Error message: Address representation clauses are not currently supported
 Nkind: N_Attribute_Definition_Clause
 --
-Occurs: 4 times
-Calling function: Process_Statement
-Error message: Unknown expression kind
-Nkind: N_Object_Declaration
---
 Occurs: 3 times
 Calling function: Do_Base_Range_Constraint
 Error message: unsupported upper range kind
@@ -103,7 +98,12 @@ Redacted compiler error message:
 unmatched actual "REDACTED" in call
 Raw compiler error message:
 --
-Occurs: 2 times
+Occurs: 1 times
++===========================GNAT BUG DETECTED==============================+
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1597|
+Error detected at REDACTED
+--
+Occurs: 1 times
 <========================>
-raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from ireps.ads:1620
+raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from ireps.ads:1597
 

--- a/experiments/golden-results/libkeccak-summary.txt
+++ b/experiments/golden-results/libkeccak-summary.txt
@@ -55,7 +55,7 @@ Raw compiler error message:
 --
 Occurs: 23 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 2 times
@@ -95,132 +95,132 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times

--- a/experiments/golden-results/libsparkcrypto-summary.txt
+++ b/experiments/golden-results/libsparkcrypto-summary.txt
@@ -255,20 +255,20 @@ Raw compiler error message:
 --
 Occurs: 20 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 2 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED

--- a/experiments/golden-results/muen-summary.txt
+++ b/experiments/golden-results/muen-summary.txt
@@ -79,11 +79,6 @@ Error message: Unsupported pragma: Precondition
 Nkind: N_Pragma
 --
 Occurs: 7 times
-Calling function: Do_Itype_Integer_Subtype
-Error message: Non-literal bound unsupported
-Nkind: N_Defining_Identifier
---
-Occurs: 7 times
 Calling function: Process_Declaration
 Error message: Generic instantiation declaration
 Nkind: N_Function_Instantiation
@@ -99,11 +94,6 @@ Error message: Kind not in class type
 Nkind: N_Attribute_Reference
 --
 Occurs: 6 times
-Calling function: Do_Constant
-Error message: Constant Type not in symbol table
-Nkind: N_Integer_Literal
---
-Occurs: 6 times
 Calling function: Do_Identifier
 Error message: Etype not a type
 Nkind: N_Identifier
@@ -113,15 +103,15 @@ Calling function: Process_Declaration
 Error message: Generic instantiation declaration
 Nkind: N_Procedure_Instantiation
 --
+Occurs: 5 times
+Calling function: Do_Itype_Integer_Subtype
+Error message: Non-literal bound unsupported
+Nkind: N_Defining_Identifier
+--
 Occurs: 4 times
 Calling function: Process_Declaration
 Error message: Package body declaration
 Nkind: N_Package_Body
---
-Occurs: 3 times
-Calling function: Do_Aggregate_Literal
-Error message: Unhandled aggregate kind
-Nkind: N_Aggregate
 --
 Occurs: 3 times
 Calling function: Do_Type_Definition
@@ -132,6 +122,11 @@ Occurs: 3 times
 Calling function: Process_Declaration
 Error message: Generic declaration
 Nkind: N_Generic_Subprogram_Declaration
+--
+Occurs: 2 times
+Calling function: Do_Aggregate_Literal
+Error message: Unhandled aggregate kind
+Nkind: N_Aggregate
 --
 Occurs: 2 times
 Calling function: Do_Type_Definition
@@ -152,6 +147,11 @@ Occurs: 2 times
 Calling function: Process_Statement
 Error message: Unknown expression kind
 Nkind: N_Object_Renaming_Declaration
+--
+Occurs: 1 times
+Calling function: Do_Constant
+Error message: Constant Type not in symbol table
+Nkind: N_Integer_Literal
 --
 Occurs: 1 times
 Calling function: Do_Op_Expon
@@ -3018,34 +3018,39 @@ Occurs: 12 times
 | GNU Ada (ada2goto) Assert_Failure sinfo.adb:495                          |
 Error detected at REDACTED
 --
-Occurs: 6 times
+Occurs: 7 times
 +===========================GNAT BUG DETECTED==============================+
 | GNU Ada (ada2goto) Constraint_Error Symbol_Table_Info.Symbol_Maps.Constant_Reference: key not in map|
 Error detected at REDACTED
 --
 Occurs: 2 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1557                     |
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1597|
 Error detected at REDACTED
 --
 Occurs: 2 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1558                     |
+Error detected at REDACTED
+--
+Occurs: 2 times
++===========================GNAT BUG DETECTED==============================+
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1738|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1715|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1738|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1715|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1738|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1715|
 Error detected at REDACTED
 --
 Occurs: 1 times
@@ -3320,212 +3325,207 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1053                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1558                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1557                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1558                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1557                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
-Error detected at REDACTED
---
-Occurs: 1 times
-+===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
@@ -3568,12 +3568,7 @@ Occurs: 1 times
 | GNU Ada (ada2goto) Constraint_Error Symbol_Table_Info.Symbol_Maps.Constant_Reference: key not in map|
 Error detected at REDACTED
 --
-Occurs: 6 times
+Occurs: 2 times
 <========================>
-raised CONSTRAINT_ERROR : Symbol_Table_Info.Symbol_Maps.Constant_Reference: key not in map
-
---
-Occurs: 4 times
-<========================>
-raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from ireps.ads:1620
+raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from ireps.ads:1597
 

--- a/experiments/golden-results/vct-summary.txt
+++ b/experiments/golden-results/vct-summary.txt
@@ -300,12 +300,12 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
 Error detected at REDACTED
 --
 Occurs: 2 times

--- a/gnat2goto/driver/driver.adb
+++ b/gnat2goto/driver/driver.adb
@@ -143,7 +143,7 @@ package body Driver is
    end GNAT_To_Goto;
 
    procedure Initialize_CProver_Internal_Variables (Start_Body : Irep) is
-      Int_32_T : constant Irep := Make_Signedint_Type (32);
+      Int_32_T : constant Irep := Make_Signedbv_Type (32);
 
       procedure Declare_Missing_Global (Symbol_Expr : Irep)
         with Pre => Kind (Symbol_Expr) = I_Symbol_Expr;
@@ -193,9 +193,8 @@ package body Driver is
 
       procedure Initialize_CProver_Dead_Object;
       procedure Initialize_CProver_Dead_Object is
-         Dead_Object_Type : constant Irep := Make_Pointer_Type
-           (I_Subtype => Make_Void_Type,
-            Width => Pointer_Type_Width);
+         Dead_Object_Type : constant Irep :=
+           Make_Pointer_Type (Base => Make_Void_Type);
          Dead_Object_Sym : constant Irep := Make_Symbol_Expr
            (I_Type => Dead_Object_Type,
             Identifier => "__CPROVER_dead_object",
@@ -675,7 +674,7 @@ package body Driver is
       end Add_Global_Sym;
 
       --  must be int type or error when using __CPROVER_rounded_mode
-      Int_32_T : constant Irep := Make_Int_Type (32);
+      Int_32_T : constant Irep := Make_Signedbv_Type (32);
    begin
       Add_Global_Sym (Intern ("__CPROVER_rounding_mode"), Int_32_T);
    end Add_CProver_Internal_Symbols;

--- a/gnat2goto/driver/gnat2goto_itypes.adb
+++ b/gnat2goto/driver/gnat2goto_itypes.adb
@@ -145,8 +145,7 @@ package body Gnat2goto_Itypes is
                                       Low_Bound (Scalar_Range (N))))),
                        Upper_Bound => Store_Nat_Bound (Bound_Type_Nat (Intval (
                                       High_Bound (Scalar_Range (N))))),
-                               Width       => Positive (UI_To_Int (Esize (N))),
-                               I_Subtype   => Ireps.Empty);
+                       Width       => Positive (UI_To_Int (Esize (N))));
    end Do_Itype_Integer_Subtype;
 
    ------------------------------
@@ -159,8 +158,7 @@ package body Gnat2goto_Itypes is
                                       Low_Bound (Scalar_Range (N))))),
                        Upper_Bound => Store_Nat_Bound (Bound_Type_Nat (Intval (
                                       High_Bound (Scalar_Range (N))))),
-                               Width       => Positive (UI_To_Int (Esize (N))),
-                               I_Subtype   => Ireps.Empty));
+                       Width       => Positive (UI_To_Int (Esize (N)))));
 
    -----------------------------
    -- Do_Itype_Record_Subtype --
@@ -211,16 +209,14 @@ package body Gnat2goto_Itypes is
       end case;
 
       if Kind (Followed_Mod_Type) = I_Ada_Mod_Type then
-         return Make_Bounded_Mod_Type (I_Subtype   => Make_Nil_Type,
-                                       Width       =>
+         return Make_Bounded_Mod_Type (Width       =>
                                          Get_Width (Followed_Mod_Type),
                                        Lower_Bound => Lower_Bound_Value,
                                        Ada_Mod_Max =>
                                          Get_Ada_Mod_Max (Followed_Mod_Type),
                                        Upper_Bound => Upper_Bound_Value);
       else
-         return Make_Bounded_Unsignedbv_Type (I_Subtype   => Make_Nil_Type,
-                                              Width       =>
+         return Make_Bounded_Unsignedbv_Type (Width       =>
                                                 Get_Width (Followed_Mod_Type),
                                               Lower_Bound => Lower_Bound_Value,
                                              Upper_Bound => Upper_Bound_Value);

--- a/gnat2goto/driver/goto_utils.adb
+++ b/gnat2goto/driver/goto_utils.adb
@@ -30,32 +30,6 @@ package body GOTO_Utils is
       return R;
    end Make_Address_Of;
 
-   -------------------
-   -- Make_Int_Type --
-   -------------------
-
-   function Make_Int_Type (Width : Positive) return Irep is
-      I : constant Irep := New_Irep (I_Signedbv_Type);
-   begin
-      Set_Width (I, Width);
-      return I;
-   end Make_Int_Type;
-
-   function Make_Signedint_Type (Width : Positive) return Irep is
-   begin
-      return Make_Signedbv_Type (I_Subtype => Make_Nil_Type, Width => Width);
-   end Make_Signedint_Type;
-
-   function Make_Signedbv_Type (Width : Positive) return Irep is
-   begin
-      return Make_Signedbv_Type (I_Subtype => Make_Nil_Type, Width => Width);
-   end Make_Signedbv_Type;
-
-   function Make_Unsignedbv_Type (Width : Positive) return Irep is
-   begin
-      return Make_Unsignedbv_Type (I_Subtype => Make_Nil_Type, Width => Width);
-   end Make_Unsignedbv_Type;
-
    -----------------------
    -- Make_Pointer_Type --
    -----------------------

--- a/gnat2goto/driver/goto_utils.ads
+++ b/gnat2goto/driver/goto_utils.ads
@@ -22,14 +22,6 @@ package GOTO_Utils is
    function Fresh_Var_Name (Infix : String) return String;
    function Fresh_Var_Symbol_Expr (Ty : Irep; Infix : String) return Irep;
 
-   function Make_Int_Type (Width : Positive) return Irep;
-
-   function Make_Signedint_Type (Width : Positive) return Irep;
-
-   function Make_Signedbv_Type (Width : Positive) return Irep;
-
-   function Make_Unsignedbv_Type (Width : Positive) return Irep;
-
    function Make_Pointer_Type (Base : Irep) return Irep;
 
    function Make_Address_Of (Base : Irep) return Irep;
@@ -145,7 +137,7 @@ package GOTO_Utils is
       Expr_Type : Irep;
       Source_Location : Source_Ptr)
    return Irep
-   with Pre => Kind (Expr_Type) in Class_Bitvector_Type,
+   with Pre => Kind (Expr_Type) in Class_Bitvector_Type | I_Pointer_Type,
         Post => Kind (Integer_Constant_To_Expr'Result) = I_Constant_Expr;
 
    function Make_Simple_Side_Effect_Expr_Function_Call

--- a/gnat2goto/driver/range_check.ads
+++ b/gnat2goto/driver/range_check.ads
@@ -74,7 +74,8 @@ private
 
    function Load_Nat_Bound_In_Hex (Index : Integer; Actual_Type : Irep)
                                return String
-     with Pre => Kind (Actual_Type) = I_Bounded_Signedbv_Type;
+     with Pre => Kind (Actual_Type) in
+     I_Bounded_Signedbv_Type | I_Bounded_Unsignedbv_Type;
 
    function Load_Real_Bound_In_Hex (Index : Integer; Actual_Type : Irep)
                                     return String

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -1078,7 +1078,7 @@ package body Tree_Walk is
       -- Dummy value initialisation --
       -- To be removed once the Unsupported reports are removed --
       Set_Source_Location (Ret, Sloc (N));
-      Set_Type (Ret, Make_Signedint_Type (32));
+      Set_Type (Ret, Make_Signedbv_Type (32));
       Set_Value (Ret, "00000000000000000000000000000000");
 
       if Is_Integer_Literal then
@@ -1305,7 +1305,7 @@ package body Tree_Walk is
             Set_Basename (Element, Base_Name);
             Append_Member (Enum_Body, Element);
             Set_Type (Member_Symbol_Init,
-                      Make_Int_Type (Integer (Member_Size)));
+                      Make_Signedbv_Type (Integer (Member_Size)));
             Set_Value (Member_Symbol_Init,
                        Convert_Uint_To_Hex (Enumeration_Rep (Member),
                                                Member_Size));
@@ -1320,7 +1320,7 @@ package body Tree_Walk is
          Next (Member);
          exit when not Present (Member);
       end loop;
-      Set_Subtype (Ret, Make_Int_Type (32));
+      Set_Subtype (Ret, Make_Signedbv_Type (32));
       Set_Body (Ret, Enum_Body);
       return Ret;
    end Do_Enumeration_Definition;
@@ -3219,11 +3219,11 @@ package body Tree_Walk is
             Cast_LHS_To_Integer : constant Irep :=
               Make_Op_Typecast (Op0 => LHS_Value,
                                 Source_Location => Source_Loc,
-                                I_Type => Make_Signedint_Type (32));
+                                I_Type => Make_Signedbv_Type (32));
             Cast_RHS_To_Integer : constant Irep :=
               Make_Op_Typecast (Op0 => RHS_Value,
                                 Source_Location => Source_Loc,
-                                I_Type => Make_Signedint_Type (32));
+                                I_Type => Make_Signedbv_Type (32));
             R : constant Irep := Operator (Lhs => Cast_LHS_To_Integer,
                                            Rhs => Cast_RHS_To_Integer,
                                            Source_Location => Source_Loc,
@@ -5516,8 +5516,7 @@ package body Tree_Walk is
       end if;
 
       return Make_Ada_Mod_Type
-        (I_Subtype => Make_Nil_Type,
-         Width => Ada_Type_Size,
+        (Width => Ada_Type_Size,
          Ada_Mod_Max => Convert_Uint_To_Hex
            (Mod_Max, Pos (Ada_Type_Size)));
    end Do_Modular_Type_Definition;

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -723,7 +723,8 @@ package body Tree_Walk is
                           Global_Symbol_Table));
             end;
          else
-            Set_Rhs (R, RHS);
+            Set_Rhs (R, Typecast_If_Necessary (
+                     RHS, Get_Type (LHS), Global_Symbol_Table));
          end if;
          return R;
       end;
@@ -1755,8 +1756,18 @@ package body Tree_Walk is
 
    function Do_Handled_Sequence_Of_Statements (N : Node_Id) return Irep is
       Stmts : constant List_Id := Statements (N);
+      Stmnt : Node_Id := First (Stmts);
+      Reps : constant Irep := New_Irep (I_Code_Block);
    begin
-      return Process_Statements (Stmts);
+      while Present (Stmnt) loop
+         if Nkind (Stmnt) = N_Object_Declaration then
+            Process_Declaration (Stmnt, Reps);
+         else
+            Process_Statement (Stmnt, Reps);
+         end if;
+         Next (Stmnt);
+      end loop;
+      return Reps;
    end Do_Handled_Sequence_Of_Statements;
 
    -------------------
@@ -2230,7 +2241,8 @@ package body Tree_Walk is
                   --  TODO: needs generalization to support enums
                   if Reverse_Present (Spec) then
                      Set_Lhs (Init, Sym_Loopvar);
-                     Set_Rhs (Init, Bound_High);
+                     Set_Rhs (Init, Typecast_If_Necessary (Bound_High,
+                              Get_Type (Sym_Loopvar), Global_Symbol_Table));
                      Cond := Make_Op_Geq
                        (Rhs             => Bound_Low,
                         Lhs             => Sym_Loopvar,
@@ -2242,7 +2254,8 @@ package body Tree_Walk is
                        (Sym_Loopvar, Etype (Low_Bound (Dsd)), -1);
                   else
                      Set_Lhs (Init, Sym_Loopvar);
-                     Set_Rhs (Init, Bound_Low);
+                     Set_Rhs (Init, Typecast_If_Necessary (Bound_Low,
+                              Get_Type (Sym_Loopvar), Global_Symbol_Table));
                      Cond := Make_Op_Leq
                        (Rhs             => Bound_High,
                         Lhs             => Sym_Loopvar,
@@ -3053,7 +3066,7 @@ package body Tree_Walk is
       Set_Symbol (Decl, Id);
       Append_Op (Block, Decl);
 
-      if Has_Init_Expression (N) then
+      if Has_Init_Expression (N) or Present (Expression (N)) then
          Init_Expr := Do_Expression (Expression (N));
       elsif Needs_Default_Initialisation (Etype (Defined)) then
          declare
@@ -5458,6 +5471,9 @@ package body Tree_Walk is
 --         when N_Freeze_Entity =>
 --            --  Ignore, nothing to generate
 --            null;
+         when N_Object_Declaration =>
+            Report_Unhandled_Node_Empty (N, "Process_Statement",
+                                  "Object declaration statement unsupported.");
 
          when others =>
             Report_Unhandled_Node_Empty (N, "Process_Statement",

--- a/gnat2goto/ireps/irep_specs/bitvector_type.json
+++ b/gnat2goto/ireps/irep_specs/bitvector_type.json
@@ -1,5 +1,5 @@
 {
-  "parent": "type_with_subtype",
+  "parent": "type",
   "namedSub": {
     "width": {"type": "integer"}
   }

--- a/gnat2goto/ireps/irep_specs/pointer_type.json
+++ b/gnat2goto/ireps/irep_specs/pointer_type.json
@@ -1,4 +1,7 @@
 {
-  "parent": "bitvector_type",
+   "parent": "type_with_subtype",
+   "namedSub": {
+      "width": {"type": "integer"}
+   },
   "id": "pointer"
 }

--- a/gnat2goto/ireps/ireps_generator.py
+++ b/gnat2goto/ireps/ireps_generator.py
@@ -2048,26 +2048,26 @@ class IrepsGenerator(object):
         write(b, "")
         write(b, "if Kind (I) = I_Bounded_Signedbv_Type then")
         with indent(b):
-            write(b, "return Make_Signedbv_Type (Get_Subtype (I), Get_Width (I));")
+            write(b, "return Make_Signedbv_Type (Get_Width (I));")
         write(b, "end if;")
         write(b, "")
         write(b, "if Kind (I) = I_Bounded_Floatbv_Type then")
         with indent(b):
-            write(b, "return Make_Floatbv_Type (Get_Subtype (I), Get_Width (I), Get_F (I));")
+            write(b, "return Make_Floatbv_Type (Get_Width (I), Get_F (I));")
         write(b, "end if;")
         write(b, "")
         write(b, "if Kind (I) = I_Bounded_Unsignedbv_Type then")
         with indent(b):
-            write(b, "return Make_Unsignedbv_Type (Get_Subtype (I), Get_Width (I));")
+            write(b, "return Make_Unsignedbv_Type (Get_Width (I));")
         write(b, "end if;")
         write(b, "")
         write(b, "if Kind (I) = I_Bounded_Mod_Type then")
         with indent(b):
-            write(b, "return Make_Unsignedbv_Type (Get_Subtype (I), Get_Width (I));")
+            write(b, "return Make_Unsignedbv_Type (Get_Width (I));")
         write(b, "end if;")
         write(b, "if Kind (I) = I_Ada_Mod_Type then")
         with indent(b):
-            write(b, "return Make_Unsignedbv_Type (Make_Nil_Type, Get_Width (I));")
+            write(b, "return Make_Unsignedbv_Type (Get_Width (I));")
         write(b, "end if;")
         write(b, "")
         write(b, "declare")

--- a/testsuite/gnat2goto/tests/loop_range_variable/test.adb
+++ b/testsuite/gnat2goto/tests/loop_range_variable/test.adb
@@ -1,0 +1,13 @@
+procedure Test is
+   type Unsigned_8 is mod 2 ** 4;
+   subtype s10_index is Unsigned_8 range 1 .. 10;
+   length : Unsigned_8 := 4;
+   j : s10_index;
+begin
+   j := 1;
+   for k in s10_index range 1 .. length loop
+      j := j + 1;
+   end loop;
+   pragma Assert (j < 4);
+
+end Test;

--- a/testsuite/gnat2goto/tests/loop_range_variable/test.out
+++ b/testsuite/gnat2goto/tests/loop_range_variable/test.out
@@ -1,0 +1,3 @@
+[assertion.1] Range Check: SUCCESS
+[1] file test.adb line 11 assertion: FAILURE
+VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/loop_range_variable/test.py
+++ b/testsuite/gnat2goto/tests/loop_range_variable/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
since these may contain declarations as well. We thus go through the sequence
and call process declaration/statement respectively. These declarations should
be initialised with expression even thought their has-init-expression flag is
set to false.

Also:
1) extend load_bound_in_hex to accept unsigned type
2) typecast assignments (somehow a type with empty subtype is different from a
type without subtype)
3) removing extra type-info in ireps.adb produces integral bv-types with nil
subtypes.