### PR TITLE
Support ranges in case statements and case expressions

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -1730,12 +1730,12 @@ Raw compiler error message:
 --
 Occurs: 29 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 5 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1049                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1053                     |
 Error detected at REDACTED
 --
 Occurs: 4 times
@@ -1750,27 +1750,27 @@ Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 2 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
@@ -1810,372 +1810,372 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1049                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1053                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
@@ -2250,5 +2250,5 @@ raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from ireps.ads:176
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 | Error detected at stm32-exti.adb:47:19                                   |

--- a/experiments/golden-results/UKNI-Information-Barrier-summary.txt
+++ b/experiments/golden-results/UKNI-Information-Barrier-summary.txt
@@ -33,11 +33,6 @@ Calling function: Do_Base_Range_Constraint
 Error message: unsupported upper range kind
 Nkind: N_Selected_Component
 --
-Occurs: 1 times
-Calling function: Do_Expression
-Error message: Unknown expression kind
-Nkind: N_Range
---
 Occurs: 5 times
 Redacted compiler error message:
 "REDACTED" not declared in "REDACTED"

--- a/experiments/golden-results/libkeccak-summary.txt
+++ b/experiments/golden-results/libkeccak-summary.txt
@@ -55,7 +55,7 @@ Raw compiler error message:
 --
 Occurs: 23 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 2 times
@@ -95,132 +95,132 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times

--- a/experiments/golden-results/libsparkcrypto-summary.txt
+++ b/experiments/golden-results/libsparkcrypto-summary.txt
@@ -255,20 +255,20 @@ Raw compiler error message:
 --
 Occurs: 20 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 2 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED

--- a/experiments/golden-results/muen-summary.txt
+++ b/experiments/golden-results/muen-summary.txt
@@ -3025,12 +3025,12 @@ Error detected at REDACTED
 --
 Occurs: 2 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1553                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1557                     |
 Error detected at REDACTED
 --
 Occurs: 2 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
@@ -3320,212 +3320,212 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1049                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1053                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1553                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1557                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1553                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1557                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times

--- a/experiments/golden-results/vct-summary.txt
+++ b/experiments/golden-results/vct-summary.txt
@@ -300,12 +300,12 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4757                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4793                     |
 Error detected at REDACTED
 --
 Occurs: 2 times

--- a/testsuite/gnat2goto/tests/case_expression_range/test.opt
+++ b/testsuite/gnat2goto/tests/case_expression_range/test.opt
@@ -1,1 +1,0 @@
-ALL XFAIL gnat2goto throws exceptions but produces something that crashes CBMC even harder

--- a/testsuite/gnat2goto/tests/case_expression_range/test.out
+++ b/testsuite/gnat2goto/tests/case_expression_range/test.out
@@ -1,0 +1,3 @@
+[1] file case_expression_range.adb line 10 assertion: SUCCESS
+[2] file case_expression_range.adb line 11 assertion: SUCCESS
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/case_statement_range/case_statement_range.adb
+++ b/testsuite/gnat2goto/tests/case_statement_range/case_statement_range.adb
@@ -1,10 +1,10 @@
-function Case_Statement_Range return String is
+function Case_Statement_Range return Integer is
   type T is range 0 .. 10;
   X : T := 6;
 begin
   case X is
-    when 0 .. 5  => return "Zero to five";
-    when 6 .. 10 => return "Six to ten";
-    when others  => return "Invalid";
+    when 0 .. 5  => pragma Assert (false); return 10;
+    when 6 .. 10 => return 20;
+    when others  => pragma Assert (false); return 30;
   end case;
 end Case_Statement_Range;

--- a/testsuite/gnat2goto/tests/case_statement_range/main.adb
+++ b/testsuite/gnat2goto/tests/case_statement_range/main.adb
@@ -1,0 +1,6 @@
+with Case_Statement_Range;
+
+procedure Main is
+begin
+  pragma Assert (Case_Statement_Range = 20);
+end Main;

--- a/testsuite/gnat2goto/tests/case_statement_range/test.opt
+++ b/testsuite/gnat2goto/tests/case_statement_range/test.opt
@@ -1,1 +1,0 @@
-ALL XFAIL gnat2goto can't handle ranges in case statements

--- a/testsuite/gnat2goto/tests/case_statement_range/test.out
+++ b/testsuite/gnat2goto/tests/case_statement_range/test.out
@@ -1,1 +1,4 @@
+[2] file case_statement_range.adb line 6 assertion: SUCCESS
+[3] file case_statement_range.adb line 8 assertion: SUCCESS
+[1] file main.adb line 5 assertion: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/case_statement_range/test.py
+++ b/testsuite/gnat2goto/tests/case_statement_range/test.py
@@ -1,3 +1,3 @@
 from test_support import *
 
-prove()
+prove(main='main.adb')


### PR DESCRIPTION
Add support for ranges in case statements and case expressions, and activate the relevant tests.

This adds support for a missing feature needed for UKNI, constructs that look like this:

```ada
case X is
    when 0 .. 5  => return 10;
```