### PR TITLE
Rework of subtype constraint

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -1705,7 +1705,7 @@ Raw compiler error message:
 --
 Occurs: 29 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 6 times
@@ -1720,32 +1720,32 @@ Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1054                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:957                      |
 Error detected at REDACTED
 --
 Occurs: 2 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
@@ -1850,362 +1850,362 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
@@ -2255,5 +2255,5 @@ raised CONSTRAINT_ERROR : Symbol_Table_Info.Symbol_Maps.Constant_Reference: key 
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 | Error detected at stm32-exti.adb:47:19                                   |

--- a/experiments/golden-results/UKNI-Information-Barrier-summary.txt
+++ b/experiments/golden-results/UKNI-Information-Barrier-summary.txt
@@ -3,31 +3,6 @@ Calling function: Process_Declaration
 Error message: Address representation clauses are not currently supported
 Nkind: N_Attribute_Definition_Clause
 --
-Occurs: 3 times
-Calling function: Do_Base_Range_Constraint
-Error message: unsupported upper range kind
-Nkind: N_Op_Add
---
-Occurs: 1 times
-Calling function: Do_Base_Range_Constraint
-Error message: unsupported lower range kind
-Nkind: N_Attribute_Reference
---
-Occurs: 1 times
-Calling function: Do_Base_Range_Constraint
-Error message: unsupported lower range kind
-Nkind: N_Selected_Component
---
-Occurs: 1 times
-Calling function: Do_Base_Range_Constraint
-Error message: unsupported upper range kind
-Nkind: N_Attribute_Reference
---
-Occurs: 1 times
-Calling function: Do_Base_Range_Constraint
-Error message: unsupported upper range kind
-Nkind: N_Selected_Component
---
 Occurs: 5 times
 Redacted compiler error message:
 "REDACTED" not declared in "REDACTED"

--- a/experiments/golden-results/libkeccak-summary.txt
+++ b/experiments/golden-results/libkeccak-summary.txt
@@ -55,7 +55,7 @@ Raw compiler error message:
 --
 Occurs: 23 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 2 times
@@ -95,132 +95,132 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times

--- a/experiments/golden-results/libsparkcrypto-summary.txt
+++ b/experiments/golden-results/libsparkcrypto-summary.txt
@@ -255,20 +255,20 @@ Raw compiler error message:
 --
 Occurs: 20 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 2 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED

--- a/experiments/golden-results/muen-summary.txt
+++ b/experiments/golden-results/muen-summary.txt
@@ -3020,12 +3020,12 @@ Error detected at REDACTED
 --
 Occurs: 2 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1558                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1461                     |
 Error detected at REDACTED
 --
 Occurs: 2 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
@@ -3320,207 +3320,207 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1558                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1461                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1558                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1461                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times

--- a/experiments/golden-results/vct-summary.txt
+++ b/experiments/golden-results/vct-summary.txt
@@ -300,12 +300,12 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4806                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4829                     |
 Error detected at REDACTED
 --
 Occurs: 2 times

--- a/gnat2goto/driver/arrays.adb
+++ b/gnat2goto/driver/arrays.adb
@@ -804,17 +804,6 @@ package body Arrays is
       return Get_Last_Index (Do_Expression (Prefix (N)));
    end Do_Array_Last;
 
-   --  This handled the oddball anonymous range nodes that can occur
-   --  in array type declarations; they're effectively subtype indication
-   --  nodes with an implied base type and a range constraint.
-   function Do_Array_Range (N : Node_Id) return Irep
-   is
-      Underlying : constant Irep :=
-        Do_Type_Reference (Etype (Etype (N)));
-   begin
-      return Do_Bare_Range_Constraint (N, Underlying);
-   end Do_Array_Range;
-
    ------------------------------
    -- Get_Array_Component_Type --
    ------------------------------

--- a/gnat2goto/driver/arrays.ads
+++ b/gnat2goto/driver/arrays.ads
@@ -82,9 +82,6 @@ private
    function Do_RHS_Array_Assign (N : Node_Id) return Irep_Array
      with Pre => Nkind (N) in N_Subexpr;
 
-   function Do_Array_Range (N : Node_Id) return Irep
-     with Pre  => Nkind (N) = N_Range;
-
    function Make_Array_First_Expr
      (Base_Type : Node_Id; Base_Irep : Irep) return Irep;
 

--- a/gnat2goto/driver/gnat2goto_itypes.adb
+++ b/gnat2goto/driver/gnat2goto_itypes.adb
@@ -180,33 +180,24 @@ package body Gnat2goto_Itypes is
       Lower_Bound : constant Node_Id := Low_Bound (S_Range);
       Upper_Bound : constant Node_Id := High_Bound (S_Range);
 
-      Lower_Bound_Value : Integer;
-      Upper_Bound_Value : Integer;
+      Lower_Bound_Value : constant Integer :=
+        (case Nkind (Lower_Bound) is
+            when N_Integer_Literal =>
+               Store_Nat_Bound (Bound_Type_Nat (Intval (Lower_Bound))),
+            when others =>
+               Store_Symbol_Bound (Bound_Type_Symbol (
+           Do_Expression (Lower_Bound))));
+
+      Upper_Bound_Value : constant Integer :=
+        (case Nkind (Upper_Bound) is
+            when N_Integer_Literal =>
+               Store_Nat_Bound (Bound_Type_Nat (Intval (Upper_Bound))),
+            when others =>
+               Store_Symbol_Bound (Bound_Type_Symbol (
+           Do_Expression (Upper_Bound))));
    begin
       pragma Assert (Kind (Followed_Mod_Type) in I_Unsignedbv_Type
                        | I_Ada_Mod_Type);
-
-      case Nkind (Lower_Bound) is
-         when N_Integer_Literal => Lower_Bound_Value :=
-              Store_Nat_Bound (Bound_Type_Nat (Intval (Lower_Bound)));
-         when N_Identifier => Lower_Bound_Value :=
-              Store_Symbol_Bound (Bound_Type_Symbol (Lower_Bound));
-         when others =>
-            Report_Unhandled_Node_Empty (Lower_Bound,
-                                         "Do_Base_Range_Constraint",
-                                         "unsupported lower range kind");
-      end case;
-
-      case Nkind (Upper_Bound) is
-         when N_Integer_Literal => Upper_Bound_Value :=
-              Store_Nat_Bound (Bound_Type_Nat (Intval (Upper_Bound)));
-         when N_Identifier => Upper_Bound_Value :=
-              Store_Symbol_Bound (Bound_Type_Symbol (Upper_Bound));
-         when others =>
-            Report_Unhandled_Node_Empty (Upper_Bound,
-                                         "Do_Base_Range_Constraint",
-                                         "unsupported upper range kind");
-      end case;
 
       if Kind (Followed_Mod_Type) = I_Ada_Mod_Type then
          return Make_Bounded_Mod_Type (Width       =>

--- a/gnat2goto/driver/range_check.ads
+++ b/gnat2goto/driver/range_check.ads
@@ -39,7 +39,7 @@ package Range_Check is
                                     Bounds_Type : Irep) return Irep
      with Pre => Kind (Bounds_Type) in
      I_Bounded_Signedbv_Type | I_Bounded_Floatbv_Type | I_Symbol_Type
-       | I_Unsignedbv_Type | I_Signedbv_Type;
+       | I_Unsignedbv_Type | I_Signedbv_Type | I_Bounded_Unsignedbv_Type;
 
    function Make_Range_Expression (Value_Expr : Irep; Lower_Bound : Irep;
                                    Upper_Bound : Irep)

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -227,8 +227,6 @@ package body Tree_Walk is
 
    function Do_Range_In_Case (N : Node_Id; Symbol : Irep) return Irep;
 
-   function Do_Range_Constraint (N : Node_Id; Underlying : Irep) return Irep;
-
    function Do_Record_Definition (N : Node_Id; Discs : List_Id) return Irep
    with Pre  => Nkind (N) in N_Record_Definition | N_Variant,
         Post => Kind (Do_Record_Definition'Result) = I_Struct_Type;
@@ -730,132 +728,6 @@ package body Tree_Walk is
          return R;
       end;
    end Do_Assignment_Statement;
-
-   ------------------------------
-   -- Do_Bare_Range_Constraint --
-   ------------------------------
-
-   function Do_Bare_Range_Constraint (Range_Expr : Node_Id; Underlying : Irep)
-                                     return Irep
-   is
-      Resolved_Underlying : constant Irep :=
-        Follow_Symbol_Type (Underlying, Global_Symbol_Table);
-      --  ??? why not get this from the entity
-
-      function Get_Array_Attr_Bound_Symbol (Bound_Node : Node_Id)
-                                            return Bound_Type_Symbol
-        with Pre => Get_Attribute_Id (Attribute_Name (Bound_Node))
-          in Attribute_First | Attribute_Last;
-      function Get_Array_Attr_Bound_Symbol (Bound_Node : Node_Id)
-                                            return Bound_Type_Symbol
-      is
-      begin
-         if Get_Attribute_Id (Attribute_Name (Bound_Node)) =  Attribute_First
-         then
-            return Bound_Type_Symbol (Do_Array_First (Bound_Node));
-         else
-            return Bound_Type_Symbol (Do_Array_Last (Bound_Node));
-         end if;
-      end Get_Array_Attr_Bound_Symbol;
-
-      procedure Set_Bound_Value (Bound : Node_Id;
-                                 Bound_Value : out Integer;
-                                 Ok : out Boolean)
-      with Pre => Is_OK_Static_Expression (Bound);
-      --  For static expressions, the gnat front end replaces all attribute
-      --  references by the lower and upper bounds of the attributed prefix.
-      --  If the type of the range is an integer type, it folds the lower and
-      --  upper bounds expressions into their intege value. If the range is
-      --  an enumeration type it sets the lower and upper bounds to the
-      --  enumeration literal identifiers of the bounds.
-
-      procedure Set_Bound_Value (Bound : Node_Id;
-                                 Bound_Value : out Integer;
-                                 Ok : out Boolean) is
-      begin
-         Ok := False;
-         Bound_Value := 0;
-         case Nkind (Bound) is
-         when N_Integer_Literal =>
-            Bound_Value :=
-              Store_Nat_Bound (Bound_Type_Nat (Intval (Bound)));
-            Ok := True;
-         when N_Identifier =>
-            Bound_Value :=
-                 Store_Symbol_Bound (Bound_Type_Symbol (
-                                     Do_Identifier (Bound)));
-            Ok := True;
-            when others =>
-               null;
-         end case;
-      end Set_Bound_Value;
-
-      Lower_Bound : constant Node_Id := Low_Bound (Range_Expr);
-      Upper_Bound : constant Node_Id := High_Bound (Range_Expr);
-
-      Lower_Bound_Value : Integer;
-      Upper_Bound_Value : Integer;
-
-      Ok : Boolean;
-
-      Result_Type : constant Irep :=
-        New_Irep (if Kind (Resolved_Underlying) = I_Ada_Mod_Type
-                    then I_Bounded_Unsignedbv_Type
-                    else I_Bounded_Signedbv_Type);
-   begin
-      if not (Kind (Resolved_Underlying) in Class_Bitvector_Type or
-              Kind (Resolved_Underlying) = I_C_Enum_Type)
-      then
-         return Report_Unhandled_Node_Type (Range_Expr,
-                                            "Do_Base_Range_Constraint",
-                                        "range expression not bitvector type");
-      end if;
-
-      if Is_OK_Static_Range (Range_Expr) then
-         Set_Bound_Value (Lower_Bound, Lower_Bound_Value, Ok);
-         if not Ok then
-            return Report_Unhandled_Node_Type
-              (Lower_Bound,
-               "Do_Base_Range_Constraint",
-               "unsupported lower range kind");
-         end if;
-         Set_Bound_Value (Upper_Bound, Upper_Bound_Value, Ok);
-         if not Ok then
-            return Report_Unhandled_Node_Type
-              (Lower_Bound,
-               "Do_Range_Constraint",
-               "unsupported upper range kind");
-         end if;
-
-      elsif Nkind (Lower_Bound) = N_Attribute_Reference and then
-        (Get_Attribute_Id (Attribute_Name (Lower_Bound)) =
-           Attribute_First and
-             (Get_Attribute_Id (Attribute_Name (Upper_Bound))) =
-             Attribute_Last)
-      then
-         Lower_Bound_Value :=
-           Store_Symbol_Bound
-             (Get_Array_Attr_Bound_Symbol (Lower_Bound));
-         Upper_Bound_Value :=
-           Store_Symbol_Bound (Get_Array_Attr_Bound_Symbol (Upper_Bound));
-      else
-         return Report_Unhandled_Node_Type
-           (Lower_Bound,
-            "Do_Range_Constraint",
-            "only static ranges are supported");
-
-      end if;
-
-      if Kind (Resolved_Underlying) = I_C_Enum_Type then
-         Set_Width (Result_Type,
-          Get_Width (Get_Subtype (Resolved_Underlying)));
-      else
-         Set_Width (Result_Type, Get_Width (Resolved_Underlying));
-      end if;
-      Set_Lower_Bound (Result_Type, Lower_Bound_Value);
-      Set_Upper_Bound (Result_Type, Upper_Bound_Value);
-      return Result_Type;
-   end Do_Bare_Range_Constraint;
 
    ------------------------
    -- Do_Call_Parameters --
@@ -3911,8 +3783,127 @@ package body Tree_Walk is
    -------------------------
 
    function Do_Range_Constraint (N : Node_Id; Underlying : Irep)
-                                 return Irep
-   is (Do_Bare_Range_Constraint (Range_Expression (N), Underlying));
+                                     return Irep
+   is
+      Range_Expr : constant Node_Id := Range_Expression (N);
+      Resolved_Underlying : constant Irep :=
+        Follow_Symbol_Type (Underlying, Global_Symbol_Table);
+      --  ??? why not get this from the entity
+
+      function Get_Array_Attr_Bound_Symbol (Bound_Node : Node_Id)
+                                            return Bound_Type_Symbol
+        with Pre => Get_Attribute_Id (Attribute_Name (Bound_Node))
+          in Attribute_First | Attribute_Last;
+      function Get_Array_Attr_Bound_Symbol (Bound_Node : Node_Id)
+                                            return Bound_Type_Symbol
+      is
+      begin
+         if Get_Attribute_Id (Attribute_Name (Bound_Node)) =  Attribute_First
+         then
+            return Bound_Type_Symbol (Do_Array_First (Bound_Node));
+         else
+            return Bound_Type_Symbol (Do_Array_Last (Bound_Node));
+         end if;
+      end Get_Array_Attr_Bound_Symbol;
+
+      procedure Set_Bound_Value (Bound : Node_Id;
+                                 Bound_Value : out Integer;
+                                 Ok : out Boolean)
+      with Pre => Is_OK_Static_Expression (Bound);
+      --  For static expressions, the gnat front end replaces all attribute
+      --  references by the lower and upper bounds of the attributed prefix.
+      --  If the type of the range is an integer type, it folds the lower and
+      --  upper bounds expressions into their intege value. If the range is
+      --  an enumeration type it sets the lower and upper bounds to the
+      --  enumeration literal identifiers of the bounds.
+
+      procedure Set_Bound_Value (Bound : Node_Id;
+                                 Bound_Value : out Integer;
+                                 Ok : out Boolean) is
+      begin
+         Ok := False;
+         Bound_Value := 0;
+         case Nkind (Bound) is
+         when N_Integer_Literal =>
+            Bound_Value :=
+              Store_Nat_Bound (Bound_Type_Nat (Intval (Bound)));
+            Ok := True;
+         when N_Identifier =>
+            Bound_Value :=
+                 Store_Symbol_Bound (Bound_Type_Symbol (
+                                     Do_Identifier (Bound)));
+            Ok := True;
+            when others =>
+               null;
+         end case;
+      end Set_Bound_Value;
+
+      Lower_Bound : constant Node_Id := Low_Bound (Range_Expr);
+      Upper_Bound : constant Node_Id := High_Bound (Range_Expr);
+
+      Lower_Bound_Value : Integer;
+      Upper_Bound_Value : Integer;
+
+      Ok : Boolean;
+
+      Result_Type : constant Irep :=
+        New_Irep (if Kind (Resolved_Underlying) = I_Ada_Mod_Type
+                    then I_Bounded_Unsignedbv_Type
+                    else I_Bounded_Signedbv_Type);
+   begin
+      if not (Kind (Resolved_Underlying) in Class_Bitvector_Type or
+              Kind (Resolved_Underlying) = I_C_Enum_Type)
+      then
+         return Report_Unhandled_Node_Type (Range_Expr,
+                                            "Do_Base_Range_Constraint",
+                                        "range expression not bitvector type");
+      end if;
+
+      if Is_OK_Static_Range (Range_Expr) then
+         Set_Bound_Value (Lower_Bound, Lower_Bound_Value, Ok);
+         if not Ok then
+            return Report_Unhandled_Node_Type
+              (Lower_Bound,
+               "Do_Base_Range_Constraint",
+               "unsupported lower range kind");
+         end if;
+         Set_Bound_Value (Upper_Bound, Upper_Bound_Value, Ok);
+         if not Ok then
+            return Report_Unhandled_Node_Type
+              (Lower_Bound,
+               "Do_Range_Constraint",
+               "unsupported upper range kind");
+         end if;
+
+      elsif Nkind (Lower_Bound) = N_Attribute_Reference and then
+        (Get_Attribute_Id (Attribute_Name (Lower_Bound)) =
+           Attribute_First and
+             (Get_Attribute_Id (Attribute_Name (Upper_Bound))) =
+             Attribute_Last)
+      then
+         Lower_Bound_Value :=
+           Store_Symbol_Bound
+             (Get_Array_Attr_Bound_Symbol (Lower_Bound));
+         Upper_Bound_Value :=
+           Store_Symbol_Bound (Get_Array_Attr_Bound_Symbol (Upper_Bound));
+      else
+         return Report_Unhandled_Node_Type
+           (Lower_Bound,
+            "Do_Range_Constraint",
+            "only static ranges are supported");
+
+      end if;
+
+      if Kind (Resolved_Underlying) = I_C_Enum_Type then
+         Set_Width (Result_Type,
+          Get_Width (Get_Subtype (Resolved_Underlying)));
+      else
+         Set_Width (Result_Type, Get_Width (Resolved_Underlying));
+      end if;
+      Set_Lower_Bound (Result_Type, Lower_Bound_Value);
+      Set_Upper_Bound (Result_Type, Upper_Bound_Value);
+      return Result_Type;
+   end Do_Range_Constraint;
 
    --------------------------
    -- Do_Record_Definition --

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -4,6 +4,7 @@ with Sem;
 with Sem_Eval;              use Sem_Eval;
 with Sem_Util;              use Sem_Util;
 with Sem_Aux;               use Sem_Aux;
+--  with Sem_Eval;              use Sem_Eval;
 with Snames;                use Snames;
 with Stringt;               use Stringt;
 with Treepr;                use Treepr;
@@ -749,7 +750,7 @@ package body Tree_Walk is
                                             return Bound_Type_Symbol
       is
       begin
-         if Get_Attribute_Id (Attribute_Name (Bound_Node)) = Attribute_First
+         if Get_Attribute_Id (Attribute_Name (Bound_Node)) =  Attribute_First
          then
             return Bound_Type_Symbol (Do_Array_First (Bound_Node));
          else
@@ -757,11 +758,45 @@ package body Tree_Walk is
          end if;
       end Get_Array_Attr_Bound_Symbol;
 
+      procedure Set_Bound_Value (Bound : Node_Id;
+                                 Bound_Value : out Integer;
+                                 Ok : out Boolean)
+      with Pre => Is_OK_Static_Expression (Bound);
+      --  For static expressions, the gnat front end replaces all attribute
+      --  references by the lower and upper bounds of the attributed prefix.
+      --  If the type of the range is an integer type, it folds the lower and
+      --  upper bounds expressions into their intege value. If the range is
+      --  an enumeration type it sets the lower and upper bounds to the
+      --  enumeration literal identifiers of the bounds.
+
+      procedure Set_Bound_Value (Bound : Node_Id;
+                                 Bound_Value : out Integer;
+                                 Ok : out Boolean) is
+      begin
+         Ok := False;
+         Bound_Value := 0;
+         case Nkind (Bound) is
+         when N_Integer_Literal =>
+            Bound_Value :=
+              Store_Nat_Bound (Bound_Type_Nat (Intval (Bound)));
+            Ok := True;
+         when N_Identifier =>
+            Bound_Value :=
+                 Store_Symbol_Bound (Bound_Type_Symbol (
+                                     Do_Identifier (Bound)));
+            Ok := True;
+            when others =>
+               null;
+         end case;
+      end Set_Bound_Value;
+
       Lower_Bound : constant Node_Id := Low_Bound (Range_Expr);
       Upper_Bound : constant Node_Id := High_Bound (Range_Expr);
 
       Lower_Bound_Value : Integer;
       Upper_Bound_Value : Integer;
+
+      Ok : Boolean;
 
       Result_Type : constant Irep :=
         New_Irep (if Kind (Resolved_Underlying) = I_Ada_Mod_Type
@@ -776,35 +811,40 @@ package body Tree_Walk is
                                         "range expression not bitvector type");
       end if;
 
-      case Nkind (Lower_Bound) is
-         when N_Integer_Literal => Lower_Bound_Value :=
-              Store_Nat_Bound (Bound_Type_Nat (Intval (Lower_Bound)));
-         when N_Attribute_Reference => Lower_Bound_Value :=
-              Store_Symbol_Bound (Get_Array_Attr_Bound_Symbol (Lower_Bound));
-         when N_Identifier =>
-            Lower_Bound_Value :=
-              Store_Symbol_Bound (Bound_Type_Symbol (
-                                   Do_Identifier (Lower_Bound)));
-         when others =>
-            Report_Unhandled_Node_Empty (Lower_Bound,
-                                         "Do_Base_Range_Constraint",
-                                         "unsupported lower range kind");
-      end case;
+      if Is_OK_Static_Range (Range_Expr) then
+         Set_Bound_Value (Lower_Bound, Lower_Bound_Value, Ok);
+         if not Ok then
+            return Report_Unhandled_Node_Type
+              (Lower_Bound,
+               "Do_Base_Range_Constraint",
+               "unsupported lower range kind");
+         end if;
+         Set_Bound_Value (Upper_Bound, Upper_Bound_Value, Ok);
+         if not Ok then
+            return Report_Unhandled_Node_Type
+              (Lower_Bound,
+               "Do_Range_Constraint",
+               "unsupported upper range kind");
+         end if;
 
-      case Nkind (Upper_Bound) is
-         when N_Integer_Literal => Upper_Bound_Value :=
-              Store_Nat_Bound (Bound_Type_Nat (Intval (Upper_Bound)));
-         when N_Attribute_Reference => Upper_Bound_Value :=
-              Store_Symbol_Bound (Get_Array_Attr_Bound_Symbol (Upper_Bound));
-         when N_Identifier =>
-            Upper_Bound_Value :=
-              Store_Symbol_Bound (Bound_Type_Symbol (
-                                   Do_Identifier (Upper_Bound)));
-         when others =>
-            Report_Unhandled_Node_Empty (Upper_Bound,
-                                         "Do_Base_Range_Constraint",
-                                         "unsupported upper range kind");
-      end case;
+      elsif Nkind (Lower_Bound) = N_Attribute_Reference and then
+        (Get_Attribute_Id (Attribute_Name (Lower_Bound)) =
+           Attribute_First and
+             (Get_Attribute_Id (Attribute_Name (Upper_Bound))) =
+             Attribute_Last)
+      then
+         Lower_Bound_Value :=
+           Store_Symbol_Bound
+             (Get_Array_Attr_Bound_Symbol (Lower_Bound));
+         Upper_Bound_Value :=
+           Store_Symbol_Bound (Get_Array_Attr_Bound_Symbol (Upper_Bound));
+      else
+         return Report_Unhandled_Node_Type
+           (Lower_Bound,
+            "Do_Range_Constraint",
+            "only static ranges are supported");
+
+      end if;
 
       if Kind (Resolved_Underlying) = I_C_Enum_Type then
          Set_Width (Result_Type,

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -113,9 +113,6 @@ package body Tree_Walk is
    with Pre  => Nkind (N) = N_Handled_Sequence_Of_Statements,
         Post => Kind (Do_Handled_Sequence_Of_Statements'Result) = I_Code_Block;
 
-   function Do_Identifier (N : Node_Id) return Irep
-   with Pre  => Nkind (N) in N_Identifier | N_Expanded_Name;
-
    function Do_If_Statement (N : Node_Id) return Irep
    with Pre  => Nkind (N) = N_If_Statement,
         Post => Kind (Do_If_Statement'Result) = I_Code_Ifthenelse;
@@ -230,11 +227,6 @@ package body Tree_Walk is
    function Do_Record_Definition (N : Node_Id; Discs : List_Id) return Irep
    with Pre  => Nkind (N) in N_Record_Definition | N_Variant,
         Post => Kind (Do_Record_Definition'Result) = I_Struct_Type;
-
-   function Do_Selected_Component (N : Node_Id) return Irep
-   with Pre  => Nkind (N) = N_Selected_Component,
-        Post => Kind (Do_Selected_Component'Result) in
-          I_Member_Expr | I_Op_Comma;
 
    function Do_Signed_Integer_Definition (N : Node_Id) return Irep
    with Pre  => Nkind (N) = N_Signed_Integer_Type_Definition,
@@ -3847,7 +3839,8 @@ package body Tree_Walk is
       Ok : Boolean;
 
       Result_Type : constant Irep :=
-        New_Irep (if Kind (Resolved_Underlying) = I_Ada_Mod_Type
+        New_Irep (if Kind (Resolved_Underlying) = I_Ada_Mod_Type or
+                      Kind (Resolved_Underlying) = I_Unsignedbv_Type
                     then I_Bounded_Unsignedbv_Type
                     else I_Bounded_Signedbv_Type);
    begin

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -4,7 +4,6 @@ with Sem;
 with Sem_Eval;              use Sem_Eval;
 with Sem_Util;              use Sem_Util;
 with Sem_Aux;               use Sem_Aux;
---  with Sem_Eval;              use Sem_Eval;
 with Snames;                use Snames;
 with Stringt;               use Stringt;
 with Treepr;                use Treepr;

--- a/gnat2goto/driver/tree_walk.ads
+++ b/gnat2goto/driver/tree_walk.ads
@@ -136,9 +136,9 @@ package Tree_Walk is
                                         Fun_Name : String;
                                         Message : String) return Irep;
 
-   function Do_Bare_Range_Constraint (Range_Expr : Node_Id; Underlying : Irep)
-                                      return Irep
-     with Pre => Nkind (Range_Expr) = N_Range;
+   function Do_Range_Constraint (N : Node_Id; Underlying : Irep)
+                                 return Irep
+     with Pre => Nkind (Range_Expression (N)) = N_Range;
 
    procedure Append_Declare_And_Init
      (Symbol : Irep; Value : Irep; Block : Irep; Source_Loc : Source_Ptr)

--- a/gnat2goto/driver/tree_walk.ads
+++ b/gnat2goto/driver/tree_walk.ads
@@ -147,4 +147,12 @@ package Tree_Walk is
    function Create_Dummy_Irep return Irep;
 
    function Make_Type_Symbol (Name : Symbol_Id; Defn : Irep) return Symbol;
+
+   function Do_Identifier (N : Node_Id) return Irep
+     with Pre  => Nkind (N) in N_Identifier | N_Expanded_Name;
+
+   function Do_Selected_Component (N : Node_Id) return Irep
+   with Pre  => Nkind (N) = N_Selected_Component,
+        Post => Kind (Do_Selected_Component'Result) in
+          I_Member_Expr | I_Op_Comma;
 end Tree_Walk;

--- a/testsuite/gnat2goto/tests/range_over_subtype/test.adb
+++ b/testsuite/gnat2goto/tests/range_over_subtype/test.adb
@@ -1,0 +1,35 @@
+procedure Test is
+   type Unsigned_16 is mod 2**16;
+   NUMBER_ADC_CHANNELS : constant := 2 ** 12;
+   subtype Data_Channel_Number is Unsigned_16 range
+     0 .. NUMBER_ADC_CHANNELS - 1;
+
+   type Peak_Record_Type is
+      record
+--         Centre_Channel             : Data_Channel_Number;
+         Low_Channel  : Data_Channel_Number;
+         High_Channel : Data_Channel_Number;
+      end record;
+
+   Peak_Boundaries : Peak_Record_Type;
+
+   Int_Var : Unsigned_16 := 0;
+
+   procedure Foo (Peaks : Peak_Record_Type) is
+   begin
+      for I in Data_Channel_Number range
+        Peaks.Low_Channel ..
+        Peaks.High_Channel + 4 loop
+
+         Int_Var := Int_Var + I;
+      end loop;
+
+      pragma Assert (Int_Var = 15);
+
+   end Foo;
+begin
+   Peak_Boundaries.Low_Channel := 2;
+   Peak_Boundaries.High_Channel := 8;
+
+   Foo (Peak_Boundaries);
+end Test;

--- a/testsuite/gnat2goto/tests/range_over_subtype/test.out
+++ b/testsuite/gnat2goto/tests/range_over_subtype/test.out
@@ -1,0 +1,2 @@
+[1] file test.adb line 27 assertion: FAILURE
+VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/range_over_subtype/test.py
+++ b/testsuite/gnat2goto/tests/range_over_subtype/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
Note that commits 5,6 are from prerequisite PR #280 -- no need to review them here. On top of #277 I only added a simple case analysis for mod-subtype bounds (7th commit). Now there are no constraint-related issues in UKNI.