### PR TITLE
Refactor/remove New_Irep from driver.adb

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -1765,7 +1765,7 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:114|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:117|
 Error detected at REDACTED
 --
 Occurs: 1 times

--- a/experiments/golden-results/muen-summary.txt
+++ b/experiments/golden-results/muen-summary.txt
@@ -3030,7 +3030,7 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:114|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:117|
 Error detected at REDACTED
 --
 Occurs: 1 times

--- a/gnat2goto/driver/driver.adb
+++ b/gnat2goto/driver/driver.adb
@@ -416,11 +416,6 @@ package body Driver is
                others => <>);
             Initial_Call_Args : constant Irep := Make_Argument_List;
             Entry_Procedure : constant Irep := Symbol_Expr (Program_Symbol);
-            Initial_Call      : constant Irep := Make_Code_Function_Call
-              (Arguments => Initial_Call_Args,
-               I_Function => Entry_Procedure,
-               Source_Location => No_Location);
-
             Program_Args : constant Irep_List :=
               Get_Parameter (Get_Parameters (Get_Type (Entry_Procedure)));
          begin
@@ -470,7 +465,6 @@ package body Driver is
                   C := List_Next (Program_Args, C);
                end loop;
             end;
-            Set_Arguments (Initial_Call, Initial_Call_Args);
             --  Catch the call's return value if it has one
             if Kind (Get_Return_Type (Get_Type (Entry_Procedure)))
               /= I_Empty
@@ -488,18 +482,18 @@ package body Driver is
                   Return_Decl : constant Irep := Make_Code_Decl
                     (Symbol => Return_Expr,
                      Source_Location => No_Location);
+                  Initial_Call      : constant Irep := Make_Code_Function_Call
+                    (Arguments => Initial_Call_Args,
+                     I_Function => Entry_Procedure,
+                     Source_Location => No_Location,
+                     Lhs => Return_Expr);
                begin
                   Global_Symbol_Table.Insert (Return_Id, Return_Symbol);
-
-                  Set_Identifier (Return_Expr, Unintern (Return_Id));
-                  Set_Type (Return_Expr, Return_Symbol.SymType);
-                  Set_Lhs (Initial_Call, Return_Expr);
-                  Set_Symbol (Return_Decl, Return_Expr);
                   Append_Op (Start_Body, Return_Decl);
+                  Append_Op (Start_Body, Initial_Call);
                end;
             end if;
             Global_Symbol_Table.Insert (Start_Name, Start_Symbol);
-            Append_Op (Start_Body, Initial_Call);
          end;
       end if;
 

--- a/gnat2goto/driver/driver.adb
+++ b/gnat2goto/driver/driver.adb
@@ -59,18 +59,17 @@ package body Driver is
 
    procedure Add_Malloc_Symbol is
       Malloc_Name : constant String := "malloc";
-      Malloc_Params : constant Irep := New_Irep (I_Parameter_List);
+      Malloc_Params : constant Irep := Make_Parameter_List;
       Size_Param : constant Irep :=
         Create_Fun_Parameter (Fun_Name        => Malloc_Name,
                               Param_Name      => "size",
-                              Param_Type      =>
-                           Make_Symbol_Type (Identifier => "__CPROVER_size_t"),
+                              Param_Type      => CProver_Size_T,
                               Param_List      => Malloc_Params,
                               A_Symbol_Table  => Global_Symbol_Table);
       Malloc_Type : constant Irep :=
         Make_Code_Type (Parameters  => Malloc_Params,
                         Ellipsis    => False,
-                        Return_Type => Make_Pointer_Type (Make_Void_Type),
+                        Return_Type => Make_Pointer_Type (CProver_Void_T),
                         Inlined     => False,
                         Knr         => False);
       Malloc_Symbol : Symbol;
@@ -89,26 +88,25 @@ package body Driver is
 
    procedure Add_Memcpy_Symbol is
       Memcpy_Name : constant String := "memcpy";
-      Memcpy_Params : constant Irep := New_Irep (I_Parameter_List);
+      Memcpy_Params : constant Irep := Make_Parameter_List;
       Destination_Param : constant Irep :=
         Create_Fun_Parameter (Fun_Name        => Memcpy_Name,
                               Param_Name      => "destination",
                               Param_Type      =>
-                                Make_Pointer_Type (Make_Void_Type),
+                                Make_Pointer_Type (CProver_Void_T),
                               Param_List      => Memcpy_Params,
                               A_Symbol_Table  => Global_Symbol_Table);
       Source_Param : constant Irep :=
         Create_Fun_Parameter (Fun_Name        => Memcpy_Name,
                               Param_Name      => "source",
                               Param_Type      =>
-                                Make_Pointer_Type (Make_Void_Type),
+                                Make_Pointer_Type (CProver_Void_T),
                               Param_List      => Memcpy_Params,
                               A_Symbol_Table  => Global_Symbol_Table);
       Num_Param : constant Irep :=
         Create_Fun_Parameter (Fun_Name        => Memcpy_Name,
                               Param_Name      => "num",
-                              Param_Type      =>
-                           Make_Symbol_Type (Identifier => "__CPROVER_size_t"),
+                              Param_Type      => CProver_Size_T,
                               Param_List      => Memcpy_Params,
                               A_Symbol_Table  => Global_Symbol_Table);
       Memcpy_Type : constant Irep :=
@@ -355,16 +353,6 @@ package body Driver is
    is
       pragma Assert (Nkind (GNAT_Root) = N_Compilation_Unit);
 
-      Void_Type : constant Irep := New_Irep (I_Void_Type);
-
-      Start_Name : constant Symbol_Id := Intern ("__CPROVER__start");
-
-      Start_Symbol      : Symbol;
-      Start_Type        : constant Irep := New_Irep (I_Code_Type);
-      Start_Body        : constant Irep := New_Irep (I_Code_Block);
-      Initial_Call      : constant Irep := New_Irep (I_Code_Function_Call);
-      Initial_Call_Args : constant Irep := New_Irep (I_Argument_List);
-
       Unit_Is_Subprogram : Boolean;
       Program_Symbol : constant Symbol :=
         Do_Compilation_Unit (GNAT_Root, Unit_Is_Subprogram);
@@ -407,21 +395,36 @@ package body Driver is
          end loop;
       end;
 
-      if not Add_Start then
-         Sanitise_Type_Declarations (Global_Symbol_Table,
-                                     Sanitised_Symbol_Table);
-         Put_Line (Sym_Tab_File,
-                   SymbolTable2Json (Sanitised_Symbol_Table).Write (False));
-      else
-         Initialize_CProver_Internal_Variables (Start_Body);
+      if Add_Start
+      then
          declare
-            Program_Expr : constant Irep := New_Irep (I_Symbol_Expr);
-            Program_Type : constant Irep := Program_Symbol.SymType;
-            Program_Return_Type : constant Irep :=
-              Get_Return_Type (Program_Type);
+            Start_Name : constant Symbol_Id := Intern ("__CPROVER__start");
+
+            Start_Type        : constant Irep := Make_Code_Type
+              (Return_Type => CProver_Void_T,
+               Parameters => Make_Parameter_List,
+               Ellipsis => False,
+               Inlined => False,
+               Knr => False);
+            Start_Body        : constant Irep := Make_Code_Block
+              (Source_Location => No_Location);
+            Start_Symbol      : constant Symbol :=
+              (Name | PrettyName | BaseName => Start_Name,
+               SymType => Start_Type,
+               Value => Start_Body,
+               Mode => Intern ("C"),
+               others => <>);
+            Initial_Call_Args : constant Irep := Make_Argument_List;
+            Entry_Procedure : constant Irep := Symbol_Expr (Program_Symbol);
+            Initial_Call      : constant Irep := Make_Code_Function_Call
+              (Arguments => Initial_Call_Args,
+               I_Function => Entry_Procedure,
+               Source_Location => No_Location);
+
             Program_Args : constant Irep_List :=
-              Get_Parameter (Get_Parameters (Program_Type));
+              Get_Parameter (Get_Parameters (Get_Type (Entry_Procedure)));
          begin
+            Initialize_CProver_Internal_Variables (Start_Body);
             --  Generate a simple _start function that calls the entry point
             declare
                C : List_Cursor := List_First (Program_Args);
@@ -435,59 +438,57 @@ package body Driver is
                      Arg_Type : constant Irep := Get_Type (Arg);
                      Arg_Id   : constant Symbol_Id :=
                        Intern ("input_" &  Get_Identifier (Arg));
-                     Arg_Symbol : Symbol;
+                     Arg_Symbol : constant Symbol :=
+                       (Name | PrettyName | BaseName => Arg_Id,
+                        Mode => Intern ("C"),
+                        SymType => Arg_Type,
+                        IsStateVar | IsLValue | IsAuxiliary => True,
+                        others => <>);
 
                      Arg_Symbol_Expr : constant Irep :=
-                       New_Irep (I_Symbol_Expr);
-                     Arg_Decl        : constant Irep :=
-                       New_Irep (I_Code_Decl);
+                       Symbol_Expr (Arg_Symbol);
+                     Arg_Decl        : constant Irep := Make_Code_Decl
+                       (Symbol => Arg_Symbol_Expr,
+                        Source_Location => No_Location);
                      Arg_Nondet      : constant Irep :=
-                       New_Irep (I_Side_Effect_Expr_Nondet);
-                     Arg_Assign      : constant Irep :=
-                       New_Irep (I_Code_Assign);
+                       Make_Side_Effect_Expr_Nondet
+                       (I_Type => Arg_Symbol.SymType,
+                        Source_Location => No_Location);
+                     Arg_Assign      : constant Irep := Make_Code_Assign
+                       (Lhs => Arg_Symbol_Expr,
+                        Rhs => Arg_Nondet,
+                        Source_Location => No_Location);
 
                   begin
-                     Arg_Symbol.Name        := Arg_Id;
-                     Arg_Symbol.PrettyName  := Arg_Id;
-                     Arg_Symbol.BaseName    := Arg_Id;
-                     Arg_Symbol.Mode        := Intern ("C");
-                     Arg_Symbol.SymType     := Arg_Type;
-                     Arg_Symbol.IsStateVar  := True;
-                     Arg_Symbol.IsLValue    := True;
-                     Arg_Symbol.IsAuxiliary := True;
                      Global_Symbol_Table.Insert (Arg_Id, Arg_Symbol);
 
-                     Set_Identifier (Arg_Symbol_Expr, Unintern (Arg_Id));
-                     Set_Type       (Arg_Symbol_Expr, Arg_Type);
-
-                     Set_Symbol (Arg_Decl, Arg_Symbol_Expr);
-                     Append_Op  (Start_Body, Arg_Decl);
-
-                     Set_Type (Arg_Nondet, Arg_Type);
-                     Set_Lhs  (Arg_Assign, Arg_Symbol_Expr);
-                     Set_Rhs  (Arg_Assign, Arg_Nondet);
-
-                     Append_Op (Start_Body, Arg_Assign);
-
                      Append_Argument (Initial_Call_Args, Arg_Symbol_Expr);
+
+                     Append_Op  (Start_Body, Arg_Decl);
+                     Append_Op (Start_Body, Arg_Assign);
                   end;
                   C := List_Next (Program_Args, C);
                end loop;
             end;
             Set_Arguments (Initial_Call, Initial_Call_Args);
             --  Catch the call's return value if it has one
-            if Kind (Program_Return_Type) /= I_Empty then
+            if Kind (Get_Return_Type (Get_Type (Entry_Procedure)))
+              /= I_Empty
+            then
                declare
-                  Return_Symbol : Symbol;
-                  Return_Expr : constant Irep := New_Irep (I_Symbol_Expr);
-                  Return_Decl : constant Irep := New_Irep (I_Code_Decl);
                   Return_Id   : constant Symbol_Id := Intern ("return'");
+                  Return_Symbol : constant Symbol :=
+                    (Name | BaseName | PrettyName => Return_Id,
+                     Mode => Intern ("C"),
+                     SymType => Get_Return_Type (Get_Type (Entry_Procedure)),
+                     IsLValue => True,
+                     IsStaticLifetime => True,
+                     others => <>);
+                  Return_Expr : constant Irep := Symbol_Expr (Return_Symbol);
+                  Return_Decl : constant Irep := Make_Code_Decl
+                    (Symbol => Return_Expr,
+                     Source_Location => No_Location);
                begin
-                  Return_Symbol.Name       := Return_Id;
-                  Return_Symbol.BaseName   := Return_Id;
-                  Return_Symbol.PrettyName := Return_Id;
-                  Return_Symbol.Mode       := Intern ("C");
-                  Return_Symbol.SymType    := Program_Return_Type;
                   Global_Symbol_Table.Insert (Return_Id, Return_Symbol);
 
                   Set_Identifier (Return_Expr, Unintern (Return_Id));
@@ -497,33 +498,17 @@ package body Driver is
                   Append_Op (Start_Body, Return_Decl);
                end;
             end if;
-
-            Set_Identifier (Program_Expr, Unintern (Program_Symbol.Name));
-            Set_Type (Program_Expr, Program_Symbol.SymType);
-
-            Set_Function (Initial_Call, Program_Expr);
+            Global_Symbol_Table.Insert (Start_Name, Start_Symbol);
+            Append_Op (Start_Body, Initial_Call);
          end;
-
-         Append_Op (Start_Body, Initial_Call);
-
-         Start_Symbol.Name       := Start_Name;
-         Start_Symbol.PrettyName := Start_Name;
-         Start_Symbol.BaseName   := Start_Name;
-
-         Set_Return_Type (Start_Type, Void_Type);
-
-         Start_Symbol.SymType := Start_Type;
-         Start_Symbol.Value   := Start_Body;
-         Start_Symbol.Mode    := Intern ("C");
-
-         Global_Symbol_Table.Insert (Start_Name, Start_Symbol);
-         Sanitise_Type_Declarations (Global_Symbol_Table,
-                                     Sanitised_Symbol_Table);
-         Put_Line (Sym_Tab_File,
-                   SymbolTable2Json (Sanitised_Symbol_Table).Write (False));
       end if;
 
+      Sanitise_Type_Declarations (Global_Symbol_Table,
+                                  Sanitised_Symbol_Table);
+      Put_Line (Sym_Tab_File,
+                SymbolTable2Json (Sanitised_Symbol_Table).Write (False));
       Close (Sym_Tab_File);
+
    end Translate_Compilation_Unit;
 
    function Is_Back_End_Switch (Switch : String) return Boolean is
@@ -588,65 +573,74 @@ package body Driver is
 
       procedure Add_CProver_Size_T;
       procedure Add_CProver_Size_T is
-         Builtin   : Symbol;
-         Type_Irep : constant Irep := New_Irep (I_Unsignedbv_Type);
+         Size_T : constant Irep := Make_Unsignedbv_Type
+           (Width => 64);
+         Size_T_Symbol   : constant Symbol :=
+           (Name | PrettyName | BaseName => Intern ("__CPROVER_size_t"),
+            SymType => Size_T,
+            IsType => True,
+            others => <>);
       begin
-         Set_Width (Type_Irep, 64);
-         Builtin.Name       := Intern ("__CPROVER_size_t");
-         Builtin.PrettyName := Builtin.Name;
-         Builtin.BaseName   := Builtin.Name;
-         Builtin.SymType    := Type_Irep;
-         Builtin.IsType     := True;
-
-         Global_Symbol_Table.Insert (Builtin.Name, Builtin);
+         Global_Symbol_Table.Insert (Size_T_Symbol.Name, Size_T_Symbol);
       end Add_CProver_Size_T;
+
+      function Get_Bv_Width (Type_Node : Node_Id) return Integer;
+      function Get_Bv_Width (Type_Node : Node_Id) return Integer
+        is (Integer (UI_To_Int (Esize (Type_Node))));
+      function Translate_Signed_Type (Type_Node : Node_Id)
+        return Irep;
+      function Translate_Enum_Type (Type_Node : Node_Id)
+        return Irep;
+      function Translate_Floating_Type (Type_Node : Node_Id)
+        return Irep;
+      Translated_Boolean_Type : constant Irep := CProver_Bool_T;
+
+      function Translate_Signed_Type (Type_Node : Node_Id)
+                                     return Irep
+      is (Make_Signedbv_Type
+            (Width => Get_Bv_Width (Type_Node)));
+
+      function Translate_Enum_Type (Type_Node : Node_Id)
+                                   return Irep
+      is (Make_Unsignedbv_Type
+            (Width => Get_Bv_Width (Type_Node)));
+
+      function Translate_Floating_Type (Type_Node : Node_Id)
+                                       return Irep
+      is
+         Width : constant Integer :=  Get_Bv_Width (Type_Node);
+         Mantissa_Size : constant Integer := Float_Mantissa_Size (Width);
+      begin
+         return Make_Floatbv_Type
+           (Width => Width,
+            F => Mantissa_Size);
+      end Translate_Floating_Type;
    begin
       --  Add primitive types to the symtab
+      --  XXX if we properly support processing Standard
+      --      this will become (mostly) redundant
       for Standard_Type in S_Types'Range loop
          declare
             Builtin_Node : constant Node_Id := Standard_Entity (Standard_Type);
-
-            Type_Kind : constant Irep_Kind :=
-              (case Ekind (Builtin_Node) is
-                 when E_Floating_Point_Type    => I_Floatbv_Type,
-                 when E_Signed_Integer_Subtype => I_Signedbv_Type,
-                 when E_Enumeration_Type       =>
-                                                (if Standard_Type /= S_Boolean
-                                                then I_Unsignedbv_Type
-                                                else I_Bool_Type),
-                 when others                   => I_Empty);
-
+            Translated_Type : constant Irep := (case Ekind (Builtin_Node) is
+               when E_Floating_Point_Type =>
+                  Translate_Floating_Type (Builtin_Node),
+               when E_Signed_Integer_Subtype =>
+                  Translate_Signed_Type (Builtin_Node),
+               when E_Enumeration_Type =>
+                  (if Standard_Type /= S_Boolean
+                     then Translate_Enum_Type (Builtin_Node)
+                     else Translated_Boolean_Type),
+               when others => CProver_Nil_T);
+            Type_Symbol : constant Symbol :=
+            (Name | PrettyName | BaseName =>
+                Intern (Unique_Name (Builtin_Node)),
+             SymType => Translated_Type,
+             IsType => True,
+             others => <>);
          begin
-            if Type_Kind /= I_Empty then
-               declare
-                  Type_Irep : constant Irep := New_Irep (Type_Kind);
-                  Builtin   : Symbol;
-
-                  Esize_Width : constant Nat :=
-                    UI_To_Int (Esize (Builtin_Node));
-
-               begin
-                  if Kind (Type_Irep) in Class_Bitvector_Type then
-                     Set_Width (Type_Irep, Integer (Esize_Width));
-                  end if;
-
-                  if Type_Kind = I_Floatbv_Type then
-                     --  Ada's floating-point types are interesting, as they're
-                     --  specified in terms of decimal precision. Entirely too
-                     --  interesting for now... Let's use float32 or float64
-                     --  for now and fix this later.
-
-                     Set_F (Type_Irep, Float_Mantissa_Size (Type_Irep));
-                  end if;
-
-                  Builtin.Name       := Intern (Unique_Name (Builtin_Node));
-                  Builtin.PrettyName := Builtin.Name;
-                  Builtin.BaseName   := Builtin.Name;
-                  Builtin.SymType    := Type_Irep;
-                  Builtin.IsType     := True;
-
-                  Global_Symbol_Table.Insert (Builtin.Name, Builtin);
-               end;
+            if Kind (Translated_Type) /= I_Nil_Type then
+               Global_Symbol_Table.Insert (Type_Symbol.Name, Type_Symbol);
             end if;
          end;
       end loop;
@@ -705,6 +699,7 @@ package body Driver is
             Modified_Symbol.SymType :=
               Remove_Extra_Type_Information
               (Follow_Irep (SymType, Follow_Symbol'Access));
+
             Modified_Symbol.Value :=
               Remove_Extra_Type_Information
               (Follow_Irep (Value, Follow_Symbol'Access));

--- a/gnat2goto/driver/goto_utils.adb
+++ b/gnat2goto/driver/goto_utils.adb
@@ -18,6 +18,36 @@ package body GOTO_Utils is
       return Size_T;
    end CProver_Size_T;
 
+   Void_T : Irep := Ireps.Empty;
+   function CProver_Void_T return Irep
+   is
+   begin
+      if Void_T = Ireps.Empty then
+         Void_T := Make_Void_Type;
+      end if;
+      return Void_T;
+   end CProver_Void_T;
+
+   Nil_T : Irep := Ireps.Empty;
+   function CProver_Nil_T return Irep
+   is
+   begin
+      if Nil_T = Ireps.Empty then
+         Nil_T := Make_Nil_Type;
+      end if;
+      return Nil_T;
+   end CProver_Nil_T;
+
+   Bool_T : Irep := Ireps.Empty;
+   function CProver_Bool_T return Irep
+   is
+   begin
+      if Bool_T = Ireps.Empty then
+         Bool_T := Make_Bool_Type;
+      end if;
+      return Bool_T;
+   end CProver_Bool_T;
+
    ---------------------
    -- Make_Address_Of --
    ---------------------
@@ -379,9 +409,8 @@ package body GOTO_Utils is
                                Last       => Last);
    end Build_Array_Size;
 
-   function To_Float_Format (Float_Type : Irep) return Float_Format
+   function To_Float_Format (Float_Width : Integer) return Float_Format
    is
-      Float_Width : constant Integer := Get_Width (Float_Type);
       Unsupported_Float_Width : exception;
    begin
       case Float_Width is
@@ -393,9 +422,9 @@ package body GOTO_Utils is
       end case;
    end To_Float_Format;
 
-   function Float_Mantissa_Size (Float_Type : Irep) return Integer
+   function Float_Mantissa_Size (Float_Width : Integer) return Integer
    is
-      Format : constant Float_Format := To_Float_Format (Float_Type);
+      Format : constant Float_Format := To_Float_Format (Float_Width);
    begin
       case Format is
          when IEEE_32_Bit =>

--- a/gnat2goto/driver/goto_utils.ads
+++ b/gnat2goto/driver/goto_utils.ads
@@ -10,6 +10,9 @@ package GOTO_Utils is
    type Irep_Array is array (Integer range <>) of Irep;
 
    function CProver_Size_T return Irep;
+   function CProver_Void_T return Irep;
+   function CProver_Nil_T return Irep;
+   function CProver_Bool_T return Irep;
 
    --  Utility routines for high-level GOTO AST construction
 
@@ -115,10 +118,9 @@ package GOTO_Utils is
 
    type Float_Format is (IEEE_32_Bit, IEEE_64_Bit);
 
-   function To_Float_Format (Float_Type : Irep) return Float_Format
-     with Pre => Kind (Float_Type) in I_Floatbv_Type | I_Bounded_Floatbv_Type;
+   function To_Float_Format (Float_Width : Integer) return Float_Format;
 
-   function Float_Mantissa_Size (Float_Type : Irep) return Integer;
+   function Float_Mantissa_Size (Float_Width : Integer) return Integer;
 
    function Build_Index_Constant (Value : Int;
                                   Source_Loc : Source_Ptr) return Irep;

--- a/gnat2goto/driver/range_check.adb
+++ b/gnat2goto/driver/range_check.adb
@@ -340,7 +340,8 @@ package body Range_Check is
    function Load_Real_Bound_In_Hex (Index : Integer; Actual_Type : Irep)
                                     return String
    is
-      Bit_Width : constant Float_Format := To_Float_Format (Actual_Type);
+      Bit_Width : constant Float_Format :=
+        To_Float_Format (Get_Width (Actual_Type));
       Bound : constant Ureal :=
         Ureal (Real_Bounds_Table.Element (Index));
    begin

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -4200,7 +4200,7 @@ package body Tree_Walk is
       Esize_Width : constant Nat := UI_To_Int (Esize (E));
    begin
       Set_Width (Ret, Integer (Esize_Width));
-      Set_F (Ret, Float_Mantissa_Size (Ret));
+      Set_F (Ret, Float_Mantissa_Size (Get_Width (Ret)));
 
       --  If user specified range bounds we store them
       if Nkind (Scalar_Range_Ent) = N_Real_Range_Specification then


### PR DESCRIPTION
`New_Irep`, and generally using the `Set_*` stuff is a nuisance for maintainability, as any change to the allowed and required fields will not be noticed at compile time. This is the first PR among a series of PRs with the goal of purging it from the codebase entirely and eventually removing it.

This is also preparatory work to fix a long standing issue of assertions just having their assertion number and source locations, but no text or human readable condition.

Also adds/changes some utility functions (particularly float format related stuff now gets passed the width of the floating point type directly rather than an Irep which we only use to get the width).