### PR TITLE
Add index check

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -129,6 +129,11 @@ Error message: Generic declaration
 Nkind: N_Generic_Package_Declaration
 --
 Occurs: 3 times
+Calling function: Do_Constant
+Error message: Unsupported constant type
+Nkind: N_Integer_Literal
+--
+Occurs: 3 times
 Calling function: Do_Expression
 Error message: ATTRIBUTE_FLOOR unsupported
 Nkind: N_Attribute_Reference
@@ -142,11 +147,6 @@ Occurs: 3 times
 Calling function: Process_Declaration
 Error message: Generic instantiation declaration
 Nkind: N_Package_Instantiation
---
-Occurs: 2 times
-Calling function: Do_Constant
-Error message: Constant Type not in symbol table
-Nkind: N_Integer_Literal
 --
 Occurs: 2 times
 Calling function: Do_Derived_Type_Definition
@@ -187,11 +187,6 @@ Occurs: 1 times
 Calling function: Do_Compilation_Unit
 Error message: Generic units are unsupported
 Nkind: N_Compilation_Unit
---
-Occurs: 1 times
-Calling function: Do_Constant
-Error message: Constant Type not in Class_Bitvector_Type
-Nkind: N_Integer_Literal
 --
 Occurs: 1 times
 Calling function: Do_Expression
@@ -2205,47 +2200,47 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
@@ -2325,7 +2320,7 @@ raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from arrays.ads:57
 --
 Occurs: 2 times
 <========================>
-raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from range_check.ads:50
+raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from range_check.ads:54
 
 --
 Occurs: 1 times

--- a/experiments/golden-results/libkeccak-summary.txt
+++ b/experiments/golden-results/libkeccak-summary.txt
@@ -60,7 +60,7 @@ Raw compiler error message:
 --
 Occurs: 23 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 2 times
@@ -70,122 +70,122 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:54|
 Error detected at REDACTED
 --
 Occurs: 1 times

--- a/experiments/golden-results/muen-summary.txt
+++ b/experiments/golden-results/muen-summary.txt
@@ -125,7 +125,7 @@ Nkind: N_Object_Renaming_Declaration
 --
 Occurs: 1 times
 Calling function: Do_Constant
-Error message: Constant Type not in symbol table
+Error message: Unsupported constant type
 Nkind: N_Integer_Literal
 --
 Occurs: 1 times

--- a/experiments/golden-results/vct-summary.txt
+++ b/experiments/golden-results/vct-summary.txt
@@ -295,5 +295,5 @@ Error detected at REDACTED
 --
 Occurs: 2 times
 <========================>
-raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from range_check.ads:50
+raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from range_check.ads:54
 

--- a/gnat2goto/driver/arrays.ads
+++ b/gnat2goto/driver/arrays.ads
@@ -85,9 +85,6 @@ private
    function Make_Array_First_Expr
      (Base_Type : Node_Id; Base_Irep : Irep) return Irep;
 
-   function Make_Array_Index_Op
-     (Base_Irep : Irep; Idx_Irep : Irep) return Irep;
-
    function Build_Array_Size (First : Irep; Last : Irep; Idx_Type : Irep)
                               return Irep
      with Pre => (Kind (First) in Class_Expr

--- a/gnat2goto/driver/range_check.adb
+++ b/gnat2goto/driver/range_check.adb
@@ -259,6 +259,21 @@ package body Range_Check is
          I_Type          => Value_Type);
    end Make_Div_Zero_Assert_Expr;
 
+   function Make_Index_Assert_Expr (N : Node_Id; Index : Irep;
+                                    First_Index : Irep; Last_Index : Irep)
+                                    return Irep
+   is
+      Index_Type : constant Irep :=
+        Follow_Symbol_Type (Get_Type (Index), Global_Symbol_Table);
+   begin
+      return Make_Range_Assert_Expr (N                    => N,
+                                     Value                => Index,
+                                     Lower_Bound          => First_Index,
+                                     Upper_Bound          => Last_Index,
+                                     Expected_Return_Type => Index_Type,
+                          Check_Name           => "__CPROVER_Ada_Index_Check");
+   end Make_Index_Assert_Expr;
+
    function Make_Overflow_Assert_Expr (N : Node_Id; Value : Irep) return Irep
    is
       Value_Type : constant Irep :=

--- a/gnat2goto/driver/range_check.ads
+++ b/gnat2goto/driver/range_check.ads
@@ -38,6 +38,10 @@ package Range_Check is
    function Make_Div_Zero_Assert_Expr (N : Node_Id; Value : Irep;
                                        Divisor : Irep) return Irep;
 
+   function Make_Index_Assert_Expr (N : Node_Id; Index : Irep;
+                                    First_Index : Irep; Last_Index : Irep)
+                                    return Irep;
+
    function Make_Overflow_Assert_Expr (N : Node_Id; Value : Irep) return Irep;
 
    function Make_Range_Assert_Expr (N : Node_Id; Value : Irep;

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -2972,7 +2972,10 @@ package body Tree_Walk is
       begin
          return Has_Defaulted_Discriminants (E)
            or else Has_Defaulted_Components (E)
-           or else Ekind (E) = E_Array_Subtype;
+           or else Ekind (E) = E_Array_Subtype
+           or else (Ekind (E) = E_Private_Type
+                    and then Present (Full_View (E))
+                    and then Ekind (Full_View (E)) = E_Array_Subtype);
       end Needs_Default_Initialisation;
 
       function Disc_Expr (N : Node_Id) return Node_Id is
@@ -3186,6 +3189,10 @@ package body Tree_Walk is
             return Make_Array_Default_Initialiser (E);
          elsif Ekind (E) in Record_Kind then
             return Make_Record_Default_Initialiser (E, DCs);
+         elsif Ekind (E) in Private_Kind and then Present (Full_View (E))
+           and then Ekind (Full_View (E)) in Array_Kind
+         then
+            return Make_Array_Default_Initialiser (Full_View (E));
          else
             return Report_Unhandled_Node_Irep (E, "Make_Default_Initialiser",
                                                  "Unknown Ekind");

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -1008,54 +1008,33 @@ package body Tree_Walk is
 
    function Do_Constant (N : Node_Id) return Irep is
       Constant_Type : constant Irep := Do_Type_Reference (Etype (N));
-      Is_Integer_Literal : constant Boolean :=
-        Etype (N) = Stand.Universal_Integer;
-      Constant_Resolved_Type : Irep;
-      Constant_Width : Integer := 64;
-      Dummy_Value : constant Irep := Make_Constant_Expr
-        (I_Type => Make_Signedbv_Type (32),
-         Value =>  "00000000000000000000000000000000",
-         Source_Location => Get_Source_Location (N));
+      Int_Val : constant Uint := Intval (N);
+      Source_Loc : constant Irep := Get_Source_Location (N);
    begin
-      if Is_Integer_Literal then
-         Constant_Resolved_Type :=  Constant_Type;
-      else
-         if Kind (Constant_Type) = I_Symbol_Type
-             and then not Global_Symbol_Table.Contains
-               (Intern (Get_Identifier (Constant_Type)))
-         then
-            Report_Unhandled_Node_Empty (N, "Do_Constant",
-                                         "Constant Type not in symbol table");
-            return Dummy_Value;
-         end if;
-         Constant_Resolved_Type := Follow_Symbol_Type (Constant_Type,
-                                                       Global_Symbol_Table);
-      end if;
-
-      if Is_Integer_Literal then
-         null;
-      else
-         if Kind (Constant_Resolved_Type) in Class_Bitvector_Type then
-            Constant_Width := Get_Width (Constant_Resolved_Type);
-         else
-            Report_Unhandled_Node_Empty (N, "Do_Constant",
-                                  "Constant Type not in Class_Bitvector_Type");
-            return Dummy_Value;
-         end if;
-      end if;
-
-      declare
-         Value : constant String :=
-           (if not Is_Integer_Literal
-              then Convert_Uint_To_Hex
-           (Intval (N), Pos (Constant_Width))
-              else UI_Image (Input  => Intval (N), Format => Decimal));
-      begin
+      if Etype (N) = Stand.Universal_Integer then
          return Make_Constant_Expr
-           (Value => Value,
-            I_Type => Constant_Resolved_Type,
-            Source_Location => Get_Source_Location (N));
-      end;
+           (Source_Location => Source_Loc,
+            I_Type          => Constant_Type,
+            Range_Check     => False,
+            Value           => UI_Image (Int_Val, Decimal));
+      end if;
+
+      if not (Kind (Constant_Type) in Class_Bitvector_Type)
+      then
+         Report_Unhandled_Node_Empty (N, "Do_Constant",
+                                      "Unsupported constant type");
+         return Make_Constant_Expr (Source_Location => Source_Loc,
+                                    I_Type          => Constant_Type,
+                                    Range_Check     => False,
+                                    Value           => "0");
+      end if;
+
+      return Make_Constant_Expr
+        (Source_Location => Source_Loc,
+         I_Type          => Constant_Type,
+         Range_Check     => False,
+         Value           =>
+           Convert_Uint_To_Hex (Int_Val, Pos (Get_Width (Constant_Type))));
    end Do_Constant;
 
    ---------------------------

--- a/testsuite/gnat2goto/tests/arrays_access/test.out
+++ b/testsuite/gnat2goto/tests/arrays_access/test.out
@@ -1,5 +1,6 @@
 [precondition_instance.1] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.2] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.3] file <internal> memcpy destination region writeable: SUCCESS
+[assertion.1] file arrays_access.adb line 5 Ada Check assertion: SUCCESS
 [arrays_access.assertion.1] line 6 assertion Actual7(1) = 2: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/arrays_assign_nonoverlap/test.out
+++ b/testsuite/gnat2goto/tests/arrays_assign_nonoverlap/test.out
@@ -19,6 +19,7 @@
 [precondition_instance.7] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.8] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.9] file <internal> memcpy destination region writeable: SUCCESS
+[assertion.1] file arrays_assign_nonoverlap.adb line 8 Ada Check assertion: SUCCESS
 [arrays_assign_nonoverlap.assertion.1] line 8 assertion Full_Arr(1)=3: SUCCESS
 [arrays_assign_nonoverlap.assertion.2] line 9 assertion Full_Arr(2)=4: SUCCESS
 [arrays_assign_nonoverlap.assertion.3] line 10 assertion Full_Arr(3)=1: SUCCESS

--- a/testsuite/gnat2goto/tests/arrays_attributes_static/test.out
+++ b/testsuite/gnat2goto/tests/arrays_attributes_static/test.out
@@ -16,6 +16,7 @@
 [precondition_instance.7] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.8] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.9] file <internal> memcpy destination region writeable: SUCCESS
+[assertion.1] file arrays_attributes_static.adb line 12 Ada Check assertion: SUCCESS
 [arrays_attributes_static.assertion.1] line 16 assertion Array_Attribs = 41: SUCCESS
 [arrays_attributes_static.assertion.2] line 17 assertion An_Index = 12: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/arrays_concat/test.out
+++ b/testsuite/gnat2goto/tests/arrays_concat/test.out
@@ -10,5 +10,6 @@
 [precondition_instance.7] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.8] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.9] file <internal> memcpy destination region writeable: SUCCESS
+[assertion.1] file arrays_concat.adb line 7 Ada Check assertion: SUCCESS
 [arrays_concat.assertion.1] line 7 assertion Actual(2)=4: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/arrays_constraints/test.out
+++ b/testsuite/gnat2goto/tests/arrays_constraints/test.out
@@ -1,5 +1,6 @@
+[assertion.1] file array_constraints.adb line 109 Ada Check assertion: SUCCESS
+[assertion.2] file array_constraints.adb line 117 Ada Check assertion: SUCCESS
 [array_constraints.assertion.1] line 117 assertion VUA1 (1) + VUA2 (2) + VUA3 (3) + VUA4 (4) + VUA5 (5) + VUA6 (6) + VUA7 (7) + VUA8 (8) = 36: SUCCESS
-[assertion.1] line 117 Ada Check assertion: SUCCESS
 [array_constraints.assertion.2] line 131 assertion VCA1 (VCA1'Last) + VCA2 (VCA2'Last - 1) + VCA3 (VCA3'Last - 2) + VCA4 (Constrained_Array_4'Last - 3) = 10: SUCCESS
 [array_constraints.assertion.3] line 143 assertion VEA1 (One) + VEA2 (Two) + VEA3 (Three) + VEA4 (Four) + VEA5 (Five) + VEA6 (Six) = 21: SUCCESS
 [array_constraints.assertion.4] line 154 assertion VBA1 (False) + VBA2 (True) + VBA3 (False) + VBA4 (True) + VBA5 (False) + VBA6 (True) = 7: SUCCESS

--- a/testsuite/gnat2goto/tests/arrays_index/test.out
+++ b/testsuite/gnat2goto/tests/arrays_index/test.out
@@ -1,5 +1,6 @@
 [precondition_instance.1] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.2] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.3] file <internal> memcpy destination region writeable: SUCCESS
+[assertion.1] file arrays_index.adb line 5 Ada Check assertion: SUCCESS
 [arrays_index.assertion.1] line 9 assertion Actual(2) = 11: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/arrays_index_enum/test.out
+++ b/testsuite/gnat2goto/tests/arrays_index_enum/test.out
@@ -1,5 +1,6 @@
 [precondition_instance.1] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.2] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.3] file <internal> memcpy destination region writeable: SUCCESS
+[assertion.1] file test.adb line 7 Ada Check assertion: SUCCESS
 [test.assertion.1] line 7 assertion Array_Value(Two) = 2: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/discriminated_record/test.out
+++ b/testsuite/gnat2goto/tests/discriminated_record/test.out
@@ -1,3 +1,4 @@
+[assertion.1] file discriminated_record.adb line 16 Ada Check assertion: SUCCESS
 [discriminated_record.assertion.1] line 19 assertion Inst1.A (5) = 1: SUCCESS
 [discriminated_record.assertion.2] line 21 assertion Inst1.A (5) = 1: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/enum_in_param/test.out
+++ b/testsuite/gnat2goto/tests/enum_in_param/test.out
@@ -2,4 +2,5 @@
 [precondition_instance.2] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.3] file <internal> memcpy destination region writeable: SUCCESS
 [p_enum_in.assertion.1] line 19 assertion E in More_Than_Two: SUCCESS
+[assertion.1] line 23 Ada Check assertion: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/index_check/main.adb
+++ b/testsuite/gnat2goto/tests/index_check/main.adb
@@ -1,0 +1,10 @@
+procedure Main is
+   type IndexArray is array(1..10) of Integer;
+   AnArray : IndexArray := (others=>5);
+begin
+   for I in 1..12 loop
+      AnArray(I):=6;
+   end loop;
+
+   pragma Assert(AnArray(3)=6);
+end Main;

--- a/testsuite/gnat2goto/tests/index_check/test.out
+++ b/testsuite/gnat2goto/tests/index_check/test.out
@@ -1,5 +1,6 @@
 [precondition_instance.1] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.2] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.3] file <internal> memcpy destination region writeable: SUCCESS
-[assertion.1] file arrays_write_element.adb line 6 Ada Check assertion: SUCCESS
-VERIFICATION SUCCESSFUL
+[assertion.1] file main.adb line 6 Ada Check assertion: FAILURE
+[main.assertion.1] line 9 assertion AnArray(3)=6: SUCCESS
+VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/index_check/test.py
+++ b/testsuite/gnat2goto/tests/index_check/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()

--- a/testsuite/gnat2goto/tests/private_type_dec_array/test.out
+++ b/testsuite/gnat2goto/tests/private_type_dec_array/test.out
@@ -1,1 +1,2 @@
+[assertion.1] file private_dec_array.adb line 5 Ada Check assertion: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/rhs_array_assign/test.out
+++ b/testsuite/gnat2goto/tests/rhs_array_assign/test.out
@@ -7,5 +7,6 @@
 [precondition_instance.7] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.8] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.9] file <internal> memcpy destination region writeable: SUCCESS
+[assertion.1] file rhs_array_assign.adb line 8 Ada Check assertion: SUCCESS
 [rhs_array_assign.assertion.1] line 9 assertion A (5) = 5 and A (1) = 0: SUCCESS
 VERIFICATION SUCCESSFUL


### PR DESCRIPTION
when parsing the `n_indexed_component` node. Using the same methods as for the
range check, i.e. first_index < index < last_index. Includes a test.