### PR TITLE
Remove new irep range check

### DIFF
--- a/testsuite/gnat2goto/tests/arrays_range/test.out
+++ b/testsuite/gnat2goto/tests/arrays_range/test.out
@@ -1,10 +1,10 @@
-[assertion.1] Range Check: FAILURE
-[assertion.2] Range Check: SUCCESS
-[assertion.3] Range Check: FAILURE
 [precondition_instance.1] memcpy src/dst overlap: SUCCESS
 [precondition_instance.2] memcpy source region readable: SUCCESS
 [precondition_instance.3] memcpy destination region writeable: SUCCESS
+[assertion.2] file arrays_range.adb line 8 Range Check: SUCCESS
 [1] file arrays_range.adb line 9 assertion: SUCCESS
+[assertion.3] file arrays_range.adb line 10 Range Check: FAILURE
 [2] file arrays_range.adb line 11 assertion: SUCCESS
+[assertion.1] file arrays_range.adb line 12 Range Check: FAILURE
 [3] file arrays_range.adb line 13 assertion: SUCCESS
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/deferred_constant/test.out
+++ b/testsuite/gnat2goto/tests/deferred_constant/test.out
@@ -1,3 +1,3 @@
-[assertion.1] Range Check: SUCCESS
+[assertion.1] file deferred_const.adb line 4 Range Check: SUCCESS
 [1] file test.adb line 6 assertion: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/floating_definition/test.out
+++ b/testsuite/gnat2goto/tests/floating_definition/test.out
@@ -1,4 +1,4 @@
-[assertion.1] Range Check: SUCCESS
+[assertion.1] file floating_definition.adb line 9 Range Check: SUCCESS
 [1] file floating_definition.adb line 10 assertion: SUCCESS
 [2] file floating_definition.adb line 11 assertion: FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/loop_range_mod_type/test.out
+++ b/testsuite/gnat2goto/tests/loop_range_mod_type/test.out
@@ -1,3 +1,3 @@
-[assertion.1] Range Check: SUCCESS
+[assertion.1] file test.adb line 23 Range Check: SUCCESS
 [1] file test.adb line 31 assertion: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/loop_range_variable/test.out
+++ b/testsuite/gnat2goto/tests/loop_range_variable/test.out
@@ -1,3 +1,3 @@
-[assertion.1] Range Check: SUCCESS
+[assertion.1] file test.adb line 9 Range Check: SUCCESS
 [1] file test.adb line 11 assertion: FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/qualified_expression/test.out
+++ b/testsuite/gnat2goto/tests/qualified_expression/test.out
@@ -1,3 +1,3 @@
-[assertion.1] Range Check: FAILURE
-[assertion.2] Range Check: SUCCESS
+[assertion.2] file qualified_expr.adb line 7 Range Check: SUCCESS
+[assertion.1] file qualified_expr.adb line 7 Range Check: FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/range_check_non_bounded/test.out
+++ b/testsuite/gnat2goto/tests/range_check_non_bounded/test.out
@@ -1,3 +1,3 @@
-[assertion.1] Range Check: SUCCESS
+[assertion.1] file test.adb line 6 Range Check: SUCCESS
 [1] file test.adb line 7 assertion: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/ranges/test.out
+++ b/testsuite/gnat2goto/tests/ranges/test.out
@@ -1,4 +1,4 @@
-[assertion.1] Range Check: FAILURE
-[assertion.2] Range Check: SUCCESS
-[assertion.3] Range Check: FAILURE
+[assertion.2] file ranges.adb line 8 Range Check: SUCCESS
+[assertion.3] file ranges.adb line 9 Range Check: FAILURE
+[assertion.1] file ranges.adb line 11 Range Check: FAILURE
 VERIFICATION FAILED


### PR DESCRIPTION
Substitute references to `New_Irep` with the appropriately typed constructors.