### PR TITLE
Remove New_Irep from Do_Operator_Simple

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -1705,7 +1705,7 @@ Raw compiler error message:
 --
 Occurs: 29 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 6 times
@@ -1720,32 +1720,32 @@ Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:939                      |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:949                      |
 Error detected at REDACTED
 --
 Occurs: 2 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
@@ -1845,362 +1845,362 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
@@ -2250,5 +2250,5 @@ raised CONSTRAINT_ERROR : Symbol_Table_Info.Symbol_Maps.Constant_Reference: key 
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 | Error detected at stm32-exti.adb:47:19                                   |

--- a/experiments/golden-results/libkeccak-summary.txt
+++ b/experiments/golden-results/libkeccak-summary.txt
@@ -55,7 +55,7 @@ Raw compiler error message:
 --
 Occurs: 23 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 2 times
@@ -95,132 +95,132 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times

--- a/experiments/golden-results/libsparkcrypto-summary.txt
+++ b/experiments/golden-results/libsparkcrypto-summary.txt
@@ -255,20 +255,20 @@ Raw compiler error message:
 --
 Occurs: 20 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 2 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED

--- a/experiments/golden-results/muen-summary.txt
+++ b/experiments/golden-results/muen-summary.txt
@@ -3020,12 +3020,12 @@ Error detected at REDACTED
 --
 Occurs: 2 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1426                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1436                     |
 Error detected at REDACTED
 --
 Occurs: 2 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
@@ -3320,207 +3320,207 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1426                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1436                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1426                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:1436                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times

--- a/experiments/golden-results/vct-summary.txt
+++ b/experiments/golden-results/vct-summary.txt
@@ -300,12 +300,12 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4775                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4841                     |
 Error detected at REDACTED
 --
 Occurs: 2 times


### PR DESCRIPTION
This makes the function a little bit longer, but makes the control flow a little bit simpler. Also adds `Node_Id` taking overloads to `Do_Operator_Mod` and `Do_Operator_Sub_Mod` (on that note, I think I know why power-of-2 mod types cause problems now)