### PR TITLE
Basic exception support

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -83,11 +83,6 @@ Calling function: Do_Expression
 Error message: Index of string unsupported
 Nkind: N_Indexed_Component
 --
-Occurs: 18 times
-Calling function: Process_Declaration
-Error message: Exception declaration
-Nkind: N_Exception_Declaration
---
 Occurs: 14 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Global
@@ -102,11 +97,6 @@ Occurs: 11 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Check
 Nkind: N_Pragma
---
-Occurs: 10 times
-Calling function: Process_Statement
-Error message: Raise statement
-Nkind: N_Raise_Statement
 --
 Occurs: 9 times
 Calling function: Process_Pragma_Declaration
@@ -1825,17 +1815,17 @@ Error detected at REDACTED
 --
 Occurs: 9 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:142|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:147|
 Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 3 times
@@ -1845,7 +1835,7 @@ Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:976                      |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:982                      |
 Error detected at REDACTED
 --
 Occurs: 2 times
@@ -1880,347 +1870,347 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:142|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:147|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:142|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:147|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:142|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:147|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
@@ -2266,6 +2256,11 @@ Error detected at REDACTED
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
 | GNU Ada (ada2goto) Assert_Failure failed precondition from range_check.ads:50|
+Error detected at REDACTED
+--
+Occurs: 1 times
++===========================GNAT BUG DETECTED==============================+
+| GNU Ada (ada2goto) Assert_Failure failed precondition from tree_walk.adb:72|
 Error detected at REDACTED
 --
 Occurs: 1 times
@@ -2325,7 +2320,7 @@ Error detected at REDACTED
 --
 Occurs: 25 times
 <========================>
-raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from goto_utils.ads:142
+raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from goto_utils.ads:147
 
 --
 Occurs: 2 times
@@ -2346,4 +2341,9 @@ raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from range_check.a
 Occurs: 1 times
 <========================>
 raised CONSTRAINT_ERROR : Symbol_Table_Info.Symbol_Maps.Constant_Reference: key not in map
+
+--
+Occurs: 1 times
+<========================>
+raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from tree_walk.adb:72
 

--- a/experiments/golden-results/Tokeneer-summary.txt
+++ b/experiments/golden-results/Tokeneer-summary.txt
@@ -1,8 +1,3 @@
-Occurs: 84 times
-Calling function: Process_Declaration
-Error message: Exception declaration
-Nkind: N_Exception_Declaration
---
 Occurs: 21 times
 Calling function: Process_Declaration
 Error message: Representation clause unsupported: alignment

--- a/experiments/golden-results/ksum-summary.txt
+++ b/experiments/golden-results/ksum-summary.txt
@@ -1,8 +1,3 @@
-Occurs: 4 times
-Calling function: Process_Declaration
-Error message: Exception declaration
-Nkind: N_Exception_Declaration
---
 Occurs: 3 times
 Calling function: Process_Declaration
 Error message: Representation clause unsupported: alignment

--- a/experiments/golden-results/libkeccak-summary.txt
+++ b/experiments/golden-results/libkeccak-summary.txt
@@ -13,11 +13,6 @@ Calling function: Process_Declaration
 Error message: size clause not applied by the front-end
 Nkind: N_Attribute_Definition_Clause
 --
-Occurs: 56 times
-Calling function: Process_Declaration
-Error message: Exception declaration
-Nkind: N_Exception_Declaration
---
 Occurs: 47 times
 Calling function: Process_Declaration
 Error message: Use type clause declaration

--- a/experiments/golden-results/libsparkcrypto-summary.txt
+++ b/experiments/golden-results/libsparkcrypto-summary.txt
@@ -103,11 +103,6 @@ Calling function: Process_Statement
 Error message: Object declaration statement unsupported.
 Nkind: N_Object_Declaration
 --
-Occurs: 1 times
-Calling function: Process_Declaration
-Error message: Exception declaration
-Nkind: N_Exception_Declaration
---
 Occurs: 32 times
 Redacted compiler error message:
 file "REDACTED" not found
@@ -360,7 +355,7 @@ Raw compiler error message:
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:142|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:147|
 Error detected at REDACTED
 --
 Occurs: 1 times
@@ -370,5 +365,5 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 <========================>
-raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from goto_utils.ads:142
+raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from goto_utils.ads:147
 

--- a/experiments/golden-results/muen-summary.txt
+++ b/experiments/golden-results/muen-summary.txt
@@ -8,11 +8,6 @@ Calling function: Process_Declaration
 Error message: Use type clause declaration
 Nkind: N_Use_Type_Clause
 --
-Occurs: 112 times
-Calling function: Process_Declaration
-Error message: Exception declaration
-Nkind: N_Exception_Declaration
---
 Occurs: 105 times
 Calling function: Do_Type_Definition
 Error message: Access type unsupported
@@ -3030,207 +3025,207 @@ Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:142|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:147|
 Error detected at REDACTED
 --
 Occurs: 2 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times

--- a/experiments/golden-results/vct-summary.txt
+++ b/experiments/golden-results/vct-summary.txt
@@ -1,8 +1,3 @@
-Occurs: 297 times
-Calling function: Process_Declaration
-Error message: Exception declaration
-Nkind: N_Exception_Declaration
---
 Occurs: 74 times
 Calling function: Process_Declaration
 Error message: Abstract subprogram declaration
@@ -120,12 +115,12 @@ Raw compiler error message:
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1749|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1750|
 Error detected at REDACTED
 --
 Occurs: 1 times

--- a/gnat2goto/driver/goto_utils.ads
+++ b/gnat2goto/driver/goto_utils.ads
@@ -16,6 +16,7 @@ package GOTO_Utils is
    function CProver_Nil return Irep;
 
    function CProver_True return Irep;
+   function CProver_False return Irep;
 
    --  TODO change this to Irep
    function Internal_Source_Location return Irep;
@@ -24,7 +25,7 @@ package GOTO_Utils is
    function Float64_T return Irep;
    function Int32_T return Irep;
    function Int64_T return Irep;
-   function Uint8_T return Irep;
+   function Int8_T return Irep;
    function Uint32_T return Irep;
    function Uint64_T return Irep;
    function Maybe_Double_Type_Width (Original_Type : Irep) return Irep;
@@ -41,6 +42,10 @@ package GOTO_Utils is
    function Fresh_Var_Symbol_Expr (Ty : Irep; Infix : String) return Irep;
 
    function Make_Pointer_Type (Base : Irep) return Irep;
+   function Make_Array_String_Type (Size : Integer) return Irep;
+   function Make_Type_For_String (Text : String) return Irep;
+   function Make_String_Constant_Expr (Text : String; Source_Loc : Irep)
+                                       return Irep;
 
    function Make_Address_Of (Base : Irep) return Irep;
 
@@ -219,4 +224,8 @@ package GOTO_Utils is
                                   return Symbol;
 
    function File_Name_Without_Extension (N : Node_Id) return String;
+
+   function String_To_Char_Pointer (String_Irep : Irep;
+                                    A_Symbol_Table : Symbol_Table)
+                                    return Irep;
 end GOTO_Utils;

--- a/gnat2goto/ireps/irep_specs/index_expr.json
+++ b/gnat2goto/ireps/irep_specs/index_expr.json
@@ -1,5 +1,6 @@
 {
   "parent": "expr",
+  "id": "array",
   "sub": [
     {"schema": "expr", "friendly_name": "array"},
     {"schema": "expr", "friendly_name": "index"}

--- a/testsuite/gnat2goto/tests/basic_exception/test.adb
+++ b/testsuite/gnat2goto/tests/basic_exception/test.adb
@@ -1,0 +1,26 @@
+procedure Test is
+   Too_Small : exception;
+   procedure More_Than_Five (Num : Integer) is
+   begin
+      if Num <= 5 then
+         raise Too_Small with "way too small!";
+      end if;
+   end More_Than_Five;
+
+   Error_Count : Integer := 0;
+begin
+   begin
+      More_Than_Five (10);
+   exception
+      when Too_Small =>
+         Error_Count := Error_Count + 1;
+   end;
+   begin
+      More_Than_Five (5);
+   exception
+      when Too_Small =>
+         Error_Count := Error_Count + 1;
+   end;
+   --  this will be unreachable due to implementation of `raise`
+   pragma Assert (Error_Count = 1);
+end Test;

--- a/testsuite/gnat2goto/tests/basic_exception/test.c
+++ b/testsuite/gnat2goto/tests/basic_exception/test.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+int foo(unsigned char* arg)
+{
+   if (arg[0] == 't')
+      return 1;
+   else
+      return 0;
+}
+
+int main()
+{
+   int res = foo((unsigned char *)"test");
+   assert(res == 0);
+   return 0;
+}

--- a/testsuite/gnat2goto/tests/basic_exception/test.out
+++ b/testsuite/gnat2goto/tests/basic_exception/test.out
@@ -1,0 +1,4 @@
+[assertion.2] file test.adb line 6 Ada Exception: FAILURE
+[assertion.1] file test.adb line 16 Ada Check assertion: SUCCESS
+[test.assertion.1] line 25 assertion Error_Count = 1: SUCCESS
+VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/basic_exception/test.py
+++ b/testsuite/gnat2goto/tests/basic_exception/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()

--- a/testsuite/gnat2goto/tests/range_check_exception/test.adb
+++ b/testsuite/gnat2goto/tests/range_check_exception/test.adb
@@ -1,0 +1,23 @@
+procedure Test is
+   Large_Positive : Integer := Integer'Last;
+   Larger_Still : Integer;
+
+   function Double (Num : Integer) return Integer
+   is
+   begin
+      -- will raise (overflow) exception
+      return 2 * Num;
+   end;
+
+   Error_Count : Integer := 0;
+begin
+   begin
+      Larger_Still := Double (Large_Positive);
+   exception
+      when Constraint_Error =>
+         -- intentionally dead-coded (exception handling)
+         Error_Count := Error_Count + 1;
+   end;
+   --  this will be unreachable due to implementation of `raise`
+   pragma Assert (Error_Count = 1);
+end Test;

--- a/testsuite/gnat2goto/tests/range_check_exception/test.out
+++ b/testsuite/gnat2goto/tests/range_check_exception/test.out
@@ -1,0 +1,3 @@
+[assertion.1] file test.adb line 9 Ada Check assertion: FAILURE
+[test.assertion.1] line 22 assertion Error_Count = 1: SUCCESS
+VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/range_check_exception/test.py
+++ b/testsuite/gnat2goto/tests/range_check_exception/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
Turning: `raise exception` into `assert(false); assume(false);` (wrapped in a nicely named function) and conditioning the handler statements by `false` , i.e.
```
begin
  Foo (5);
exception
  when My_Favourite_Exception => Destroy_Universe (Now);
end;
```
is translated into
```
Foo(5);
if (0) { Destroy_Universe(Now); }
```
There is a test (3rd commit) and the first commit is from a prerequisite #284 -- no need to review here.