### PR TITLE
Refactor/make new irep private

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -1710,7 +1710,7 @@ Error detected at REDACTED
 --
 Occurs: 6 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1597|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1595|
 Error detected at REDACTED
 --
 Occurs: 6 times
@@ -1770,17 +1770,17 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1597|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1595|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1597|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1595|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1597|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1595|
 Error detected at REDACTED
 --
 Occurs: 1 times
@@ -2235,7 +2235,7 @@ Error detected at REDACTED
 --
 Occurs: 20 times
 <========================>
-raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from ireps.ads:1597
+raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from ireps.ads:1595
 
 --
 Occurs: 2 times

--- a/experiments/golden-results/UKNI-Information-Barrier-summary.txt
+++ b/experiments/golden-results/UKNI-Information-Barrier-summary.txt
@@ -75,10 +75,10 @@ Raw compiler error message:
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1597|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1595|
 Error detected at REDACTED
 --
 Occurs: 1 times
 <========================>
-raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from ireps.ads:1597
+raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from ireps.ads:1595
 

--- a/experiments/golden-results/muen-summary.txt
+++ b/experiments/golden-results/muen-summary.txt
@@ -3015,7 +3015,7 @@ Error detected at REDACTED
 --
 Occurs: 2 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1597|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1595|
 Error detected at REDACTED
 --
 Occurs: 2 times
@@ -3035,17 +3035,17 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1715|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1713|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1715|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1713|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1715|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1713|
 Error detected at REDACTED
 --
 Occurs: 1 times
@@ -3565,5 +3565,5 @@ Error detected at REDACTED
 --
 Occurs: 2 times
 <========================>
-raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from ireps.ads:1597
+raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from ireps.ads:1595
 

--- a/gnat2goto/ireps/ireps_generator.py
+++ b/gnat2goto/ireps/ireps_generator.py
@@ -1581,8 +1581,8 @@ class IrepsGenerator(object):
         write(b, "")
 
 
-        write(s, "function New_Irep (Kind : Valid_Irep_Kind) return Irep;")
-        write(s, "")
+        write(b, "function New_Irep (Kind : Valid_Irep_Kind) return Irep;")
+        write(b, "")
 
         write_comment_block(b, "New_Irep")
         write(b, "function New_Irep (Kind : Valid_Irep_Kind) return Irep")


### PR DESCRIPTION
From now on code outside of the internals of the Ireps module will no longer compile if it tries to use `New_Irep`.

Therefore it is now impossible to create an irep without all of its fields being initialised (they may still be initialised to dummy values, and this doesn't touch the setters, so this doesn't provide full type safety for ireps but it does at least make it a *lot* harder to create invalid ireps by accident, or introduce changes to the irep structure that break code without us noticing.