### PR TITLE
Add property class and function name to assertions

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -1705,7 +1705,7 @@ Raw compiler error message:
 --
 Occurs: 29 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 6 times
@@ -1720,22 +1720,22 @@ Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 3 times
@@ -1745,7 +1745,7 @@ Error detected at REDACTED
 --
 Occurs: 2 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
@@ -1845,362 +1845,362 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
@@ -2250,5 +2250,5 @@ raised CONSTRAINT_ERROR : Symbol_Table_Info.Symbol_Maps.Constant_Reference: key 
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 | Error detected at stm32-exti.adb:47:19                                   |

--- a/experiments/golden-results/libkeccak-summary.txt
+++ b/experiments/golden-results/libkeccak-summary.txt
@@ -55,7 +55,7 @@ Raw compiler error message:
 --
 Occurs: 23 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 2 times
@@ -95,132 +95,132 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times

--- a/experiments/golden-results/libsparkcrypto-summary.txt
+++ b/experiments/golden-results/libsparkcrypto-summary.txt
@@ -255,20 +255,20 @@ Raw compiler error message:
 --
 Occurs: 20 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 2 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED

--- a/experiments/golden-results/muen-summary.txt
+++ b/experiments/golden-results/muen-summary.txt
@@ -3025,7 +3025,7 @@ Error detected at REDACTED
 --
 Occurs: 2 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
@@ -3330,197 +3330,197 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times

--- a/experiments/golden-results/vct-summary.txt
+++ b/experiments/golden-results/vct-summary.txt
@@ -300,12 +300,12 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4869                     |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:4905                     |
 Error detected at REDACTED
 --
 Occurs: 2 times

--- a/testsuite/gnat2goto/tests/absolute/test.out
+++ b/testsuite/gnat2goto/tests/absolute/test.out
@@ -1,4 +1,4 @@
-[1] file absolute.adb line 7 assertion: SUCCESS
-[2] file absolute.adb line 8 assertion: SUCCESS
-[3] file absolute.adb line 10 assertion: FAILURE
+[absolute.assertion.1] line 7 assertion : SUCCESS
+[absolute.assertion.2] line 8 assertion : SUCCESS
+[absolute.assertion.3] line 10 assertion : FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/absolute_float/test.out
+++ b/testsuite/gnat2goto/tests/absolute_float/test.out
@@ -1,4 +1,4 @@
-[1] file absolute_float.adb line 7 assertion: SUCCESS
-[2] file absolute_float.adb line 8 assertion: SUCCESS
-[3] file absolute_float.adb line 10 assertion: FAILURE
+[absolute_float.assertion.1] line 7 assertion : SUCCESS
+[absolute_float.assertion.2] line 8 assertion : SUCCESS
+[absolute_float.assertion.3] line 10 assertion : FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/address_clause/test.out
+++ b/testsuite/gnat2goto/tests/address_clause/test.out
@@ -20,5 +20,5 @@ Standard_Error from gnat2goto address_clause:
 ----------At: Process_Declaration----------
 ----------Address representation clauses are not currently supported----------
 
-[1] file address_clause.adb line 12 assertion: SUCCESS
+[address_clause.assertion.1] line 12 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/arrays_access/test.out
+++ b/testsuite/gnat2goto/tests/arrays_access/test.out
@@ -1,5 +1,5 @@
 [precondition_instance.1] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.2] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.3] file <internal> memcpy destination region writeable: SUCCESS
-[1] file arrays_access.adb line 6 assertion: SUCCESS
+[arrays_access.assertion.1] line 6 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/arrays_assign_nonoverlap/test.out
+++ b/testsuite/gnat2goto/tests/arrays_assign_nonoverlap/test.out
@@ -19,8 +19,8 @@
 [precondition_instance.7] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.8] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.9] file <internal> memcpy destination region writeable: SUCCESS
-[1] file arrays_assign_nonoverlap.adb line 8 assertion: SUCCESS
-[2] file arrays_assign_nonoverlap.adb line 9 assertion: SUCCESS
-[3] file arrays_assign_nonoverlap.adb line 10 assertion: SUCCESS
-[4] file arrays_assign_nonoverlap.adb line 11 assertion: SUCCESS
+[arrays_assign_nonoverlap.assertion.1] line 8 assertion : SUCCESS
+[arrays_assign_nonoverlap.assertion.2] line 9 assertion : SUCCESS
+[arrays_assign_nonoverlap.assertion.3] line 10 assertion : SUCCESS
+[arrays_assign_nonoverlap.assertion.4] line 11 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/arrays_attributes_dynamic/test.out
+++ b/testsuite/gnat2goto/tests/arrays_attributes_dynamic/test.out
@@ -1,7 +1,7 @@
 [precondition_instance.1] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.2] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.3] file <internal> memcpy destination region writeable: SUCCESS
-[1] file array_attributes_dynamic.adb line 7 assertion: SUCCESS
-[2] file array_attributes_dynamic.adb line 8 assertion: FAILURE
-[3] file array_attributes_dynamic.adb line 9 assertion: SUCCESS
+[array_consumer.assertion.1] line 7 assertion : SUCCESS
+[array_consumer.assertion.2] line 8 assertion : FAILURE
+[array_consumer.assertion.3] line 9 assertion : SUCCESS
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/arrays_attributes_static/test.out
+++ b/testsuite/gnat2goto/tests/arrays_attributes_static/test.out
@@ -16,6 +16,6 @@
 [precondition_instance.7] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.8] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.9] file <internal> memcpy destination region writeable: SUCCESS
-[1] file arrays_attributes_static.adb line 16 assertion: SUCCESS
-[2] file arrays_attributes_static.adb line 17 assertion: SUCCESS
+[arrays_attributes_static.assertion.1] line 16 assertion : SUCCESS
+[arrays_attributes_static.assertion.2] line 17 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/arrays_concat/test.out
+++ b/testsuite/gnat2goto/tests/arrays_concat/test.out
@@ -10,5 +10,5 @@
 [precondition_instance.7] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.8] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.9] file <internal> memcpy destination region writeable: SUCCESS
-[1] file arrays_concat.adb line 7 assertion: SUCCESS
+[arrays_concat.assertion.1] line 7 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/arrays_constraints/test.out
+++ b/testsuite/gnat2goto/tests/arrays_constraints/test.out
@@ -1,8 +1,7 @@
-[1] file array_constraints.adb line 117 assertion: SUCCESS
-[2] file array_constraints.adb line 131 assertion: SUCCESS
-[3] file array_constraints.adb line 143 assertion: SUCCESS
-[4] file array_constraints.adb line 154 assertion: SUCCESS
-[5] file array_constraints.adb line 166 assertion: SUCCESS
-[6] file array_constraints.adb line 180 assertion: SUCCESS
+[array_constraints.assertion.1] line 117 assertion : SUCCESS
+[array_constraints.assertion.2] line 131 assertion : SUCCESS
+[array_constraints.assertion.3] line 143 assertion : SUCCESS
+[array_constraints.assertion.4] line 154 assertion : SUCCESS
+[array_constraints.assertion.5] line 166 assertion : SUCCESS
+[array_constraints.assertion.6] line 180 assertion : SUCCESS
 VERIFICATION SUCCESSFUL
-

--- a/testsuite/gnat2goto/tests/arrays_index/test.out
+++ b/testsuite/gnat2goto/tests/arrays_index/test.out
@@ -1,5 +1,5 @@
 [precondition_instance.1] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.2] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.3] file <internal> memcpy destination region writeable: SUCCESS
-[1] file arrays_index.adb line 9 assertion: SUCCESS
+[arrays_index.assertion.1] line 9 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/arrays_index_enum/test.out
+++ b/testsuite/gnat2goto/tests/arrays_index_enum/test.out
@@ -1,5 +1,5 @@
 [precondition_instance.1] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.2] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.3] file <internal> memcpy destination region writeable: SUCCESS
-[1] file test.adb line 7 assertion: SUCCESS
+[test.assertion.1] line 7 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/arrays_range/test.out
+++ b/testsuite/gnat2goto/tests/arrays_range/test.out
@@ -2,9 +2,9 @@
 [precondition_instance.2] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.3] file <internal> memcpy destination region writeable: SUCCESS
 [assertion.2] file arrays_range.adb line 8 Range Check: SUCCESS
-[1] file arrays_range.adb line 9 assertion: SUCCESS
-[assertion.3] file arrays_range.adb line 10 Range Check: FAILURE
-[2] file arrays_range.adb line 11 assertion: SUCCESS
-[assertion.1] file arrays_range.adb line 12 Range Check: FAILURE
-[3] file arrays_range.adb line 13 assertion: SUCCESS
+[array_consumer.assertion.1] line 9 assertion : SUCCESS
+[assertion.3] line 10 Range Check: FAILURE
+[array_consumer.assertion.2] line 11 assertion : SUCCESS
+[assertion.1] line 12 Range Check: FAILURE
+[array_consumer.assertion.3] line 13 assertion : SUCCESS
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/assign/test.out
+++ b/testsuite/gnat2goto/tests/assign/test.out
@@ -1,3 +1,3 @@
-[1] file assign.adb line 6 assertion: SUCCESS
-[2] file assign.adb line 7 assertion: SUCCESS
+[assign.assertion.1] line 6 assertion : SUCCESS
+[assign.assertion.2] line 7 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/attributes_discrete/test.out
+++ b/testsuite/gnat2goto/tests/attributes_discrete/test.out
@@ -1,11 +1,11 @@
-[1] file attributes_discrete.adb line 7 assertion: FAILURE
-[2] file attributes_discrete.adb line 8 assertion: SUCCESS
-[3] file attributes_discrete.adb line 9 assertion: SUCCESS
-[4] file attributes_discrete.adb line 11 assertion: SUCCESS
-[5] file attributes_discrete.adb line 12 assertion: SUCCESS
-[6] file attributes_discrete.adb line 13 assertion: SUCCESS
-[7] file attributes_discrete.adb line 15 assertion: SUCCESS
-[8] file attributes_discrete.adb line 16 assertion: SUCCESS
-[9] file attributes_discrete.adb line 17 assertion: SUCCESS
-[10] file attributes_discrete.adb line 18 assertion: SUCCESS
+[attributes_discrete.assertion.1] line 7 assertion : FAILURE
+[attributes_discrete.assertion.2] line 8 assertion : SUCCESS
+[attributes_discrete.assertion.3] line 9 assertion : SUCCESS
+[attributes_discrete.assertion.4] line 11 assertion : SUCCESS
+[attributes_discrete.assertion.5] line 12 assertion : SUCCESS
+[attributes_discrete.assertion.6] line 13 assertion : SUCCESS
+[attributes_discrete.assertion.7] line 15 assertion : SUCCESS
+[attributes_discrete.assertion.8] line 16 assertion : SUCCESS
+[attributes_discrete.assertion.9] line 17 assertion : SUCCESS
+[attributes_discrete.assertion.10] line 18 assertion : SUCCESS
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/boolean_type/test.out
+++ b/testsuite/gnat2goto/tests/boolean_type/test.out
@@ -1,5 +1,5 @@
-[1] file boolean_type.adb line 5 assertion: SUCCESS
-[2] file boolean_type.adb line 6 assertion: FAILURE
-[3] file boolean_type.adb line 7 assertion: SUCCESS
-[4] file boolean_type.adb line 8 assertion: FAILURE
+[boolean_type.assertion.1] line 5 assertion : SUCCESS
+[boolean_type.assertion.2] line 6 assertion : FAILURE
+[boolean_type.assertion.3] line 7 assertion : SUCCESS
+[boolean_type.assertion.4] line 8 assertion : FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/case_expression/test.out
+++ b/testsuite/gnat2goto/tests/case_expression/test.out
@@ -1,3 +1,3 @@
-[1] file case_expression.adb line 22 assertion: SUCCESS
-[2] file case_expression.adb line 23 assertion: SUCCESS
+[case_expression.assertion.1] line 22 assertion : SUCCESS
+[case_expression.assertion.2] line 23 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/case_expression_others/test.out
+++ b/testsuite/gnat2goto/tests/case_expression_others/test.out
@@ -1,3 +1,3 @@
-[1] file case_expression_others.adb line 18 assertion: SUCCESS
-[2] file case_expression_others.adb line 19 assertion: SUCCESS
+[case_expression_others.assertion.1] line 18 assertion : SUCCESS
+[case_expression_others.assertion.2] line 19 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/case_expression_range/test.out
+++ b/testsuite/gnat2goto/tests/case_expression_range/test.out
@@ -1,3 +1,3 @@
-[1] file case_expression_range.adb line 10 assertion: SUCCESS
-[2] file case_expression_range.adb line 11 assertion: SUCCESS
+[case_expression_range.assertion.1] line 10 assertion : SUCCESS
+[case_expression_range.assertion.2] line 11 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/case_expression_vals/test.out
+++ b/testsuite/gnat2goto/tests/case_expression_vals/test.out
@@ -1,3 +1,3 @@
-[1] file case_expression_or.adb line 11 assertion: SUCCESS
-[2] file case_expression_or.adb line 12 assertion: SUCCESS
+[case_expression_or.assertion.1] line 11 assertion : SUCCESS
+[case_expression_or.assertion.2] line 12 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/case_statement/test.out
+++ b/testsuite/gnat2goto/tests/case_statement/test.out
@@ -1,3 +1,3 @@
-[1] file case_statement.adb line 16 assertion: SUCCESS
-[2] file case_statement.adb line 17 assertion: SUCCESS
+[case_statement.assertion.1] line 16 assertion : SUCCESS
+[case_statement.assertion.2] line 17 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/case_statement_others_only/test.out
+++ b/testsuite/gnat2goto/tests/case_statement_others_only/test.out
@@ -1,2 +1,2 @@
-[1] file case_statement_others_only.adb line 13 assertion: SUCCESS
+[case_statement_others_only.assertion.1] line 13 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/case_statement_range/test.out
+++ b/testsuite/gnat2goto/tests/case_statement_range/test.out
@@ -1,4 +1,4 @@
-[2] file case_statement_range.adb line 6 assertion: SUCCESS
-[3] file case_statement_range.adb line 8 assertion: SUCCESS
-[1] file main.adb line 5 assertion: SUCCESS
+[case_statement_range.assertion.1] line 6 assertion : SUCCESS
+[case_statement_range.assertion.2] line 8 assertion : SUCCESS
+[main.assertion.1] line 5 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/case_statement_vals/test.out
+++ b/testsuite/gnat2goto/tests/case_statement_vals/test.out
@@ -1,4 +1,4 @@
-[1] file case_statement_vals.adb line 14 assertion: SUCCESS
-[2] file case_statement_vals.adb line 15 assertion: SUCCESS
-[3] file case_statement_vals.adb line 16 assertion: SUCCESS
+[case_statement_vals.assertion.1] line 14 assertion : SUCCESS
+[case_statement_vals.assertion.2] line 15 assertion : SUCCESS
+[case_statement_vals.assertion.3] line 16 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/character_literal/test.out
+++ b/testsuite/gnat2goto/tests/character_literal/test.out
@@ -1,3 +1,3 @@
-[1] file character_literal.adb line 5 assertion: FAILURE
-[2] file character_literal.adb line 6 assertion: SUCCESS
+[character_literal.assertion.1] line 5 assertion : FAILURE
+[character_literal.assertion.2] line 6 assertion : SUCCESS
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/character_literal_wide/test.out
+++ b/testsuite/gnat2goto/tests/character_literal_wide/test.out
@@ -1,3 +1,3 @@
-[1] file character_literal_wide.adb line 5 assertion: FAILURE
-[2] file character_literal_wide.adb line 6 assertion: SUCCESS
+[character_literal_wide.assertion.1] line 5 assertion : FAILURE
+[character_literal_wide.assertion.2] line 6 assertion : SUCCESS
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/character_literal_wide_wide/test.out
+++ b/testsuite/gnat2goto/tests/character_literal_wide_wide/test.out
@@ -1,3 +1,3 @@
-[1] file character_literal_wide_wide.adb line 5 assertion: FAILURE
-[2] file character_literal_wide_wide.adb line 6 assertion: SUCCESS
+[character_literal_wide_wide.assertion.1] line 5 assertion : FAILURE
+[character_literal_wide_wide.assertion.2] line 6 assertion : SUCCESS
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/constant_declarations/test.out
+++ b/testsuite/gnat2goto/tests/constant_declarations/test.out
@@ -1,2 +1,2 @@
-[1] file test.adb line 8 assertion: FAILURE
+[test.assertion.1] line 8 assertion : FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/declaration_rename_N_Renaming_Declaration/test.out
+++ b/testsuite/gnat2goto/tests/declaration_rename_N_Renaming_Declaration/test.out
@@ -1,5 +1,5 @@
-[1] file declaration_rename.adb line 28 assertion: SUCCESS
-[2] file declaration_rename.adb line 29 assertion: SUCCESS
-[3] file declaration_rename.adb line 30 assertion: SUCCESS
-[4] file declaration_rename.adb line 31 assertion: SUCCESS
+[declaration_rename.assertion.1] line 28 assertion : SUCCESS
+[declaration_rename.assertion.2] line 29 assertion : SUCCESS
+[declaration_rename.assertion.3] line 30 assertion : SUCCESS
+[declaration_rename.assertion.4] line 31 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/deferred_constant/test.out
+++ b/testsuite/gnat2goto/tests/deferred_constant/test.out
@@ -1,3 +1,3 @@
 [assertion.1] file deferred_const.adb line 4 Range Check: SUCCESS
-[1] file test.adb line 6 assertion: SUCCESS
+[test.assertion.1] line 6 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/derived_private_type/test.out
+++ b/testsuite/gnat2goto/tests/derived_private_type/test.out
@@ -1,2 +1,2 @@
-[1] file derived_private_type.adb line 7 assertion: SUCCESS
+[derived_private_type.assertion.1] line 7 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/derived_types/test.out
+++ b/testsuite/gnat2goto/tests/derived_types/test.out
@@ -1,4 +1,4 @@
-[1] file derived_types.adb line 6 assertion: SUCCESS
-[2] file derived_types.adb line 7 assertion: SUCCESS
-[3] file derived_types.adb line 8 assertion: SUCCESS
+[derived_types.assertion.1] line 6 assertion : SUCCESS
+[derived_types.assertion.2] line 7 assertion : SUCCESS
+[derived_types.assertion.3] line 8 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/divide/test.out
+++ b/testsuite/gnat2goto/tests/divide/test.out
@@ -1,3 +1,2 @@
-[1] file divide.adb line 7 assertion: SUCCESS
+[divide.assertion.1] line 7 assertion : SUCCESS
 VERIFICATION SUCCESSFUL
-

--- a/testsuite/gnat2goto/tests/enum/test.out
+++ b/testsuite/gnat2goto/tests/enum/test.out
@@ -1,5 +1,5 @@
-[1] file enum.adb line 8 assertion: SUCCESS
-[2] file enum.adb line 10 assertion: SUCCESS
-[3] file enum.adb line 12 assertion: SUCCESS
-[4] file enum.adb line 14 assertion: FAILURE
+[enum.assertion.1] line 8 assertion : SUCCESS
+[enum.assertion.2] line 10 assertion : SUCCESS
+[enum.assertion.3] line 12 assertion : SUCCESS
+[enum.assertion.4] line 14 assertion : FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/enum_character_literals/test.out
+++ b/testsuite/gnat2goto/tests/enum_character_literals/test.out
@@ -1,3 +1,3 @@
-[1] file enum_character_literals.adb line 5 assertion: SUCCESS
-[2] file enum_character_literals.adb line 6 assertion: SUCCESS
+[enum_character_literals.assertion.1] line 5 assertion : SUCCESS
+[enum_character_literals.assertion.2] line 6 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/enum_in_param/test.out
+++ b/testsuite/gnat2goto/tests/enum_in_param/test.out
@@ -1,5 +1,5 @@
 [precondition_instance.1] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.2] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.3] file <internal> memcpy destination region writeable: SUCCESS
-[1] file enum_in.adb line 19 assertion: SUCCESS
+[p_enum_in.assertion.1] line 19 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/enum_out_param/test.out
+++ b/testsuite/gnat2goto/tests/enum_out_param/test.out
@@ -1,2 +1,2 @@
-[1] file enum_out.adb line 13 assertion: SUCCESS
+[enum_out.assertion.1] line 13 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/expanded_name/test.out
+++ b/testsuite/gnat2goto/tests/expanded_name/test.out
@@ -1,2 +1,2 @@
-[1] file expanded_name.adb line 12 assertion: SUCCESS
+[expanded_name.assertion.1] line 12 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/expanded_name_subtype_indication/test.out
+++ b/testsuite/gnat2goto/tests/expanded_name_subtype_indication/test.out
@@ -1,4 +1,4 @@
-[1] file test.adb line 8 assertion: SUCCESS
-[2] file test.adb line 10 assertion: SUCCESS
-[3] file test.adb line 11 assertion: FAILURE
+[test.assertion.1] line 8 assertion : SUCCESS
+[test.assertion.2] line 10 assertion : SUCCESS
+[test.assertion.3] line 11 assertion : FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/floating_definition/test.out
+++ b/testsuite/gnat2goto/tests/floating_definition/test.out
@@ -1,4 +1,4 @@
 [assertion.1] file floating_definition.adb line 9 Range Check: SUCCESS
-[1] file floating_definition.adb line 10 assertion: SUCCESS
-[2] file floating_definition.adb line 11 assertion: FAILURE
+[floating_definition.assertion.1] line 10 assertion : SUCCESS
+[floating_definition.assertion.2] line 11 assertion : FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/floating_point_constant/test.out
+++ b/testsuite/gnat2goto/tests/floating_point_constant/test.out
@@ -1,3 +1,3 @@
-[1] file floating_point_constant.adb line 11 assertion: SUCCESS
-[2] file floating_point_constant.adb line 15 assertion: SUCCESS
+[floating_point_constant.assertion.1] line 11 assertion : SUCCESS
+[floating_point_constant.assertion.2] line 15 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/floating_point_literals/test.out
+++ b/testsuite/gnat2goto/tests/floating_point_literals/test.out
@@ -1,6 +1,6 @@
-[1] file floating_point_literals.adb line 8 assertion: FAILURE
-[2] file floating_point_literals.adb line 10 assertion: SUCCESS
-[3] file floating_point_literals.adb line 12 assertion: FAILURE
-[4] file floating_point_literals.adb line 14 assertion: SUCCESS
-[5] file floating_point_literals.adb line 16 assertion: SUCCESS
+[floating_point_literals.assertion.1] line 8 assertion : FAILURE
+[floating_point_literals.assertion.2] line 10 assertion : SUCCESS
+[floating_point_literals.assertion.3] line 12 assertion : FAILURE
+[floating_point_literals.assertion.4] line 14 assertion : SUCCESS
+[floating_point_literals.assertion.5] line 16 assertion : SUCCESS
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/forloop/test.out
+++ b/testsuite/gnat2goto/tests/forloop/test.out
@@ -1,3 +1,2 @@
-[1] file forloop.adb line 9 assertion: SUCCESS
+[forloop.assertion.1] line 9 assertion : SUCCESS
 VERIFICATION SUCCESSFUL
-

--- a/testsuite/gnat2goto/tests/func/test.out
+++ b/testsuite/gnat2goto/tests/func/test.out
@@ -1,2 +1,2 @@
-[1] file func.adb line 10 assertion: SUCCESS
+[func.assertion.1] line 10 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/func_args/test.out
+++ b/testsuite/gnat2goto/tests/func_args/test.out
@@ -1,3 +1,3 @@
-[1] file func_args.adb line 10 assertion: SUCCESS
-[2] file func_args.adb line 11 assertion: FAILURE
+[func_args.assertion.1] line 10 assertion : SUCCESS
+[func_args.assertion.2] line 11 assertion : FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/if_integer/test.out
+++ b/testsuite/gnat2goto/tests/if_integer/test.out
@@ -1,4 +1,4 @@
-[1] file divide.adb line 4 assertion: SUCCESS
-[2] file divide.adb line 6 assertion: SUCCESS
-[3] file divide.adb line 8 assertion: FAILURE
+[divide.assertion.1] line 4 assertion : SUCCESS
+[divide.assertion.2] line 6 assertion : SUCCESS
+[divide.assertion.3] line 8 assertion : FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/ifthenelse/test.out
+++ b/testsuite/gnat2goto/tests/ifthenelse/test.out
@@ -1,2 +1,2 @@
-[1] file ifthenelse.adb line 11 assertion: SUCCESS
+[ifthenelse.assertion.1] line 11 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/in_expression/test.out
+++ b/testsuite/gnat2goto/tests/in_expression/test.out
@@ -1,6 +1,6 @@
 [precondition_instance.1] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.2] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.3] file <internal> memcpy destination region writeable: SUCCESS
-[1] file in_expression.adb line 8 assertion: FAILURE
-[2] file in_expression.adb line 10 assertion: SUCCESS
+[in_expression.assertion.1] line 8 assertion : FAILURE
+[in_expression.assertion.2] line 10 assertion : SUCCESS
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/incomplete_dec/test.out
+++ b/testsuite/gnat2goto/tests/incomplete_dec/test.out
@@ -1,2 +1,2 @@
-[1] file test.adb line 7 assertion: SUCCESS
+[test.assertion.1] line 7 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/incomplete_dec_priv/test.out
+++ b/testsuite/gnat2goto/tests/incomplete_dec_priv/test.out
@@ -1,2 +1,2 @@
-[1] file test.adb line 7 assertion: SUCCESS
+[test.assertion.1] line 7 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/long_integer/test.out
+++ b/testsuite/gnat2goto/tests/long_integer/test.out
@@ -1,2 +1,2 @@
-[1] file test_long_integer.adb line 4 assertion: SUCCESS
+[test_long_integer.assertion.1] line 4 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/loop_in_custom_type/test.out
+++ b/testsuite/gnat2goto/tests/loop_in_custom_type/test.out
@@ -1,3 +1,3 @@
-[1] file test.adb line 8 assertion: FAILURE
-[2] file test.adb line 11 assertion: SUCCESS
+[test.assertion.1] line 8 assertion : FAILURE
+[test.assertion.2] line 11 assertion : SUCCESS
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/loop_range_mod_type/test.out
+++ b/testsuite/gnat2goto/tests/loop_range_mod_type/test.out
@@ -1,3 +1,3 @@
 [assertion.1] file test.adb line 23 Range Check: SUCCESS
-[1] file test.adb line 31 assertion: SUCCESS
+[test.assertion.1] line 31 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/loop_range_variable/test.out
+++ b/testsuite/gnat2goto/tests/loop_range_variable/test.out
@@ -1,3 +1,3 @@
 [assertion.1] file test.adb line 9 Range Check: SUCCESS
-[1] file test.adb line 11 assertion: FAILURE
+[test.assertion.1] line 11 assertion : FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/loops/test.out
+++ b/testsuite/gnat2goto/tests/loops/test.out
@@ -1,2 +1,2 @@
-[1] file loops.adb line 32 assertion: FAILURE
+[loops.assertion.1] line 32 assertion : FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/main_params_and_return/test.out
+++ b/testsuite/gnat2goto/tests/main_params_and_return/test.out
@@ -1,3 +1,3 @@
-[1] file main_params_and_return.adb line 19 assertion: SUCCESS
-[2] file main_params_and_return.adb line 20 assertion: SUCCESS
+[main_params_and_return.assertion.1] line 19 assertion : SUCCESS
+[main_params_and_return.assertion.2] line 20 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/mixed_parameters/test.out
+++ b/testsuite/gnat2goto/tests/mixed_parameters/test.out
@@ -1,6 +1,6 @@
-[1] file mixed_parameters.adb line 10 assertion: SUCCESS
-[2] file mixed_parameters.adb line 12 assertion: SUCCESS
-[3] file mixed_parameters.adb line 14 assertion: SUCCESS
-[4] file mixed_parameters.adb line 16 assertion: SUCCESS
-[5] file mixed_parameters.adb line 18 assertion: FAILURE
+[mixed_parameters.assertion.1] line 10 assertion : SUCCESS
+[mixed_parameters.assertion.2] line 12 assertion : SUCCESS
+[mixed_parameters.assertion.3] line 14 assertion : SUCCESS
+[mixed_parameters.assertion.4] line 16 assertion : SUCCESS
+[mixed_parameters.assertion.5] line 18 assertion : FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/not_op/test.out
+++ b/testsuite/gnat2goto/tests/not_op/test.out
@@ -1,6 +1,6 @@
 Standard_Error from gnat2goto not_op:
 not_op.adb:2:03: warning: variable "x" is read but never assigned
 
-[1] file not_op.adb line 4 assertion: SUCCESS
-[2] file not_op.adb line 5 assertion: SUCCESS
+[not_op.assertion.1] line 4 assertion : SUCCESS
+[not_op.assertion.2] line 5 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/op_and/test.out
+++ b/testsuite/gnat2goto/tests/op_and/test.out
@@ -1,6 +1,6 @@
-[1] file op_and.adb line 7 assertion: FAILURE
-[2] file op_and.adb line 9 assertion: FAILURE
-[3] file op_and.adb line 11 assertion: SUCCESS
-[4] file op_and.adb line 13 assertion: FAILURE
-[5] file op_and.adb line 15 assertion: FAILURE
+[op_and.assertion.1] line 7 assertion : FAILURE
+[op_and.assertion.2] line 9 assertion : FAILURE
+[op_and.assertion.3] line 11 assertion : SUCCESS
+[op_and.assertion.4] line 13 assertion : FAILURE
+[op_and.assertion.5] line 15 assertion : FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/op_and_example/test.out
+++ b/testsuite/gnat2goto/tests/op_and_example/test.out
@@ -1,4 +1,4 @@
-[1] file op_and_example.adb line 11 assertion: SUCCESS
-[2] file op_and_example.adb line 15 assertion: SUCCESS
-[3] file op_and_example.adb line 16 assertion: FAILURE
+[op_and_example.assertion.1] line 11 assertion : SUCCESS
+[op_and_example.assertion.2] line 15 assertion : SUCCESS
+[op_and_example.assertion.3] line 16 assertion : FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/op_and_then/test.out
+++ b/testsuite/gnat2goto/tests/op_and_then/test.out
@@ -1,4 +1,4 @@
-[1] file and_then.adb line 8 assertion: SUCCESS
-[2] file and_then.adb line 13 assertion: SUCCESS
-[3] file and_then.adb line 18 assertion: FAILURE
+[and_then.assertion.1] line 8 assertion : SUCCESS
+[and_then.assertion.2] line 13 assertion : SUCCESS
+[and_then.assertion.3] line 18 assertion : FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/op_expon_mod/test.out
+++ b/testsuite/gnat2goto/tests/op_expon_mod/test.out
@@ -1,14 +1,14 @@
-[1] file op_mod_expon.adb line 5 assertion: SUCCESS
-[2] file op_mod_expon.adb line 6 assertion: SUCCESS
-[3] file op_mod_expon.adb line 7 assertion: SUCCESS
-[4] file op_mod_expon.adb line 8 assertion: SUCCESS
-[5] file op_mod_expon.adb line 9 assertion: SUCCESS
-[6] file op_mod_expon.adb line 10 assertion: SUCCESS
-[7] file op_mod_expon.adb line 11 assertion: SUCCESS
-[8] file op_mod_expon.adb line 12 assertion: SUCCESS
-[9] file op_mod_expon.adb line 13 assertion: SUCCESS
-[10] file op_mod_expon.adb line 14 assertion: SUCCESS
-[11] file op_mod_expon.adb line 15 assertion: SUCCESS
-[12] file op_mod_expon.adb line 16 assertion: SUCCESS
-[13] file op_mod_expon.adb line 17 assertion: SUCCESS
+[test.assertion.1] line 5 assertion : SUCCESS
+[test.assertion.2] line 6 assertion : SUCCESS
+[test.assertion.3] line 7 assertion : SUCCESS
+[test.assertion.4] line 8 assertion : SUCCESS
+[test.assertion.5] line 9 assertion : SUCCESS
+[test.assertion.6] line 10 assertion : SUCCESS
+[test.assertion.7] line 11 assertion : SUCCESS
+[test.assertion.8] line 12 assertion : SUCCESS
+[test.assertion.9] line 13 assertion : SUCCESS
+[test.assertion.10] line 14 assertion : SUCCESS
+[test.assertion.11] line 15 assertion : SUCCESS
+[test.assertion.12] line 16 assertion : SUCCESS
+[test.assertion.13] line 17 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/op_or/test.out
+++ b/testsuite/gnat2goto/tests/op_or/test.out
@@ -1,6 +1,6 @@
-[1] file op_or.adb line 6 assertion: SUCCESS
-[2] file op_or.adb line 7 assertion: SUCCESS
-[3] file op_or.adb line 8 assertion: SUCCESS
-[4] file op_or.adb line 9 assertion: FAILURE
-[5] file op_or.adb line 10 assertion: SUCCESS
+[op_or.assertion.1] line 6 assertion : SUCCESS
+[op_or.assertion.2] line 7 assertion : SUCCESS
+[op_or.assertion.3] line 8 assertion : SUCCESS
+[op_or.assertion.4] line 9 assertion : FAILURE
+[op_or.assertion.5] line 10 assertion : SUCCESS
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/op_or_else/test.out
+++ b/testsuite/gnat2goto/tests/op_or_else/test.out
@@ -1,9 +1,9 @@
 [division-by-zero.2] file op_or_else.adb line 16 division by zero in op_or_else__div_by_zero__x / op_or_else__div_by_zero__y$$op_or_else__div_by_zero__y: FAILURE
 [division-by-zero.1] file op_or_else.adb line 26 division by zero in op_or_else__div_by_zero_not_called__x / op_or_else__div_by_zero_not_called__y$$op_or_else__div_by_zero_not_called__y: SUCCESS
-[1] file op_or_else.adb line 34 assertion: SUCCESS
-[2] file op_or_else.adb line 35 assertion: SUCCESS
-[3] file op_or_else.adb line 36 assertion: SUCCESS
-[4] file op_or_else.adb line 37 assertion: SUCCESS
-[5] file op_or_else.adb line 42 assertion: SUCCESS
-[6] file op_or_else.adb line 46 assertion: SUCCESS
+[op_or_else.assertion.1] line 34 assertion : SUCCESS
+[op_or_else.assertion.2] line 35 assertion : SUCCESS
+[op_or_else.assertion.3] line 36 assertion : SUCCESS
+[op_or_else.assertion.4] line 37 assertion : SUCCESS
+[op_or_else.assertion.5] line 42 assertion : SUCCESS
+[op_or_else.assertion.6] line 46 assertion : SUCCESS
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/op_or_example/test.out
+++ b/testsuite/gnat2goto/tests/op_or_example/test.out
@@ -1,4 +1,4 @@
-[1] file op_or_example.adb line 11 assertion: SUCCESS
-[2] file op_or_example.adb line 15 assertion: SUCCESS
-[3] file op_or_example.adb line 16 assertion: FAILURE
+[op_or_example.assertion.1] line 11 assertion : SUCCESS
+[op_or_example.assertion.2] line 15 assertion : SUCCESS
+[op_or_example.assertion.3] line 16 assertion : FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/out_inout_params/test.out
+++ b/testsuite/gnat2goto/tests/out_inout_params/test.out
@@ -1,5 +1,5 @@
-[1] file func_args.adb line 15 assertion: SUCCESS
-[2] file func_args.adb line 16 assertion: SUCCESS
-[3] file func_args.adb line 17 assertion: SUCCESS
-[4] file func_args.adb line 18 assertion: FAILURE
+[func_args.assertion.1] line 15 assertion : SUCCESS
+[func_args.assertion.2] line 16 assertion : SUCCESS
+[func_args.assertion.3] line 17 assertion : SUCCESS
+[func_args.assertion.4] line 18 assertion : FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/package_type/test.out
+++ b/testsuite/gnat2goto/tests/package_type/test.out
@@ -1,2 +1,2 @@
-[1] file package_type.adb line 8 assertion: SUCCESS
+[package_type.assertion.1] line 8 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/package_use_type_N_Use_Type_Clause/test.out
+++ b/testsuite/gnat2goto/tests/package_use_type_N_Use_Type_Clause/test.out
@@ -1,3 +1,3 @@
-[1] file use_type_clause.adb line 21 assertion: SUCCESS
-[2] file use_type_clause.adb line 24 assertion: SUCCESS
+[use_type_clause.assertion.1] line 21 assertion : SUCCESS
+[use_type_clause.assertion.2] line 24 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/pragma_machine_attribute/test.out
+++ b/testsuite/gnat2goto/tests/pragma_machine_attribute/test.out
@@ -1,2 +1,2 @@
-[1] file pragma_machine_attribute.adb line 21 assertion: SUCCESS
+[pragma_machine_attribute.assertion.1] line 21 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/pragmas/test.out
+++ b/testsuite/gnat2goto/tests/pragmas/test.out
@@ -1,6 +1,6 @@
 Standard_Error from gnat2goto pragmas:
 pragmas.adb:2:04: warning: variable "i" is read but never assigned
 
-[1] file pragmas.adb line 11 assertion: SUCCESS
-[2] file pragmas.adb line 12 assertion: FAILURE
+[pragmas.assertion.1] line 11 assertion : SUCCESS
+[pragmas.assertion.2] line 12 assertion : FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/primitive_pointer/test.out
+++ b/testsuite/gnat2goto/tests/primitive_pointer/test.out
@@ -1,2 +1,2 @@
-[1] file primitive_pointer.adb line 8 assertion: SUCCESS
+[primitive_pointer.assertion.1] line 8 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/private_type_dec/test.out
+++ b/testsuite/gnat2goto/tests/private_type_dec/test.out
@@ -1,2 +1,2 @@
-[1] file test.adb line 7 assertion: SUCCESS
+[test.assertion.1] line 7 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/private_type_decl/test.out
+++ b/testsuite/gnat2goto/tests/private_type_decl/test.out
@@ -1,2 +1,2 @@
-[1] file private_type_decl.adb line 8 assertion: SUCCESS
+[foo.assertion.1] line 8 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/range_check_non_bounded/test.out
+++ b/testsuite/gnat2goto/tests/range_check_non_bounded/test.out
@@ -1,3 +1,3 @@
 [assertion.1] file test.adb line 6 Range Check: SUCCESS
-[1] file test.adb line 7 assertion: SUCCESS
+[test.assertion.1] line 7 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/range_over_subtype/test.out
+++ b/testsuite/gnat2goto/tests/range_over_subtype/test.out
@@ -1,2 +1,2 @@
-[1] file test.adb line 27 assertion: FAILURE
+[foo.assertion.1] line 27 assertion : FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/real_literal/test.out
+++ b/testsuite/gnat2goto/tests/real_literal/test.out
@@ -1,4 +1,4 @@
-[1] file real_literal.adb line 5 assertion: SUCCESS
-[2] file real_literal.adb line 6 assertion: SUCCESS
-[3] file real_literal.adb line 7 assertion: SUCCESS
+[real_literal.assertion.1] line 5 assertion : SUCCESS
+[real_literal.assertion.2] line 6 assertion : SUCCESS
+[real_literal.assertion.3] line 7 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/records/test.out
+++ b/testsuite/gnat2goto/tests/records/test.out
@@ -1,3 +1,3 @@
-[1] file records.adb line 11 assertion: SUCCESS
-[2] file records.adb line 12 assertion: SUCCESS
+[records.assertion.1] line 11 assertion : SUCCESS
+[records.assertion.2] line 12 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/representation_clause_component_size/test.out
+++ b/testsuite/gnat2goto/tests/representation_clause_component_size/test.out
@@ -1,5 +1,5 @@
 [precondition_instance.1] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.2] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.3] file <internal> memcpy destination region writeable: SUCCESS
-[1] file test.adb line 16 assertion: SUCCESS
+[test.assertion.1] line 16 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/representation_clause_size/test.out
+++ b/testsuite/gnat2goto/tests/representation_clause_size/test.out
@@ -1,2 +1,2 @@
-[1] file representation_clause_size.adb line 7 assertion: SUCCESS
+[representation_clause_size.assertion.1] line 7 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/rhs_array_assign/test.out
+++ b/testsuite/gnat2goto/tests/rhs_array_assign/test.out
@@ -7,5 +7,5 @@
 [precondition_instance.7] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.8] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.9] file <internal> memcpy destination region writeable: SUCCESS
-[1] file rhs_array_assign.adb line 9 assertion: SUCCESS
+[rhs_array_assign.assertion.1] line 9 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/separate_subprog/test.out
+++ b/testsuite/gnat2goto/tests/separate_subprog/test.out
@@ -1,3 +1,3 @@
-[2] file p-inc.asu line 6 assertion: SUCCESS
-[1] file p.adb line 16 assertion: FAILURE
+[inc.assertion.1] line 6 assertion : SUCCESS
+[p.assertion.1] line 16 assertion : FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/size_mod_type/test.out
+++ b/testsuite/gnat2goto/tests/size_mod_type/test.out
@@ -1,3 +1,3 @@
-[1] file check_size_mod.adb line 17 assertion: SUCCESS
-[2] file check_size_mod.adb line 18 assertion: SUCCESS
+[check_size_mod.assertion.1] line 17 assertion : SUCCESS
+[check_size_mod.assertion.2] line 18 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/statement_new_block_N_Block_Statement/test.out
+++ b/testsuite/gnat2goto/tests/statement_new_block_N_Block_Statement/test.out
@@ -1,5 +1,5 @@
-[4] file statement_block.adb line 12 assertion: SUCCESS
-[1] file statement_block.adb line 30 assertion: SUCCESS
-[2] file statement_block.adb line 35 assertion: SUCCESS
-[3] file statement_block.adb line 45 assertion: SUCCESS
+[sum_plus_three.assertion.1] line 12 assertion : SUCCESS
+[statement_block.assertion.1] line 30 assertion : SUCCESS
+[statement_block.assertion.2] line 35 assertion : SUCCESS
+[statement_block.assertion.3] line 45 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/string_literal/test.out
+++ b/testsuite/gnat2goto/tests/string_literal/test.out
@@ -1,3 +1,3 @@
-[1] file string_literal.adb line 6 assertion: SUCCESS
-[2] file string_literal.adb line 7 assertion: SUCCESS
+[string_literal.assertion.1] line 6 assertion : SUCCESS
+[string_literal.assertion.2] line 7 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/subpackage/test.out
+++ b/testsuite/gnat2goto/tests/subpackage/test.out
@@ -1,2 +1,2 @@
-[1] file test.adb line 10 assertion: FAILURE
+[test.assertion.1] line 10 assertion : FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/subtyp/test.out
+++ b/testsuite/gnat2goto/tests/subtyp/test.out
@@ -1,2 +1,2 @@
-[1] file subtyp.adb line 7 assertion: SUCCESS
+[subtyp.assertion.1] line 7 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/two_subprog_bodies/test.out
+++ b/testsuite/gnat2goto/tests/two_subprog_bodies/test.out
@@ -1,2 +1,2 @@
-[1] file two.adb line 6 assertion: SUCCESS
+[two.assertion.1] line 6 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/type_modular/test.out
+++ b/testsuite/gnat2goto/tests/type_modular/test.out
@@ -1,10 +1,10 @@
-[1] file modular.adb line 15 assertion: SUCCESS
-[2] file modular.adb line 16 assertion: SUCCESS
-[3] file modular.adb line 17 assertion: SUCCESS
-[4] file modular.adb line 18 assertion: SUCCESS
-[5] file modular.adb line 19 assertion: SUCCESS
-[6] file modular.adb line 20 assertion: SUCCESS
-[7] file modular.adb line 21 assertion: SUCCESS
-[8] file modular.adb line 22 assertion: SUCCESS
-[9] file modular.adb line 23 assertion: SUCCESS
+[modular.assertion.1] line 15 assertion : SUCCESS
+[modular.assertion.2] line 16 assertion : SUCCESS
+[modular.assertion.3] line 17 assertion : SUCCESS
+[modular.assertion.4] line 18 assertion : SUCCESS
+[modular.assertion.5] line 19 assertion : SUCCESS
+[modular.assertion.6] line 20 assertion : SUCCESS
+[modular.assertion.7] line 21 assertion : SUCCESS
+[modular.assertion.8] line 22 assertion : SUCCESS
+[modular.assertion.9] line 23 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/type_modular_arithmetic/test.out
+++ b/testsuite/gnat2goto/tests/type_modular_arithmetic/test.out
@@ -1,20 +1,20 @@
-[1] file modular_type.adb line 6 assertion: SUCCESS
-[2] file modular_type.adb line 8 assertion: SUCCESS
-[3] file modular_type.adb line 9 assertion: SUCCESS
-[4] file modular_type.adb line 11 assertion: SUCCESS
-[5] file modular_type.adb line 12 assertion: SUCCESS
-[6] file modular_type.adb line 13 assertion: SUCCESS
-[7] file modular_type.adb line 14 assertion: SUCCESS
-[8] file modular_type.adb line 15 assertion: SUCCESS
-[9] file modular_type.adb line 16 assertion: SUCCESS
-[10] file modular_type.adb line 17 assertion: SUCCESS
-[11] file modular_type.adb line 18 assertion: SUCCESS
-[12] file modular_type.adb line 19 assertion: SUCCESS
-[13] file modular_type.adb line 20 assertion: SUCCESS
-[14] file modular_type.adb line 21 assertion: SUCCESS
-[15] file modular_type.adb line 22 assertion: SUCCESS
-[16] file modular_type.adb line 23 assertion: SUCCESS
-[17] file modular_type.adb line 24 assertion: SUCCESS
-[18] file modular_type.adb line 26 assertion: SUCCESS
-[19] file modular_type.adb line 28 assertion: SUCCESS
+[assert_val.assertion.1] line 6 assertion : SUCCESS
+[assert_val.assertion.2] line 8 assertion : SUCCESS
+[assert_val.assertion.3] line 9 assertion : SUCCESS
+[assert_val.assertion.4] line 11 assertion : SUCCESS
+[assert_val.assertion.5] line 12 assertion : SUCCESS
+[assert_val.assertion.6] line 13 assertion : SUCCESS
+[assert_val.assertion.7] line 14 assertion : SUCCESS
+[assert_val.assertion.8] line 15 assertion : SUCCESS
+[assert_val.assertion.9] line 16 assertion : SUCCESS
+[assert_val.assertion.10] line 17 assertion : SUCCESS
+[assert_val.assertion.11] line 18 assertion : SUCCESS
+[assert_val.assertion.12] line 19 assertion : SUCCESS
+[assert_val.assertion.13] line 20 assertion : SUCCESS
+[assert_val.assertion.14] line 21 assertion : SUCCESS
+[assert_val.assertion.15] line 22 assertion : SUCCESS
+[assert_val.assertion.16] line 23 assertion : SUCCESS
+[assert_val.assertion.17] line 24 assertion : SUCCESS
+[assert_val.assertion.18] line 26 assertion : SUCCESS
+[assert_val.assertion.19] line 28 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/type_modular_bitwise/test.out
+++ b/testsuite/gnat2goto/tests/type_modular_bitwise/test.out
@@ -1,5 +1,5 @@
-[1] file modular_type.adb line 7 assertion: SUCCESS
-[2] file modular_type.adb line 8 assertion: SUCCESS
-[3] file modular_type.adb line 9 assertion: SUCCESS
-[4] file modular_type.adb line 10 assertion: SUCCESS
+[assert_val.assertion.1] line 7 assertion : SUCCESS
+[assert_val.assertion.2] line 8 assertion : SUCCESS
+[assert_val.assertion.3] line 9 assertion : SUCCESS
+[assert_val.assertion.4] line 10 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/type_modular_non_power_of_two_decl/test.out
+++ b/testsuite/gnat2goto/tests/type_modular_non_power_of_two_decl/test.out
@@ -1,2 +1,2 @@
-[1] file modular_type.adb line 5 assertion: SUCCESS
+[assert_val.assertion.1] line 5 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/unary_minus/test.out
+++ b/testsuite/gnat2goto/tests/unary_minus/test.out
@@ -1,2 +1,2 @@
-[1] file minus.adb line 6 assertion: SUCCESS
+[minus.assertion.1] line 6 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/volatile/test.out
+++ b/testsuite/gnat2goto/tests/volatile/test.out
@@ -1,2 +1,2 @@
-[1] file volatile_type.adb line 14 assertion: SUCCESS
+[volatile_type.assertion.1] line 14 assertion : SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/whileloop/test.out
+++ b/testsuite/gnat2goto/tests/whileloop/test.out
@@ -1,4 +1,4 @@
-[1] file whileloop.adb line 7 assertion: SUCCESS
-[2] file whileloop.adb line 9 assertion: SUCCESS
-[3] file whileloop.adb line 11 assertion: FAILURE
+[whileloop.assertion.1] line 7 assertion : SUCCESS
+[whileloop.assertion.2] line 9 assertion : SUCCESS
+[whileloop.assertion.3] line 11 assertion : FAILURE
 VERIFICATION FAILED


### PR DESCRIPTION
These are used by cbmc to pretty print assertions. As a result, nearly all tests
have slightly different outputs now. This doesn't have the actual pretty printed
assertion expressions yet, but these are planned