### PR TITLE
Handle no return pragma

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -103,11 +103,6 @@ Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Elaborate Body
 Nkind: N_Pragma
 --
-Occurs: 9 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: No return
-Nkind: N_Pragma
---
 Occurs: 8 times
 Calling function: Process_Declaration
 Error message: Package body declaration
@@ -1835,7 +1830,7 @@ Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:982                      |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:984                      |
 Error detected at REDACTED
 --
 Occurs: 2 times

--- a/testsuite/gnat2goto/tests/no_return/main.adb
+++ b/testsuite/gnat2goto/tests/no_return/main.adb
@@ -1,0 +1,20 @@
+procedure Main is
+
+   procedure Fail(Val : Integer);
+   pragma No_Return(Fail);
+
+   procedure Fail(Val : Integer) is
+      Generic_Failure : exception;
+   begin
+      raise Generic_Failure with "Generic Failure";
+   end Fail;
+
+   Val : Integer := 5;
+begin
+   if (Val = 5)
+   then
+     pragma Assert (Val = 5);
+   else
+      Fail(Val);
+   end if;
+end Main;

--- a/testsuite/gnat2goto/tests/no_return/test.out
+++ b/testsuite/gnat2goto/tests/no_return/test.out
@@ -1,0 +1,4 @@
+[assertion.1] file <internal> Ada Check assertion: SUCCESS
+[assertion.2] file main.adb line 9 Ada Exception: SUCCESS
+[main.assertion.1] line 16 assertion Val = 5: SUCCESS
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/no_return/test.py
+++ b/testsuite/gnat2goto/tests/no_return/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()

--- a/testsuite/gnat2goto/tests/no_return_returns/main.adb
+++ b/testsuite/gnat2goto/tests/no_return_returns/main.adb
@@ -1,0 +1,13 @@
+procedure Main is
+  procedure Does_Not_Return (X : Integer) is
+  begin
+    loop
+      if X < 10 then
+        return;
+      end if;
+    end loop;
+  end Does_Not_Return;
+  pragma No_Return (Does_Not_Return);
+begin
+  Does_Not_Return (5);
+end Main;

--- a/testsuite/gnat2goto/tests/no_return_returns/test.out
+++ b/testsuite/gnat2goto/tests/no_return_returns/test.out
@@ -1,0 +1,2 @@
+[assertion.1] file <internal> Ada Check assertion: FAILURE
+VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/no_return_returns/test.py
+++ b/testsuite/gnat2goto/tests/no_return_returns/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
We insert an explicit check at the end of the function (marked by the pragma). The check is just a wrapper for `assert(false)`. Includes a check.