### PR TITLE
Handle compilation units that are package or subprogram declarations.

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -165,7 +165,7 @@ Nkind: N_Real_Literal
 --
 Occurs: 1 times
 Calling function: Do_Compilation_Unit
-Error message: Unknown tree node
+Error message: Generic units are unsupported
 Nkind: N_Compilation_Unit
 --
 Occurs: 1 times

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -986,7 +986,7 @@ package body Tree_Walk is
                Unit_Is_Subprogram := False;
             end;
          when N_Subprogram_Declaration | N_Package_Declaration =>
-            --  Pacakge and subprogram declarations are processed
+            --  Package and subprogram declarations are processed
             --  when they appear in a with statement.
             --  It might be possible to construct a package declaration
             --  which has some features that are imported but not

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -985,10 +985,18 @@ package body Tree_Walk is
                Unit_Symbol := Global_Symbol_Table (Unit_Name);
                Unit_Is_Subprogram := False;
             end;
-
+         when N_Subprogram_Declaration | N_Package_Declaration =>
+            --  Pacakge and subprogram declarations are processed
+            --  when they appear in a with statement.
+            --  It might be possible to construct a package declaration
+            --  which has some features that are imported but not
+            --  directly used (which requires the declaration to be withed),
+            --  but I can't think of one without delving deeply, and I
+            --  think such uses would be unusual (TJJ 21/11/2019)
+            null;
          when others =>
             Report_Unhandled_Node_Empty (N, "Do_Compilation_Unit",
-                                         "Unknown tree node");
+                                         "Generic units are unsupported");
       end case;
 
       return Unit_Symbol;


### PR DESCRIPTION
As these units will be analysed when "withed" they are not analysed
as a stand-alone compilation unit.