### PR TITLE
Add support for null pointer expression

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -74,11 +74,6 @@ Error message: Unsupported pragma: Obsolescent
 Nkind: N_Pragma
 --
 Occurs: 7 times
-Calling function: Do_Expression
-Error message: Unknown expression kind
-Nkind: N_Null
---
-Occurs: 7 times
 Calling function: Do_Type_Reference
 Error message: Type of type not a type
 Nkind: N_Defining_Identifier
@@ -1755,12 +1750,12 @@ Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 3 times
@@ -1770,7 +1765,7 @@ Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:984                      |
+| GNU Ada (ada2goto) Assert_Failure tree_walk.adb:987                      |
 Error detected at REDACTED
 --
 Occurs: 2 times
@@ -1815,332 +1810,332 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times

--- a/experiments/golden-results/ksum-summary.txt
+++ b/experiments/golden-results/ksum-summary.txt
@@ -9,11 +9,6 @@ Error message: Unsupported pragma: Suppress initialization
 Nkind: N_Pragma
 --
 Occurs: 1 times
-Calling function: Do_Expression
-Error message: Unknown expression kind
-Nkind: N_Null
---
-Occurs: 1 times
 Calling function: Do_Type_Definition
 Error message: Access type unsupported
 Nkind: N_Access_To_Object_Definition

--- a/experiments/golden-results/libkeccak-summary.txt
+++ b/experiments/golden-results/libkeccak-summary.txt
@@ -33,11 +33,6 @@ Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Suppress initialization
 Nkind: N_Pragma
 --
-Occurs: 9 times
-Calling function: Do_Expression
-Error message: Unknown expression kind
-Nkind: N_Null
---
 Occurs: 2 times
 Calling function: Do_Expression
 Error message: ATTRIBUTE_ASM_OUTPUT unsupported

--- a/experiments/golden-results/muen-summary.txt
+++ b/experiments/golden-results/muen-summary.txt
@@ -2985,202 +2985,202 @@ Error detected at REDACTED
 --
 Occurs: 2 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times

--- a/experiments/golden-results/vct-summary.txt
+++ b/experiments/golden-results/vct-summary.txt
@@ -120,12 +120,12 @@ Raw compiler error message:
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1775|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from ireps.ads:1784|
 Error detected at REDACTED
 --
 Occurs: 1 times

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -81,6 +81,9 @@ package body Tree_Walk is
         Post => Kind (Do_Modular_Type_Definition'Result)
                 in Class_Type;
 
+   function Do_Null_Expression (N : Node_Id) return Irep
+     with Pre => Nkind (N) = N_Null;
+
    function Do_Defining_Identifier (E : Entity_Id) return Irep
    with Pre  => Nkind (E) = N_Defining_Identifier,
         Post => Kind (Do_Defining_Identifier'Result) in
@@ -1370,6 +1373,8 @@ package body Tree_Walk is
          when N_Quantified_Expression =>
             return Report_Unhandled_Node_Irep (N, "Do_Expression",
                                                "Quantified");
+         when N_Null =>
+            return Do_Null_Expression (N);
          when others                 =>
             return Report_Unhandled_Node_Irep (N, "Do_Expression",
                                                "Unknown expression kind");
@@ -6238,4 +6243,12 @@ package body Tree_Walk is
       Append_Argument (No_Return_Check_Args, Get_Int32_T_Zero);
       return No_Return_Check_Call;
    end Get_No_Return_Check;
+
+   function Do_Null_Expression (N : Node_Id) return Irep is
+      Pointer_Type : constant Irep := Do_Type_Reference (Etype (N));
+   begin
+      return Make_Null_Pointer
+        (I_Type => Pointer_Type,
+         Source_Location => Get_Source_Location (N));
+   end Do_Null_Expression;
 end Tree_Walk;

--- a/gnat2goto/ireps/irep_specs/null_pointer.json
+++ b/gnat2goto/ireps/irep_specs/null_pointer.json
@@ -1,0 +1,4 @@
+{
+  "parent": "expr",
+  "id": "NULL"
+}

--- a/testsuite/gnat2goto/tests/null_pointer/null_pointer.adb
+++ b/testsuite/gnat2goto/tests/null_pointer/null_pointer.adb
@@ -1,0 +1,6 @@
+procedure Null_Pointer is
+  type Ptr is access Integer;
+  X : constant Ptr := null;
+begin
+  pragma Assert (X = null);
+end Null_Pointer;

--- a/testsuite/gnat2goto/tests/null_pointer/test.out
+++ b/testsuite/gnat2goto/tests/null_pointer/test.out
@@ -1,0 +1,10 @@
+Standard_Output from gnat2goto null_pointer:
+----------At: Do_Type_Definition----------
+----------Access type unsupported----------
+N_Access_To_Object_Definition (Node_Id=2262) (source)
+Parent = N_Full_Type_Declaration (Node_Id=2263)
+Sloc = 8232  null_pointer.adb:2:15
+Subtype_Indication = N_Identifier "integer" (Node_Id=2261)
+
+[null_pointer.assertion.1] line 5 assertion X = null: SUCCESS
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/null_pointer/test.py
+++ b/testsuite/gnat2goto/tests/null_pointer/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
Note that as of now this only adds support for the expression itself,
support for access types themselves is still missing, so this won’t yet
work in cases where we use access types in a nontrivial way.