### PR TITLE
Include function info in assertions

### DIFF
--- a/gnat2goto/driver/goto_utils.adb
+++ b/gnat2goto/driver/goto_utils.adb
@@ -1018,4 +1018,26 @@ package body GOTO_Utils is
                             Range_Check => Range_Check);
    end Make_Let_Binding_Expr;
 
+   function Get_Context_Name (Intermediate_Node : Node_Id)
+                              return String is
+   begin
+      if not (Present (Intermediate_Node)) then
+         return "";
+      end if;
+      case Nkind (Intermediate_Node) is
+         when N_Subprogram_Body =>
+            return Get_Name_String
+              (Chars
+                 (Defining_Unit_Name
+                      (Specification
+                           (Intermediate_Node))));
+         when N_Package_Body =>
+            return Get_Name_String
+              (Chars
+                 (Defining_Unit_Name
+                      (Intermediate_Node)));
+         when others =>
+            return Get_Context_Name (Parent (Intermediate_Node));
+      end case;
+   end Get_Context_Name;
 end GOTO_Utils;

--- a/gnat2goto/driver/goto_utils.ads
+++ b/gnat2goto/driver/goto_utils.ads
@@ -238,4 +238,9 @@ package GOTO_Utils is
       I_Type : Irep := Ireps.Empty;
       Range_Check : Boolean := False)
    return Irep;
+
+   --  return name of containing function or package
+   --  (whichever comes earlier)
+   function Get_Context_Name (Intermediate_Node : Node_Id)
+                              return String;
 end GOTO_Utils;

--- a/gnat2goto/driver/range_check.adb
+++ b/gnat2goto/driver/range_check.adb
@@ -428,6 +428,7 @@ package body Range_Check is
          Source_Location => Get_Source_Location (N),
          I_Type => Expected_Return_Type);
    begin
+      Set_Function (Source_Loc, Get_Context_Name (N));
       pragma Assert (Underlying_Lower_Type = Underlying_Upper_Type);
 
       Append_Argument (Call_Args,

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -2507,25 +2507,6 @@ package body Tree_Walk is
          function Make_Assert_Comment return Irep;
          function Make_Assert_Comment return Irep
          is
-            --  return name of containing function or package
-            --  (whichever comes earlier)
-            function Get_Context_Name (Intermediate_Node : Node_Id)
-                                      return String;
-            function Get_Context_Name (Intermediate_Node : Node_Id)
-                                      return String is
-            begin
-               case Nkind (Intermediate_Node) is
-                  when N_Subprogram_Body | N_Package_Body =>
-                     return Get_Name_String
-                       (Chars
-                          (Defining_Unit_Name
-                             (Specification
-                                (Intermediate_Node))));
-                  when others =>
-                     return Get_Context_Name (Parent (Intermediate_Node));
-               end case;
-            end Get_Context_Name;
-
             Source_Loc : constant Irep := Get_Source_Location (N);
             Context_Name : constant String := Get_Context_Name (N);
             Comment_Prefix : constant String := "assertion ";

--- a/testsuite/gnat2goto/tests/absolute/test.out
+++ b/testsuite/gnat2goto/tests/absolute/test.out
@@ -1,4 +1,4 @@
-[assertion.1] file absolute.adb line 3 Ada Check assertion: SUCCESS
+[symmetric_difference.assertion.1] line 3 Ada Check assertion: SUCCESS
 [absolute.assertion.1] line 7 assertion Symmetric_Difference (X, Y) = Symmetric_Difference (Y, X): SUCCESS
 [absolute.assertion.2] line 8 assertion Symmetric_Difference (X, Y) = 5: SUCCESS
 [absolute.assertion.3] line 10 assertion Symmetric_Difference (Y, X) /= 5: FAILURE

--- a/testsuite/gnat2goto/tests/absolute_float/test.out
+++ b/testsuite/gnat2goto/tests/absolute_float/test.out
@@ -1,4 +1,4 @@
-[assertion.1] file absolute_float.adb line 3 Ada Check assertion: SUCCESS
+[symmetric_difference.assertion.1] line 3 Ada Check assertion: SUCCESS
 [absolute_float.assertion.1] line 7 assertion Symmetric_Difference (X, Y) = Symmetric_Difference (Y, X): SUCCESS
 [absolute_float.assertion.2] line 8 assertion Symmetric_Difference (X, Y) = 5.0: SUCCESS
 [absolute_float.assertion.3] line 10 assertion Symmetric_Difference (Y, X) /= 5.0: FAILURE

--- a/testsuite/gnat2goto/tests/address_clause/test.out
+++ b/testsuite/gnat2goto/tests/address_clause/test.out
@@ -18,6 +18,6 @@ N_Attribute_Definition_Clause "address" (Node_Id=2295) (source,analyzed)
  Entity = N_Defining_Identifier "var_addr_2" (Entity_Id=2282)
  Check_Address_Alignment = True
 
-[address_clause.assertion.1] line 12 assertion Var_Addr_1 + Var_Addr_2 = 3: SUCCESS
-[assertion.1] line 12 Ada Check assertion: SUCCESS
+[address_clause.assertion.2] line 12 assertion Var_Addr_1 + Var_Addr_2 = 3: SUCCESS
+[address_clause.assertion.1] line 12 Ada Check assertion: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/arrays_access/test.out
+++ b/testsuite/gnat2goto/tests/arrays_access/test.out
@@ -1,6 +1,6 @@
 [precondition_instance.1] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.2] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.3] file <internal> memcpy destination region writeable: SUCCESS
-[assertion.1] file arrays_access.adb line 5 Ada Check assertion: SUCCESS
-[arrays_access.assertion.1] line 6 assertion Actual7(1) = 2: SUCCESS
+[arrays_access.assertion.1] line 5 Ada Check assertion: SUCCESS
+[arrays_access.assertion.2] line 6 assertion Actual7(1) = 2: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/arrays_assign_nonoverlap/test.out
+++ b/testsuite/gnat2goto/tests/arrays_assign_nonoverlap/test.out
@@ -19,9 +19,9 @@
 [precondition_instance.7] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.8] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.9] file <internal> memcpy destination region writeable: SUCCESS
-[assertion.1] file arrays_assign_nonoverlap.adb line 8 Ada Check assertion: SUCCESS
-[arrays_assign_nonoverlap.assertion.1] line 8 assertion Full_Arr(1)=3: SUCCESS
-[arrays_assign_nonoverlap.assertion.2] line 9 assertion Full_Arr(2)=4: SUCCESS
-[arrays_assign_nonoverlap.assertion.3] line 10 assertion Full_Arr(3)=1: SUCCESS
-[arrays_assign_nonoverlap.assertion.4] line 11 assertion Full_Arr(4)=2: SUCCESS
+[arrays_assign_nonoverlap.assertion.1] line 8 Ada Check assertion: SUCCESS
+[arrays_assign_nonoverlap.assertion.2] line 8 assertion Full_Arr(1)=3: SUCCESS
+[arrays_assign_nonoverlap.assertion.3] line 9 assertion Full_Arr(2)=4: SUCCESS
+[arrays_assign_nonoverlap.assertion.4] line 10 assertion Full_Arr(3)=1: SUCCESS
+[arrays_assign_nonoverlap.assertion.5] line 11 assertion Full_Arr(4)=2: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/arrays_attributes_static/test.out
+++ b/testsuite/gnat2goto/tests/arrays_attributes_static/test.out
@@ -16,7 +16,7 @@
 [precondition_instance.7] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.8] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.9] file <internal> memcpy destination region writeable: SUCCESS
-[assertion.1] file arrays_attributes_static.adb line 12 Ada Check assertion: SUCCESS
-[arrays_attributes_static.assertion.1] line 16 assertion Array_Attribs = 41: SUCCESS
-[arrays_attributes_static.assertion.2] line 17 assertion An_Index = 12: SUCCESS
+[arrays_attributes_static.assertion.1] line 12 Ada Check assertion: SUCCESS
+[arrays_attributes_static.assertion.2] line 16 assertion Array_Attribs = 41: SUCCESS
+[arrays_attributes_static.assertion.3] line 17 assertion An_Index = 12: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/arrays_concat/test.out
+++ b/testsuite/gnat2goto/tests/arrays_concat/test.out
@@ -10,6 +10,6 @@
 [precondition_instance.7] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.8] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.9] file <internal> memcpy destination region writeable: SUCCESS
-[assertion.1] file arrays_concat.adb line 7 Ada Check assertion: SUCCESS
-[arrays_concat.assertion.1] line 7 assertion Actual(2)=4: SUCCESS
+[arrays_concat.assertion.1] line 7 Ada Check assertion: SUCCESS
+[arrays_concat.assertion.2] line 7 assertion Actual(2)=4: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/arrays_constraints/test.out
+++ b/testsuite/gnat2goto/tests/arrays_constraints/test.out
@@ -1,9 +1,9 @@
-[assertion.1] file array_constraints.adb line 109 Ada Check assertion: SUCCESS
-[assertion.2] file array_constraints.adb line 117 Ada Check assertion: SUCCESS
-[array_constraints.assertion.1] line 117 assertion VUA1 (1) + VUA2 (2) + VUA3 (3) + VUA4 (4) + VUA5 (5) + VUA6 (6) + VUA7 (7) + VUA8 (8) = 36: SUCCESS
-[array_constraints.assertion.2] line 131 assertion VCA1 (VCA1'Last) + VCA2 (VCA2'Last - 1) + VCA3 (VCA3'Last - 2) + VCA4 (Constrained_Array_4'Last - 3) = 10: SUCCESS
-[array_constraints.assertion.3] line 143 assertion VEA1 (One) + VEA2 (Two) + VEA3 (Three) + VEA4 (Four) + VEA5 (Five) + VEA6 (Six) = 21: SUCCESS
-[array_constraints.assertion.4] line 154 assertion VBA1 (False) + VBA2 (True) + VBA3 (False) + VBA4 (True) + VBA5 (False) + VBA6 (True) = 7: SUCCESS
-[array_constraints.assertion.5] line 166 assertion VAC1 ('A') + VAC3 ('b') + VAC4 ('c') + VAC5 ('0') + VAC6 ('x') + VAC8 ('e') + VAC9 ('f') = 36: SUCCESS
-[array_constraints.assertion.6] line 180 assertion VAM1 (1) + VAM2 (2) + VAM3 (3) + VAM4 (4) + VAM5 (5) + VAM6 (6) + VAM7 (7) + VAM8 (8) + VAM9 (9) = 45: SUCCESS
+[array_constraints.assertion.1] line 109 Ada Check assertion: SUCCESS
+[array_constraints.assertion.8] line 117 Ada Check assertion: SUCCESS
+[array_constraints.assertion.2] line 117 assertion VUA1 (1) + VUA2 (2) + VUA3 (3) + VUA4 (4) + VUA5 (5) + VUA6 (6) + VUA7 (7) + VUA8 (8) = 36: SUCCESS
+[array_constraints.assertion.3] line 131 assertion VCA1 (VCA1'Last) + VCA2 (VCA2'Last - 1) + VCA3 (VCA3'Last - 2) + VCA4 (Constrained_Array_4'Last - 3) = 10: SUCCESS
+[array_constraints.assertion.4] line 143 assertion VEA1 (One) + VEA2 (Two) + VEA3 (Three) + VEA4 (Four) + VEA5 (Five) + VEA6 (Six) = 21: SUCCESS
+[array_constraints.assertion.5] line 154 assertion VBA1 (False) + VBA2 (True) + VBA3 (False) + VBA4 (True) + VBA5 (False) + VBA6 (True) = 7: SUCCESS
+[array_constraints.assertion.6] line 166 assertion VAC1 ('A') + VAC3 ('b') + VAC4 ('c') + VAC5 ('0') + VAC6 ('x') + VAC8 ('e') + VAC9 ('f') = 36: SUCCESS
+[array_constraints.assertion.7] line 180 assertion VAM1 (1) + VAM2 (2) + VAM3 (3) + VAM4 (4) + VAM5 (5) + VAM6 (6) + VAM7 (7) + VAM8 (8) + VAM9 (9) = 45: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/arrays_index/test.out
+++ b/testsuite/gnat2goto/tests/arrays_index/test.out
@@ -1,6 +1,6 @@
 [precondition_instance.1] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.2] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.3] file <internal> memcpy destination region writeable: SUCCESS
-[assertion.1] file arrays_index.adb line 5 Ada Check assertion: SUCCESS
-[arrays_index.assertion.1] line 9 assertion Actual(2) = 11: SUCCESS
+[arrays_index.assertion.1] line 5 Ada Check assertion: SUCCESS
+[arrays_index.assertion.2] line 9 assertion Actual(2) = 11: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/arrays_index_enum/test.out
+++ b/testsuite/gnat2goto/tests/arrays_index_enum/test.out
@@ -1,6 +1,6 @@
 [precondition_instance.1] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.2] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.3] file <internal> memcpy destination region writeable: SUCCESS
-[assertion.1] file test.adb line 7 Ada Check assertion: SUCCESS
-[test.assertion.1] line 7 assertion Array_Value(Two) = 2: SUCCESS
+[test.assertion.1] line 7 Ada Check assertion: SUCCESS
+[test.assertion.2] line 7 assertion Array_Value(Two) = 2: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/arrays_range/test.out
+++ b/testsuite/gnat2goto/tests/arrays_range/test.out
@@ -1,9 +1,9 @@
 [precondition_instance.1] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.2] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.3] file <internal> memcpy destination region writeable: SUCCESS
-[assertion.2] file arrays_range.adb line 8 Ada Check assertion: FAILURE
-[assertion.1] file arrays_range.adb line 8 Ada Check assertion: SUCCESS
-[array_consumer.assertion.1] line 9 assertion An_Index = 2: SUCCESS
-[array_consumer.assertion.2] line 11 assertion An_Index = 4: SUCCESS
-[array_consumer.assertion.3] line 13 assertion An_Index = -1: SUCCESS
+[array_consumer.assertion.2] line 8 Ada Check assertion: FAILURE
+[array_consumer.assertion.1] line 8 Ada Check assertion: SUCCESS
+[array_consumer.assertion.3] line 9 assertion An_Index = 2: SUCCESS
+[array_consumer.assertion.4] line 11 assertion An_Index = 4: SUCCESS
+[array_consumer.assertion.5] line 13 assertion An_Index = -1: SUCCESS
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/arrays_write_element/test.out
+++ b/testsuite/gnat2goto/tests/arrays_write_element/test.out
@@ -1,5 +1,5 @@
 [precondition_instance.1] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.2] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.3] file <internal> memcpy destination region writeable: SUCCESS
-[assertion.1] file arrays_write_element.adb line 6 Ada Check assertion: SUCCESS
+[arrays_write_element.assertion.1] line 6 Ada Check assertion: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/assertion_pretty_printing/test.out
+++ b/testsuite/gnat2goto/tests/assertion_pretty_printing/test.out
@@ -1,6 +1,6 @@
 [check.assertion.1] line 15 assertion X = 5: FAILURE
 [check2.assertion.1] line 20 assertion False or (X < 10 and X > 0): SUCCESS
-[assertion.1] line 28 Ada Check assertion: SUCCESS
+[plus.assertion.1] line 28 Ada Check assertion: SUCCESS
 [check3.assertion.1] line 32 assertion Plus (X, Plus (X, 1)) <= 15 and Plus (X => X, Y => -5) >= -5: FAILURE
 [check4.assertion.1] line 43 assertion X < 10: FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/assign/test.out
+++ b/testsuite/gnat2goto/tests/assign/test.out
@@ -1,4 +1,4 @@
 [assign.assertion.1] line 6 assertion a = 1: SUCCESS
 [assign.assertion.2] line 7 assertion b = 2: SUCCESS
-[assertion.1] line 8 Ada Check assertion: SUCCESS
+[assign.assertion.3] line 8 Ada Check assertion: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/basic_exception/test.out
+++ b/testsuite/gnat2goto/tests/basic_exception/test.out
@@ -1,4 +1,4 @@
-[assertion.2] file test.adb line 6 Ada Exception: FAILURE
-[assertion.1] file test.adb line 16 Ada Check assertion: SUCCESS
-[test.assertion.1] line 25 assertion Error_Count = 1: SUCCESS
+[assertion.1] file test.adb line 6 Ada Exception: FAILURE
+[test.assertion.1] line 16 Ada Check assertion: SUCCESS
+[test.assertion.2] line 25 assertion Error_Count = 1: SUCCESS
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/constant_declarations/test.out
+++ b/testsuite/gnat2goto/tests/constant_declarations/test.out
@@ -1,6 +1,6 @@
 Error from cbmc test:
-function '__CPROVER_Ada_Overflow_Check' in module '' is shadowed by a definition in module ''
 function '__range_check_const_decs.5' in module '' is shadowed by a definition in module ''
+function '__CPROVER_Ada_Overflow_Check' in module '' is shadowed by a definition in module ''
 
 [assertion.1] file const_decs.ads line 8 Ada Check assertion: FAILURE
 [test.assertion.1] line 8 assertion My_P = 50: FAILURE

--- a/testsuite/gnat2goto/tests/declaration_rename_N_Renaming_Declaration/test.out
+++ b/testsuite/gnat2goto/tests/declaration_rename_N_Renaming_Declaration/test.out
@@ -1,6 +1,6 @@
-[assertion.1] file declaration_rename.adb line 25 Ada Check assertion: SUCCESS
-[declaration_rename.assertion.1] line 28 assertion B=3: SUCCESS
-[declaration_rename.assertion.2] line 29 assertion Simply_Named_Int=11: SUCCESS
-[declaration_rename.assertion.3] line 30 assertion My_Plus(A,B)=5: SUCCESS
-[declaration_rename.assertion.4] line 31 assertion C=4: SUCCESS
+[declaration_rename.assertion.1] line 25 Ada Check assertion: SUCCESS
+[declaration_rename.assertion.2] line 28 assertion B=3: SUCCESS
+[declaration_rename.assertion.3] line 29 assertion Simply_Named_Int=11: SUCCESS
+[declaration_rename.assertion.4] line 30 assertion My_Plus(A,B)=5: SUCCESS
+[declaration_rename.assertion.5] line 31 assertion C=4: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/deferred_constant/test.out
+++ b/testsuite/gnat2goto/tests/deferred_constant/test.out
@@ -1,3 +1,3 @@
-[assertion.1] file deferred_const.adb line 4 Ada Check assertion: SUCCESS
+[inc.assertion.1] line 4 Ada Check assertion: SUCCESS
 [test.assertion.1] line 6 assertion My_P = 4: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/discriminated_record/test.out
+++ b/testsuite/gnat2goto/tests/discriminated_record/test.out
@@ -1,4 +1,4 @@
-[assertion.1] file discriminated_record.adb line 16 Ada Check assertion: SUCCESS
-[discriminated_record.assertion.1] line 19 assertion Inst1.A (5) = 1: SUCCESS
-[discriminated_record.assertion.2] line 21 assertion Inst1.A (5) = 1: SUCCESS
+[discriminated_record.assertion.1] line 16 Ada Check assertion: SUCCESS
+[discriminated_record.assertion.2] line 19 assertion Inst1.A (5) = 1: SUCCESS
+[discriminated_record.assertion.3] line 21 assertion Inst1.A (5) = 1: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/divide/test.out
+++ b/testsuite/gnat2goto/tests/divide/test.out
@@ -1,4 +1,4 @@
 [assertion.1] file divide.adb line 6 Ada Check assertion: SUCCESS
-[assertion.2] file divide.adb line 6 Ada Check assertion: SUCCESS
-[divide.assertion.1] line 7 assertion C = 2: SUCCESS
+[divide.assertion.1] line 6 Ada Check assertion: SUCCESS
+[divide.assertion.2] line 7 assertion C = 2: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/divide_by_zero/test.out
+++ b/testsuite/gnat2goto/tests/divide_by_zero/test.out
@@ -1,3 +1,3 @@
-[assertion.2] file divide_by_zero.adb line 6 Ada Check assertion: FAILURE
-[assertion.1] file divide_by_zero.adb line 6 Ada Check assertion: FAILURE
+[divide_by_zero.assertion.1] line 6 Ada Check assertion: FAILURE
+[assertion.1] line 6 Ada Check assertion: FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/enum_in_param/test.out
+++ b/testsuite/gnat2goto/tests/enum_in_param/test.out
@@ -2,5 +2,5 @@
 [precondition_instance.2] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.3] file <internal> memcpy destination region writeable: SUCCESS
 [p_enum_in.assertion.1] line 19 assertion E in More_Than_Two: SUCCESS
-[assertion.1] line 23 Ada Check assertion: SUCCESS
+[enum_in.assertion.1] line 23 Ada Check assertion: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/expanded_name/test.out
+++ b/testsuite/gnat2goto/tests/expanded_name/test.out
@@ -1,3 +1,3 @@
-[assertion.1] file expanded_name.adb line 8 Ada Check assertion: SUCCESS
-[expanded_name.assertion.1] line 12 assertion (if Withed_Package.X = 1 then N = 2 else N = 1): SUCCESS
+[expanded_name.assertion.1] line 8 Ada Check assertion: SUCCESS
+[expanded_name.assertion.2] line 12 assertion (if Withed_Package.X = 1 then N = 2 else N = 1): SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/expanded_name_subtype_indication/test.out
+++ b/testsuite/gnat2goto/tests/expanded_name_subtype_indication/test.out
@@ -1,5 +1,5 @@
-[test.assertion.1] line 8 assertion Val < 2.0: SUCCESS
-[test.assertion.2] line 10 assertion Val > 0.0: SUCCESS
-[test.assertion.3] line 11 assertion Val * 20.0 < 10.0: FAILURE
-[assertion.1] line 11 Ada Check assertion: SUCCESS
+[test.assertion.2] line 8 assertion Val < 2.0: SUCCESS
+[test.assertion.3] line 10 assertion Val > 0.0: SUCCESS
+[test.assertion.4] line 11 assertion Val * 20.0 < 10.0: FAILURE
+[test.assertion.1] line 11 Ada Check assertion: SUCCESS
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/floating_definition/test.out
+++ b/testsuite/gnat2goto/tests/floating_definition/test.out
@@ -1,5 +1,5 @@
-[assertion.1] file floating_definition.adb line 8 Ada Check assertion: SUCCESS
-[assertion.2] file floating_definition.adb line 9 Ada Check assertion: SUCCESS
-[floating_definition.assertion.1] line 10 assertion Small_Number > 0.9: SUCCESS
-[floating_definition.assertion.2] line 11 assertion Large_Number > 22.7: FAILURE
+[floating_definition.assertion.1] line 8 Ada Check assertion: SUCCESS
+[floating_definition.assertion.4] line 9 Ada Check assertion: SUCCESS
+[floating_definition.assertion.2] line 10 assertion Small_Number > 0.9: SUCCESS
+[floating_definition.assertion.3] line 11 assertion Large_Number > 22.7: FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/floating_point_literals/test.out
+++ b/testsuite/gnat2goto/tests/floating_point_literals/test.out
@@ -1,7 +1,7 @@
-[floating_point_literals.assertion.1] line 8 assertion X > Z: FAILURE
-[floating_point_literals.assertion.2] line 10 assertion X < Z: SUCCESS
-[assertion.1] line 12 Ada Check assertion: SUCCESS
-[floating_point_literals.assertion.3] line 12 assertion X + Y = Z: FAILURE
-[floating_point_literals.assertion.4] line 14 assertion X + Y < Z: SUCCESS
-[floating_point_literals.assertion.5] line 16 assertion W < 1.2: SUCCESS
+[floating_point_literals.assertion.2] line 8 assertion X > Z: FAILURE
+[floating_point_literals.assertion.3] line 10 assertion X < Z: SUCCESS
+[floating_point_literals.assertion.1] line 12 Ada Check assertion: SUCCESS
+[floating_point_literals.assertion.4] line 12 assertion X + Y = Z: FAILURE
+[floating_point_literals.assertion.5] line 14 assertion X + Y < Z: SUCCESS
+[floating_point_literals.assertion.6] line 16 assertion W < 1.2: SUCCESS
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/forloop/test.out
+++ b/testsuite/gnat2goto/tests/forloop/test.out
@@ -1,3 +1,3 @@
-[assertion.1] file forloop.adb line 6 Ada Check assertion: SUCCESS
-[forloop.assertion.1] line 9 assertion A = 6: SUCCESS
+[forloop.assertion.1] line 6 Ada Check assertion: SUCCESS
+[forloop.assertion.2] line 9 assertion A = 6: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/func/test.out
+++ b/testsuite/gnat2goto/tests/func/test.out
@@ -1,3 +1,3 @@
-[assertion.1] file func.adb line 6 Ada Check assertion: SUCCESS
+[assign2.assertion.1] line 6 Ada Check assertion: SUCCESS
 [func.assertion.1] line 10 assertion C = 3: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/func_args/test.out
+++ b/testsuite/gnat2goto/tests/func_args/test.out
@@ -1,4 +1,4 @@
-[assertion.1] file func_args.adb line 6 Ada Check assertion: SUCCESS
+[assign2.assertion.1] line 6 Ada Check assertion: SUCCESS
 [func_args.assertion.1] line 10 assertion C = 3: SUCCESS
 [func_args.assertion.2] line 11 assertion Assign2 (5, 6) = 12: FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/generics/test.out
+++ b/testsuite/gnat2goto/tests/generics/test.out
@@ -1,4 +1,4 @@
 [check_assoc_int_minusR.assertion.1] line 10 assertion (A + (B + C)) = ((A + B) + C): FAILURE
-[assertion.1] line 10 Ada Check assertion: FAILURE
-[check_assoc_intR.assertion.1] line 10 assertion (A + (B + C)) = ((A + B) + C): SUCCESS
+[check_assoc_intR.assertion.1] line 10 Ada Check assertion: FAILURE
+[check_assoc_intR.assertion.2] line 10 assertion (A + (B + C)) = ((A + B) + C): SUCCESS
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/if_integer/test.out
+++ b/testsuite/gnat2goto/tests/if_integer/test.out
@@ -1,6 +1,6 @@
-[divide.assertion.1] line 4 assertion B / 1 = B: SUCCESS
+[divide.assertion.2] line 4 assertion B / 1 = B: SUCCESS
 [assertion.1] line 4 Ada Check assertion: SUCCESS
-[divide.assertion.2] line 6 assertion B / B = 1: SUCCESS
-[assertion.2] line 6 Ada Check assertion: SUCCESS
-[divide.assertion.3] line 8 assertion B < 0: FAILURE
+[divide.assertion.3] line 6 assertion B / B = 1: SUCCESS
+[divide.assertion.1] line 6 Ada Check assertion: SUCCESS
+[divide.assertion.4] line 8 assertion B < 0: FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/ifthenelse/test.out
+++ b/testsuite/gnat2goto/tests/ifthenelse/test.out
@@ -1,3 +1,3 @@
-[assertion.1] file ifthenelse.adb line 7 Ada Check assertion: SUCCESS
+[ifthenelse.assertion.2] line 7 Ada Check assertion: SUCCESS
 [ifthenelse.assertion.1] line 11 assertion C = 3: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/incomplete_dec/test.out
+++ b/testsuite/gnat2goto/tests/incomplete_dec/test.out
@@ -1,3 +1,3 @@
-[assertion.1] file incomplete_dec.adb line 4 Ada Check assertion: SUCCESS
+[inc.assertion.1] line 4 Ada Check assertion: SUCCESS
 [test.assertion.1] line 7 assertion My_Rec.A = 2: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/incomplete_dec_priv/test.out
+++ b/testsuite/gnat2goto/tests/incomplete_dec_priv/test.out
@@ -1,3 +1,3 @@
-[assertion.1] file incomplete_dec_priv.adb line 4 Ada Check assertion: SUCCESS
+[p.assertion.1] line 4 Ada Check assertion: SUCCESS
 [test.assertion.1] line 7 assertion My_Int = 5: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/index_check/test.out
+++ b/testsuite/gnat2goto/tests/index_check/test.out
@@ -1,6 +1,6 @@
 [precondition_instance.1] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.2] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.3] file <internal> memcpy destination region writeable: SUCCESS
-[assertion.1] file main.adb line 6 Ada Check assertion: FAILURE
+[main.assertion.2] line 6 Ada Check assertion: FAILURE
 [main.assertion.1] line 9 assertion AnArray(3)=6: SUCCESS
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/int_overflow/test.out
+++ b/testsuite/gnat2goto/tests/int_overflow/test.out
@@ -1,2 +1,2 @@
-[assertion.1] file int_overflow.adb line 5 Ada Check assertion: FAILURE
+[int_overflow.assertion.1] line 5 Ada Check assertion: FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/intrinsic/test.out
+++ b/testsuite/gnat2goto/tests/intrinsic/test.out
@@ -3,5 +3,5 @@ Warning: Multi-language analysis unsupported.
 Warning: Multi-language analysis unsupported.
 
 [overflow.1] file use_import.adb line 16 arithmetic overflow on signed unary minus in -((long int)use_import__i): SUCCESS
-[assertion.1] file use_import.adb line 16 Ada Check assertion: SUCCESS
+[use_import.assertion.1] line 16 Ada Check assertion: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/loop_in_custom_type/test.out
+++ b/testsuite/gnat2goto/tests/loop_in_custom_type/test.out
@@ -1,4 +1,4 @@
-[test.assertion.1] line 8 assertion X>4: FAILURE
-[assertion.1] line 9 Ada Check assertion: SUCCESS
-[test.assertion.2] line 11 assertion Iter_Counter = To - From + 1: SUCCESS
+[test.assertion.2] line 8 assertion X>4: FAILURE
+[test.assertion.1] line 9 Ada Check assertion: SUCCESS
+[test.assertion.3] line 11 assertion Iter_Counter = To - From + 1: SUCCESS
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/loop_range_mod_type/test.out
+++ b/testsuite/gnat2goto/tests/loop_range_mod_type/test.out
@@ -1,3 +1,3 @@
-[assertion.1] file test.adb line 23 Ada Check assertion: SUCCESS
-[test.assertion.1] line 31 assertion Sum = RAM_End - RAM_Start + 1: SUCCESS
+[test.assertion.1] line 23 Ada Check assertion: SUCCESS
+[test.assertion.2] line 31 assertion Sum = RAM_End - RAM_Start + 1: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/loop_range_variable/test.out
+++ b/testsuite/gnat2goto/tests/loop_range_variable/test.out
@@ -1,3 +1,3 @@
-[assertion.1] file test.adb line 9 Ada Check assertion: SUCCESS
-[test.assertion.1] line 11 assertion j < 4: FAILURE
+[test.assertion.1] line 9 Ada Check assertion: SUCCESS
+[test.assertion.2] line 11 assertion j < 4: FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/main_params_and_return/test.out
+++ b/testsuite/gnat2goto/tests/main_params_and_return/test.out
@@ -1,4 +1,4 @@
-[assertion.1] file main_params_and_return.adb line 18 Ada Check assertion: SUCCESS
-[main_params_and_return.assertion.1] line 19 assertion C <= 20: SUCCESS
-[main_params_and_return.assertion.2] line 20 assertion C >= 0: SUCCESS
+[main_params_and_return.assertion.1] line 18 Ada Check assertion: SUCCESS
+[main_params_and_return.assertion.2] line 19 assertion C <= 20: SUCCESS
+[main_params_and_return.assertion.3] line 20 assertion C >= 0: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/mixed_parameters/test.out
+++ b/testsuite/gnat2goto/tests/mixed_parameters/test.out
@@ -1,4 +1,4 @@
-[assertion.1] file mixed_parameters.adb line 5 Ada Check assertion: SUCCESS
+[subtract.assertion.1] line 5 Ada Check assertion: SUCCESS
 [mixed_parameters.assertion.1] line 10 assertion C = 1: SUCCESS
 [mixed_parameters.assertion.2] line 12 assertion C = 0: SUCCESS
 [mixed_parameters.assertion.3] line 14 assertion C = 5: SUCCESS

--- a/testsuite/gnat2goto/tests/number_declarations/test.out
+++ b/testsuite/gnat2goto/tests/number_declarations/test.out
@@ -1,2 +1,2 @@
-[assertion.1] file use_number_declarations.adb line 11 Ada Check assertion: FAILURE
+[use_number_declarations.assertion.1] line 11 Ada Check assertion: FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/op_or_else/test.out
+++ b/testsuite/gnat2goto/tests/op_or_else/test.out
@@ -1,5 +1,5 @@
-[assertion.2] file op_or_else.adb line 16 Ada Check assertion: FAILURE
-[assertion.1] file op_or_else.adb line 16 Ada Check assertion: FAILURE
+[div_by_zero.assertion.1] line 16 Ada Check assertion: FAILURE
+[assertion.1] line 16 Ada Check assertion: FAILURE
 [op_or_else.assertion.1] line 34 assertion A or else B: SUCCESS
 [op_or_else.assertion.2] line 35 assertion B or else A: SUCCESS
 [op_or_else.assertion.3] line 36 assertion A or else A: SUCCESS

--- a/testsuite/gnat2goto/tests/out_inout_params/test.out
+++ b/testsuite/gnat2goto/tests/out_inout_params/test.out
@@ -1,4 +1,4 @@
-[assertion.1] file func_args.adb line 8 Ada Check assertion: SUCCESS
+[assign2.assertion.1] line 8 Ada Check assertion: SUCCESS
 [func_args.assertion.1] line 15 assertion A = 2: SUCCESS
 [func_args.assertion.2] line 16 assertion B = 3: SUCCESS
 [func_args.assertion.3] line 17 assertion C = 4: SUCCESS

--- a/testsuite/gnat2goto/tests/package_type/test.out
+++ b/testsuite/gnat2goto/tests/package_type/test.out
@@ -1,3 +1,3 @@
-[package_type.assertion.1] line 8 assertion Small_Number * 2 = 8: SUCCESS
-[assertion.1] line 8 Ada Check assertion: SUCCESS
+[package_type.assertion.2] line 8 assertion Small_Number * 2 = 8: SUCCESS
+[package_type.assertion.1] line 8 Ada Check assertion: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/package_use_type_N_Use_Type_Clause/test.out
+++ b/testsuite/gnat2goto/tests/package_use_type_N_Use_Type_Clause/test.out
@@ -1,4 +1,4 @@
-[assertion.1] file count_types.adb line 5 Ada Check assertion: SUCCESS
+[double.assertion.1] line 5 Ada Check assertion: SUCCESS
 [use_type_clause.assertion.1] line 21 assertion A=1: SUCCESS
 [use_type_clause.assertion.2] line 24 assertion B=2: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/pragma_machine_attribute/test.out
+++ b/testsuite/gnat2goto/tests/pragma_machine_attribute/test.out
@@ -1,3 +1,3 @@
-[assertion.1] file pragma_machine_attribute.adb line 12 Ada Check assertion: SUCCESS
+[timer_interrupt.assertion.1] line 12 Ada Check assertion: SUCCESS
 [pragma_machine_attribute.assertion.1] line 21 assertion Timeout and Interval = Seconds_Count: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/primitive_pointer/test.out
+++ b/testsuite/gnat2goto/tests/primitive_pointer/test.out
@@ -1,3 +1,3 @@
-[assertion.1] file primitive_pointer.adb line 7 Ada Check assertion: SUCCESS
-[primitive_pointer.assertion.1] line 8 assertion A = 6: SUCCESS
+[primitive_pointer.assertion.1] line 7 Ada Check assertion: SUCCESS
+[primitive_pointer.assertion.2] line 8 assertion A = 6: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/private_type_dec/test.out
+++ b/testsuite/gnat2goto/tests/private_type_dec/test.out
@@ -1,3 +1,3 @@
-[assertion.1] file private_dec.adb line 4 Ada Check assertion: SUCCESS
+[p.assertion.1] line 4 Ada Check assertion: SUCCESS
 [test.assertion.1] line 7 assertion My_Int = 5: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/private_type_dec_array/test.out
+++ b/testsuite/gnat2goto/tests/private_type_dec_array/test.out
@@ -1,2 +1,2 @@
-[assertion.1] file private_dec_array.adb line 5 Ada Check assertion: SUCCESS
+[p.assertion.1] line 5 Ada Check assertion: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/proc/test.out
+++ b/testsuite/gnat2goto/tests/proc/test.out
@@ -1,2 +1,2 @@
-[assertion.1] file proc.adb line 6 Ada Check assertion: SUCCESS
+[assign2.assertion.1] line 6 Ada Check assertion: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/proc_args/test.out
+++ b/testsuite/gnat2goto/tests/proc_args/test.out
@@ -1,2 +1,2 @@
-[assertion.1] file proc_args.adb line 6 Ada Check assertion: SUCCESS
+[assign2.assertion.1] line 6 Ada Check assertion: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/procedure_pointer/test.out
+++ b/testsuite/gnat2goto/tests/procedure_pointer/test.out
@@ -1,3 +1,3 @@
-[assertion.1] file test.adb line 5 Ada Check assertion: SUCCESS
+[increment_by.assertion.1] line 5 Ada Check assertion: SUCCESS
 [assert_modify.assertion.1] line 17 assertion Global_Number = 5: FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/qualified_expression/test.out
+++ b/testsuite/gnat2goto/tests/qualified_expression/test.out
@@ -1,2 +1,2 @@
-[assertion.1] file qualified_expr.adb line 7 Ada Check assertion: FAILURE
+[do_loop.assertion.1] line 7 Ada Check assertion: FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/range_check_exception/test.out
+++ b/testsuite/gnat2goto/tests/range_check_exception/test.out
@@ -1,3 +1,3 @@
-[assertion.1] file test.adb line 9 Ada Check assertion: FAILURE
+[double.assertion.1] line 9 Ada Check assertion: FAILURE
 [test.assertion.1] line 22 assertion Error_Count = 1: SUCCESS
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/range_check_non_bounded/test.out
+++ b/testsuite/gnat2goto/tests/range_check_non_bounded/test.out
@@ -1,3 +1,3 @@
-[assertion.1] file test.adb line 6 Ada Check assertion: SUCCESS
-[test.assertion.1] line 7 assertion Int_Var = 5: SUCCESS
+[test.assertion.1] line 6 Ada Check assertion: SUCCESS
+[test.assertion.2] line 7 assertion Int_Var = 5: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/ranges/test.out
+++ b/testsuite/gnat2goto/tests/ranges/test.out
@@ -1,2 +1,2 @@
-[assertion.1] file ranges.adb line 8 Ada Check assertion: FAILURE
+[ranges.assertion.1] line 8 Ada Check assertion: FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/records/test.out
+++ b/testsuite/gnat2goto/tests/records/test.out
@@ -1,4 +1,4 @@
-[assertion.1] file records.adb line 10 Ada Check assertion: SUCCESS
-[records.assertion.1] line 11 assertion d.a = 1: SUCCESS
-[records.assertion.2] line 12 assertion d.b = 2: SUCCESS
+[records.assertion.1] line 10 Ada Check assertion: SUCCESS
+[records.assertion.2] line 11 assertion d.a = 1: SUCCESS
+[records.assertion.3] line 12 assertion d.b = 2: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/recursion/test.out
+++ b/testsuite/gnat2goto/tests/recursion/test.out
@@ -1,2 +1,2 @@
-[assertion.1] file recursion.adb line 6 Ada Check assertion: FAILURE
+[recursion.assertion.1] line 6 Ada Check assertion: FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/rhs_array_assign/test.out
+++ b/testsuite/gnat2goto/tests/rhs_array_assign/test.out
@@ -7,6 +7,6 @@
 [precondition_instance.7] file <internal> memcpy src/dst overlap: SUCCESS
 [precondition_instance.8] file <internal> memcpy source region readable: SUCCESS
 [precondition_instance.9] file <internal> memcpy destination region writeable: SUCCESS
-[assertion.1] file rhs_array_assign.adb line 8 Ada Check assertion: SUCCESS
-[rhs_array_assign.assertion.1] line 9 assertion A (5) = 5 and A (1) = 0: SUCCESS
+[rhs_array_assign.assertion.1] line 8 Ada Check assertion: SUCCESS
+[rhs_array_assign.assertion.2] line 9 assertion A (5) = 5 and A (1) = 0: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/separate_subprog/test.out
+++ b/testsuite/gnat2goto/tests/separate_subprog/test.out
@@ -1,4 +1,4 @@
-[assertion.1] file p-inc.asu line 5 Ada Check assertion: FAILURE
-[inc.assertion.1] line 6 assertion N = Old_N + 1: SUCCESS
+[inc.assertion.1] line 5 Ada Check assertion: FAILURE
+[inc.assertion.2] line 6 assertion N = Old_N + 1: SUCCESS
 [p.assertion.1] line 16 assertion X = Old_X + 1: FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/statement_new_block_N_Block_Statement/test.out
+++ b/testsuite/gnat2goto/tests/statement_new_block_N_Block_Statement/test.out
@@ -1,5 +1,5 @@
-[assertion.1] file statement_block.adb line 11 Ada Check assertion: SUCCESS
-[sum_plus_three.assertion.1] line 12 assertion Local1=3: SUCCESS
+[sum_plus_three.assertion.1] line 11 Ada Check assertion: SUCCESS
+[sum_plus_three.assertion.2] line 12 assertion Local1=3: SUCCESS
 [statement_block.assertion.1] line 30 assertion Var2=2: SUCCESS
 [statement_block.assertion.2] line 35 assertion Var2=4: SUCCESS
 [statement_block.assertion.3] line 45 assertion Var2=10: SUCCESS

--- a/testsuite/gnat2goto/tests/subtyp/test.out
+++ b/testsuite/gnat2goto/tests/subtyp/test.out
@@ -1,3 +1,3 @@
-[assertion.1] file subtyp.adb line 4 Ada Check assertion: SUCCESS
+[inc.assertion.1] line 4 Ada Check assertion: SUCCESS
 [subtyp.assertion.1] line 7 assertion X = 3: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/two_subprog_bodies/test.out
+++ b/testsuite/gnat2goto/tests/two_subprog_bodies/test.out
@@ -1,3 +1,3 @@
-[assertion.1] file one.adb line 3 Ada Check assertion: SUCCESS
+[one.assertion.1] line 3 Ada Check assertion: SUCCESS
 [two.assertion.1] line 6 assertion X=2: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/unary_minus/test.out
+++ b/testsuite/gnat2goto/tests/unary_minus/test.out
@@ -1,3 +1,3 @@
-[assertion.1] file minus.adb line 5 Ada Check assertion: SUCCESS
-[minus.assertion.1] line 6 assertion B = 22: SUCCESS
+[minus.assertion.1] line 5 Ada Check assertion: SUCCESS
+[minus.assertion.2] line 6 assertion B = 22: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/unary_minus_overflow/test.out
+++ b/testsuite/gnat2goto/tests/unary_minus_overflow/test.out
@@ -1,3 +1,3 @@
-[assertion.1] file minus.adb line 9 Ada Check assertion: SUCCESS
+[negate.assertion.1] line 9 Ada Check assertion: SUCCESS
 [minus.assertion.1] line 15 assertion Large_Negative = 2: FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/whileloop/test.out
+++ b/testsuite/gnat2goto/tests/whileloop/test.out
@@ -1,5 +1,5 @@
-[whileloop.assertion.1] line 7 assertion A <= B: SUCCESS
-[assertion.1] line 8 Ada Check assertion: SUCCESS
-[whileloop.assertion.2] line 9 assertion A - C <= B: SUCCESS
-[whileloop.assertion.3] line 11 assertion A <= B: FAILURE
+[whileloop.assertion.2] line 7 assertion A <= B: SUCCESS
+[whileloop.assertion.1] line 8 Ada Check assertion: SUCCESS
+[whileloop.assertion.3] line 9 assertion A - C <= B: SUCCESS
+[whileloop.assertion.4] line 11 assertion A <= B: FAILURE
 VERIFICATION FAILED


### PR DESCRIPTION
It was missing in the index/range/etc. checks. Now it is be part of get-source-location.