### PR TITLE
enable test for N_Renaming_Declaration #97

### DIFF
--- a/testsuite/gnat2goto/tests/declaration_rename_N_Renaming_Declaration/declaration_rename.adb
+++ b/testsuite/gnat2goto/tests/declaration_rename_N_Renaming_Declaration/declaration_rename.adb
@@ -17,8 +17,7 @@ procedure Declaration_Rename is
    --  (this operator is required for the 'pragma Assert'
    function "=" (Left, Right: ET.New_Integer) return Boolean renames ET."=";
 
-   --  currently unsupported --
-   --  Var : ET.New_Integer renames ET.External_Var;
+   Var : ET.New_Integer renames ET.External_Var;
 
    C : ET.New_Integer := 4;
 begin
@@ -29,8 +28,7 @@ begin
    pragma Assert (Simply_Named_Int=11);
    pragma Assert (My_Plus(A,B)=5);
    pragma Assert (C=4);
-   
-   --  currently unsupported --
-   --  Var := 5;
-   --  pragma Assert (Var=5);
+
+   Var := 5;
+   pragma Assert (Var=5);
 end Declaration_Rename;

--- a/testsuite/gnat2goto/tests/declaration_rename_N_Renaming_Declaration/external_types.ads
+++ b/testsuite/gnat2goto/tests/declaration_rename_N_Renaming_Declaration/external_types.ads
@@ -1,3 +1,5 @@
 package External_Types is
    type New_Integer is new Integer;
+
+   External_Var : New_Integer;
 end External_Types;

--- a/testsuite/gnat2goto/tests/declaration_rename_N_Renaming_Declaration/test.out
+++ b/testsuite/gnat2goto/tests/declaration_rename_N_Renaming_Declaration/test.out
@@ -1,6 +1,7 @@
-[declaration_rename.assertion.1] line 25 Ada Check assertion: SUCCESS
-[declaration_rename.assertion.2] line 28 assertion B=3: SUCCESS
-[declaration_rename.assertion.3] line 29 assertion Simply_Named_Int=11: SUCCESS
-[declaration_rename.assertion.4] line 30 assertion My_Plus(A,B)=5: SUCCESS
-[declaration_rename.assertion.5] line 31 assertion C=4: SUCCESS
+[declaration_rename.assertion.1] line 24 Ada Check assertion: SUCCESS
+[declaration_rename.assertion.2] line 27 assertion B=3: SUCCESS
+[declaration_rename.assertion.3] line 28 assertion Simply_Named_Int=11: SUCCESS
+[declaration_rename.assertion.4] line 29 assertion My_Plus(A,B)=5: SUCCESS
+[declaration_rename.assertion.5] line 30 assertion C=4: SUCCESS
+[declaration_rename.assertion.6] line 33 assertion Var=5: SUCCESS
 VERIFICATION SUCCESSFUL


### PR DESCRIPTION
As per the comment in Tree_Walk.Process_Declaration, the GNAT frontend
handles N_Renaming_Declaration, and thus N_Package_Renaming_Declaration.
This patch demonstrates that N_Package_Renaming_Declaration is handled
by enabling a previously commented-out assertion on a renamed package.

* tests/declaration_rename_N_Renaming_Declaration/declaration_rename.adb
* tests/declaration_rename_N_Renaming_Declaration/external_types.ads
* tests/declaration_rename_N_Renaming_Declaration/test.out
Enable assertion showing that package renaming declarations now work.