### PR TITLE
enable test for Non-literal bound #54

### DIFF
--- a/testsuite/gnat2goto/tests/nonliteral_bound/nonliterals.adb
+++ b/testsuite/gnat2goto/tests/nonliteral_bound/nonliterals.adb
@@ -1,0 +1,11 @@
+procedure Nonliterals is
+   subtype Range1 is Integer range 10 .. 20;
+
+   Actual1 : Range1 := 11;
+
+   Result : Integer;
+begin
+   Result := Range1'First + Range1'Last + Actual1;
+
+   pragma Assert (Result = 41);
+end Nonliterals;

--- a/testsuite/gnat2goto/tests/nonliteral_bound/test.out
+++ b/testsuite/gnat2goto/tests/nonliteral_bound/test.out
@@ -1,0 +1,2 @@
+[nonliterals.assertion.1] line 10 assertion Result = 41: SUCCESS
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/nonliteral_bound/test.py
+++ b/testsuite/gnat2goto/tests/nonliteral_bound/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
Non-literal bound is now supported (i.e. 'First and 'Last), so this
patch creates a test to demonstrate this.

* tests/nonliteral_bound/
Add test.