### PR TITLE
Display Ekind of unhandled Itypes in Do_Itype_Definition

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -105,7 +105,7 @@ Nkind: N_Attribute_Reference
 --
 Occurs: 2 times
 Calling function: Do_Itype_Definition
-Error message: Unknown Ekind
+Error message: Unknown Ekind E_ENUMERATION_SUBTYPE
 Nkind: N_Defining_Identifier
 --
 Occurs: 1 times

--- a/gnat2goto/driver/gnat2goto_itypes.adb
+++ b/gnat2goto/driver/gnat2goto_itypes.adb
@@ -92,8 +92,10 @@ package body Gnat2goto_Itypes is
          when E_Anonymous_Access_Type => Make_Pointer_Type
                 (Base => Do_Type_Reference (Designated_Type (Etype (N)))),
          when E_Modular_Integer_Subtype => Do_Modular_Integer_Subtype (N),
-         when others => Report_Unhandled_Node_Irep (N, "Do_Itype_Definition",
-                                                    "Unknown Ekind"));
+         when others => Report_Unhandled_Node_Irep
+          (N,
+           "Do_Itype_Definition",
+           "Unknown Ekind " & Entity_Kind'Image (Ekind (N))));
    end Do_Itype_Definition;
 
    ----------------------------


### PR DESCRIPTION
Small fix to make sure that if we get an unknown kind of Itype we know which one it is.