### PR TITLE
Use enum pos

### DIFF
--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -1245,15 +1245,49 @@ package body Tree_Walk is
          exit when not Present (Member);
       end loop;
 
-      return Make_C_Enum_Type
-        (I_Subtype =>
-           Make_Bounded_Signedbv_Type
-             (Width       => 32, -- FIXME why 32?
-              Lower_Bound => Store_Symbol_Bound
-                (Bound_Type_Symbol (Do_Defining_Identifier (First_Member))),
-              Upper_Bound => Store_Symbol_Bound
-                (Bound_Type_Symbol (Do_Defining_Identifier (Last_Member)))),
-         I_Body => Enum_Body);
+      declare
+         function Make_Char_Symbol (N : Node_Id) return Irep is
+           (Make_Symbol_Expr
+              (Source_Location => Get_Source_Location (N),
+               I_Type          => Enum_Type_Symbol,
+               Range_Check     => False,
+               Identifier      => Unique_Name (N)))
+            with Pre => Nkind (N) = N_Defining_Character_Literal;
+
+         Lower_Bound : constant Irep :=
+           (case Nkind (First_Member) is
+               when N_Defining_Identifier =>
+                  Do_Defining_Identifier (First_Member),
+               when N_Defining_Character_Literal =>
+                  Make_Char_Symbol (First_Member),
+               when others =>
+                  Report_Unhandled_Node_Irep
+              (N        => First_Member,
+               Fun_Name => "Do_Enumeration_Definition",
+               Message  => "Incorrect Enumeration Literal"));
+
+         Upper_Bound : constant Irep :=
+           (case Nkind (Last_Member) is
+               when N_Defining_Identifier =>
+                  Do_Defining_Identifier (Last_Member),
+               when N_Defining_Character_Literal =>
+                  Make_Char_Symbol (Last_Member),
+               when others =>
+                  Report_Unhandled_Node_Irep
+              (N        => Last_Member,
+               Fun_Name => "Do_Enumeration_Definition",
+               Message  => "Incorrect Enumeration Literal"));
+      begin
+         return Make_C_Enum_Type
+           (I_Subtype =>
+              Make_Bounded_Signedbv_Type
+                (Width       => 32, -- FIXME why 32?
+                 Lower_Bound => Store_Symbol_Bound
+                   (Bound_Type_Symbol (Lower_Bound)),
+                 Upper_Bound => Store_Symbol_Bound
+                   (Bound_Type_Symbol (Upper_Bound))),
+            I_Body => Enum_Body);
+      end;
    end Do_Enumeration_Definition;
 
    function Do_Attribute_Pos_Val (N : Node_Id) return Irep is

--- a/testsuite/gnat2goto/tests/enum_range_checks/enums.adb
+++ b/testsuite/gnat2goto/tests/enum_range_checks/enums.adb
@@ -1,4 +1,5 @@
 procedure Enums is
+   --  Check the use of Pos instead of Rep.
    type My_Enum is (one, two, three, four, five);
 
    subtype Enum_Sub is My_Enum range two .. four;

--- a/testsuite/gnat2goto/tests/enum_range_checks/enums.adb
+++ b/testsuite/gnat2goto/tests/enum_range_checks/enums.adb
@@ -1,0 +1,31 @@
+procedure Enums is
+   type My_Enum is (one, two, three, four, five);
+
+   subtype Enum_Sub is My_Enum range two .. four;
+
+   VE : My_Enum;
+   VS : Enum_Sub;
+   T  : My_Enum;
+begin
+   VE := one;
+   VS := two;
+   T  := VE;
+   VE := VS;
+   VS := VE;
+   VE := T;
+   pragma Assert (VE in My_Enum);
+   pragma Assert (VE >= My_Enum'First and VE <= My_Enum'Last);
+   pragma Assert (VE >= Enum_Sub'First and VE <= Enum_Sub'Last);
+   pragma Assert (VS in My_Enum);
+   pragma Assert (VS >= My_Enum'First and VS <= My_Enum'Last);
+   pragma Assert (VS >= Enum_Sub'First and VS <= Enum_Sub'Last);
+   pragma Assert (VE <= VS);
+   pragma Assert (VE <= My_Enum'Last);
+   pragma Assert (VE >= My_Enum'First);
+   pragma Assert (VE in Enum_Sub);
+   pragma Assert (VE >= Enum_Sub'First);
+   pragma Assert (VE = one);
+   pragma Assert (VE = T);
+   pragma Assert (VS = two);
+   pragma Assert (T = one);
+end Enums;

--- a/testsuite/gnat2goto/tests/enum_range_checks/test.out
+++ b/testsuite/gnat2goto/tests/enum_range_checks/test.out
@@ -1,0 +1,5 @@
+[enum.assertion.1] line 8 assertion A = Get_A: SUCCESS
+[enum.assertion.2] line 10 assertion B = Get_B: SUCCESS
+[enum.assertion.3] line 12 assertion Get_A /= Get_B: SUCCESS
+[enum.assertion.4] line 14 assertion Get_A = Get_B: FAILURE
+VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/enum_range_checks/test.out
+++ b/testsuite/gnat2goto/tests/enum_range_checks/test.out
@@ -1,17 +1,17 @@
-[enums.assertion.1] line 14 Ada Check assertion: SUCCESS
-[enums.assertion.2] line 16 assertion VE in My_Enum: SUCCESS
-[enums.assertion.3] line 17 assertion VE >= My_Enum'First and VE <= My_Enum'Last: SUCCESS
-[enums.assertion.4] line 18 assertion VE >= Enum_Sub'First and VE <= Enum_Sub'Last: FAILURE
-[enums.assertion.5] line 19 assertion VS in My_Enum: SUCCESS
-[enums.assertion.6] line 20 assertion VS >= My_Enum'First and VS <= My_Enum'Last: SUCCESS
-[enums.assertion.7] line 21 assertion VS >= Enum_Sub'First and VS <= Enum_Sub'Last: SUCCESS
-[enums.assertion.8] line 22 assertion VE <= VS: SUCCESS
-[enums.assertion.9] line 23 assertion VE <= My_Enum'Last: SUCCESS
-[enums.assertion.10] line 24 assertion VE >= My_Enum'First: SUCCESS
-[enums.assertion.11] line 25 assertion VE in Enum_Sub: FAILURE
-[enums.assertion.12] line 26 assertion VE >= Enum_Sub'First: FAILURE
-[enums.assertion.13] line 27 assertion VE = one: SUCCESS
-[enums.assertion.14] line 28 assertion VE = T: SUCCESS
-[enums.assertion.15] line 29 assertion VS = two: SUCCESS
-[enums.assertion.16] line 30 assertion T = one: SUCCESS
+[enums.assertion.1] line 15 Ada Check assertion: SUCCESS
+[enums.assertion.2] line 17 assertion VE in My_Enum: SUCCESS
+[enums.assertion.3] line 18 assertion VE >= My_Enum'First and VE <= My_Enum'Last: SUCCESS
+[enums.assertion.4] line 19 assertion VE >= Enum_Sub'First and VE <= Enum_Sub'Last: FAILURE
+[enums.assertion.5] line 20 assertion VS in My_Enum: SUCCESS
+[enums.assertion.6] line 21 assertion VS >= My_Enum'First and VS <= My_Enum'Last: SUCCESS
+[enums.assertion.7] line 22 assertion VS >= Enum_Sub'First and VS <= Enum_Sub'Last: SUCCESS
+[enums.assertion.8] line 23 assertion VE <= VS: SUCCESS
+[enums.assertion.9] line 24 assertion VE <= My_Enum'Last: SUCCESS
+[enums.assertion.10] line 25 assertion VE >= My_Enum'First: SUCCESS
+[enums.assertion.11] line 26 assertion VE in Enum_Sub: FAILURE
+[enums.assertion.12] line 27 assertion VE >= Enum_Sub'First: FAILURE
+[enums.assertion.13] line 28 assertion VE = one: SUCCESS
+[enums.assertion.14] line 29 assertion VE = T: SUCCESS
+[enums.assertion.15] line 30 assertion VS = two: SUCCESS
+[enums.assertion.16] line 31 assertion T = one: SUCCESS
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/enum_range_checks/test.out
+++ b/testsuite/gnat2goto/tests/enum_range_checks/test.out
@@ -1,5 +1,17 @@
-[enum.assertion.1] line 8 assertion A = Get_A: SUCCESS
-[enum.assertion.2] line 10 assertion B = Get_B: SUCCESS
-[enum.assertion.3] line 12 assertion Get_A /= Get_B: SUCCESS
-[enum.assertion.4] line 14 assertion Get_A = Get_B: FAILURE
+[enums.assertion.1] line 14 Ada Check assertion: SUCCESS
+[enums.assertion.2] line 16 assertion VE in My_Enum: SUCCESS
+[enums.assertion.3] line 17 assertion VE >= My_Enum'First and VE <= My_Enum'Last: SUCCESS
+[enums.assertion.4] line 18 assertion VE >= Enum_Sub'First and VE <= Enum_Sub'Last: FAILURE
+[enums.assertion.5] line 19 assertion VS in My_Enum: SUCCESS
+[enums.assertion.6] line 20 assertion VS >= My_Enum'First and VS <= My_Enum'Last: SUCCESS
+[enums.assertion.7] line 21 assertion VS >= Enum_Sub'First and VS <= Enum_Sub'Last: SUCCESS
+[enums.assertion.8] line 22 assertion VE <= VS: SUCCESS
+[enums.assertion.9] line 23 assertion VE <= My_Enum'Last: SUCCESS
+[enums.assertion.10] line 24 assertion VE >= My_Enum'First: SUCCESS
+[enums.assertion.11] line 25 assertion VE in Enum_Sub: FAILURE
+[enums.assertion.12] line 26 assertion VE >= Enum_Sub'First: FAILURE
+[enums.assertion.13] line 27 assertion VE = one: SUCCESS
+[enums.assertion.14] line 28 assertion VE = T: SUCCESS
+[enums.assertion.15] line 29 assertion VS = two: SUCCESS
+[enums.assertion.16] line 30 assertion T = one: SUCCESS
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/enum_range_checks/test.py
+++ b/testsuite/gnat2goto/tests/enum_range_checks/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()

--- a/testsuite/gnat2goto/tests/function_pointer/test.out
+++ b/testsuite/gnat2goto/tests/function_pointer/test.out
@@ -1,6 +1,6 @@
 Standard_Output from gnat2goto test:
 ----------At: Do_Itype_Definition----------
-----------Unknown Ekind----------
+----------Unknown Ekind E_ACCESS_SUBTYPE----------
 N_Defining_Identifier "T6b" (Entity_Id=2491)
  Parent = <empty>
  Sloc = 8480  test.adb:13:4

--- a/testsuite/gnat2goto/tests/procedure_pointer/test.out
+++ b/testsuite/gnat2goto/tests/procedure_pointer/test.out
@@ -1,6 +1,6 @@
 Standard_Output from gnat2goto test:
 ----------At: Do_Itype_Definition----------
-----------Unknown Ekind----------
+----------Unknown Ekind E_ACCESS_SUBTYPE----------
 N_Defining_Identifier "T4b" (Entity_Id=2491)
  Parent = <empty>
  Sloc = 8525  test.adb:14:4


### PR DESCRIPTION
Use enumeration literal position as their value rather than their representation value.  Using their position maintains an order relation between the literals of an enumeration whereas using their representation value does not necessarily.  If, in future, a representation value is needed (for low level I/O) a function could be provided to obtain the representation from an enumeration literals position.  Such a function exists in gnat but is possible a goto equivalent may be needed.
