### PR TITLE
Change the URLs for GNAT GPL 2016 and GNATCOL 2016 in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ dist: trusty
 compiler: gcc
 
 env:
-  GNAT: "http://mirrors.cdn.adacore.com/art/5739cefdc7a447658e0b016b"
-  GNATCOLL: "http://mirrors.cdn.adacore.com/art/5a15cb87c7a4479a23674d44"
+  GNAT: "https://community.download.adacore.com/v1/845147a8c6ef6af29a68144d6b3d228fd226268e?filename=gnat-gpl-2016-x86_64-linux-bin.tar.gz"
+  GNATCOLL: "https://community.download.adacore.com/v1/18ce6dfd017b4d4005aa6a9284a4a09ee16f88c3?filename=gnatcoll-gpl-2016-src-m1.tar.gz"
 
 cache:
   ccache: true

--- a/testsuite/gnat2goto/tests/function_pointer/test.out
+++ b/testsuite/gnat2goto/tests/function_pointer/test.out
@@ -1,6 +1,6 @@
 Standard_Output from gnat2goto test:
 ----------At: Do_Itype_Definition----------
-----------Unknown Ekind----------
+----------Unknown Ekind E_ACCESS_SUBTYPE----------
 N_Defining_Identifier "T6b" (Entity_Id=2491)
  Parent = <empty>
  Sloc = 8480  test.adb:13:4

--- a/testsuite/gnat2goto/tests/procedure_pointer/test.out
+++ b/testsuite/gnat2goto/tests/procedure_pointer/test.out
@@ -1,6 +1,6 @@
 Standard_Output from gnat2goto test:
 ----------At: Do_Itype_Definition----------
-----------Unknown Ekind----------
+----------Unknown Ekind E_ACCESS_SUBTYPE----------
 N_Defining_Identifier "T4b" (Entity_Id=2491)
  Parent = <empty>
  Sloc = 8525  test.adb:14:4


### PR DESCRIPTION
The AdaCore website seems to have migrated to a new AWS S3 based
storage so the older URLs.  I have checked and files have the same
SHA1 as before.