### PR TITLE
More pragmas

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -13,11 +13,6 @@ Calling function: Process_Declaration
 Error message: Unknown declaration kind
 Nkind: N_Validate_Unchecked_Conversion
 --
-Occurs: 202 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Suppress initialization
-Nkind: N_Pragma
---
 Occurs: 153 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Postcondition
@@ -186,6 +181,11 @@ Nkind: N_Pragma
 Occurs: 1 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Refine
+Nkind: N_Pragma
+--
+Occurs: 1 times
+Calling function: Process_Pragma_Declaration
+Error message: Unsupported pragma: Suppress initialization
 Nkind: N_Pragma
 --
 Occurs: 1 times

--- a/experiments/golden-results/Tokeneer-summary.txt
+++ b/experiments/golden-results/Tokeneer-summary.txt
@@ -1,8 +1,3 @@
-Occurs: 21 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Suppress initialization
-Nkind: N_Pragma
---
 Occurs: 9 times
 Calling function: Do_Aggregate_Literal
 Error message: Unhandled aggregate kind: E_PRIVATE_TYPE

--- a/experiments/golden-results/ksum-summary.txt
+++ b/experiments/golden-results/ksum-summary.txt
@@ -1,8 +1,3 @@
-Occurs: 3 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Suppress initialization
-Nkind: N_Pragma
---
 Occurs: 41 times
 Redacted compiler error message:
 file "REDACTED" not found

--- a/experiments/golden-results/libkeccak-summary.txt
+++ b/experiments/golden-results/libkeccak-summary.txt
@@ -18,11 +18,6 @@ Calling function: Process_Declaration
 Error message: Use type clause declaration
 Nkind: N_Use_Type_Clause
 --
-Occurs: 18 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Suppress initialization
-Nkind: N_Pragma
---
 Occurs: 2 times
 Calling function: Do_Expression
 Error message: ATTRIBUTE_ASM_OUTPUT unsupported

--- a/experiments/golden-results/libsparkcrypto-summary.txt
+++ b/experiments/golden-results/libsparkcrypto-summary.txt
@@ -83,11 +83,6 @@ Calling function: Do_Expression
 Error message: ATTRIBUTE_ASM_OUTPUT unsupported
 Nkind: N_Attribute_Reference
 --
-Occurs: 2 times
-Calling function: Process_Pragma_Declaration
-Error message: Known but unsupported pragma: Linker Options
-Nkind: N_Pragma
---
 Occurs: 32 times
 Redacted compiler error message:
 file "REDACTED" not found

--- a/experiments/golden-results/vct-summary.txt
+++ b/experiments/golden-results/vct-summary.txt
@@ -18,11 +18,6 @@ Calling function: Do_Expression
 Error message: ATTRIBUTE_COPY_SIGN unsupported
 Nkind: N_Attribute_Reference
 --
-Occurs: 6 times
-Calling function: Process_Pragma_Declaration
-Error message: Unsupported pragma: Suppress initialization
-Nkind: N_Pragma
---
 Occurs: 4 times
 Calling function: Process_Declaration
 Error message: size clause not applied by the front-end

--- a/testsuite/gnat2goto/tests/fixed_array_address_model/test.out
+++ b/testsuite/gnat2goto/tests/fixed_array_address_model/test.out
@@ -1,11 +1,3 @@
-Standard_Output from gnat2goto fixed_array_address_model:
-----------At: Process_Pragma_Declaration----------
-----------Unknown pragma: compile_time_warning----------
-N_Pragma (Node_Id=3683) (source,analyzed)
- Sloc = 19196  s-atacco.ads:42:4 [fixed_array_address_model.adb:10:4]
- Pragma_Argument_Associations = List (List_Id=-99999824)
- Pragma_Identifier = N_Identifier "compile_time_warning" (Node_Id=3695)
-
 [fixed_array_address_model.assertion.1] line 18 Ada Check assertion: SUCCESS
 [fixed_array_address_model.assertion.2] line 24 assertion PV.all (I) = My_Int (I): SUCCESS
 [fixed_array_address_model.assertion.3] line 32 assertion V (I) = My_Int (V'Last - I + 1): SUCCESS

--- a/testsuite/gnat2goto/tests/more_pragmas/more_pragmas.adb
+++ b/testsuite/gnat2goto/tests/more_pragmas/more_pragmas.adb
@@ -1,0 +1,38 @@
+procedure More_Pragmas is
+   --  The following pragma should not be reported as unsupported.
+   pragma Linker_Options ("Dummy");
+
+   pragma Compile_Time_Warning (True, "This should not be reported as unsupported");
+
+   type A1 is array (1 .. 10) of Integer;
+   --  The following pragma should not be reported as unsupported.
+   pragma Suppress_Initialization (A1);
+
+   type My_Int is range 0 .. 100;
+   --  The following pragma should not be reported as unsupported.
+   pragma Suppress_Initialization (My_Int);
+
+   type A2 is array (1 .. 10) of Integer with Default_Component_Value => 0;
+   --  The following pragma should be reported as unsupported.
+   pragma Suppress_Initialization (A2);
+
+   type R is record
+      A, B : Integer;
+   end record;
+    --  The following pragma should be reported as unsupported.
+   pragma Suppress_Initialization (R);
+
+   type My_Int_2 is range 0 .. 100 with Default_Value => 0;
+    --  The following pragma should be reported as unsupported.
+   pragma Suppress_Initialization (My_int_2);
+
+   V : Integer := 0;
+    --  The following pragma should be reported as unsupported.
+   pragma Suppress_Initialization (V);
+
+   pragma Compile_Time_Warning (False, "This should not be reported as unsupported");
+begin
+   pragma Compile_Time_Warning (True, "This should not be reported as unsupported");
+   pragma Assert (V = 0);
+   pragma Compile_Time_Warning (V /= 0, "This should not be reported as unsupported");
+end More_Pragmas;

--- a/testsuite/gnat2goto/tests/more_pragmas/test.out
+++ b/testsuite/gnat2goto/tests/more_pragmas/test.out
@@ -1,0 +1,34 @@
+Standard_Output from gnat2goto more_pragmas:
+----------At: Process_Pragma_Declaration----------
+----------Unsupported pragma: Suppress initialization----------
+N_Pragma (Node_Id=2315) (source,analyzed)
+ Sloc = 8846  more_pragmas.adb:17:4
+ Pragma_Argument_Associations = List (List_Id=-99999973)
+ Pragma_Identifier = N_Identifier "suppress_initialization" (Node_Id=2316)
+ Next_Rep_Item = N_Aspect_Specification (Node_Id=2313)
+----------At: Process_Pragma_Declaration----------
+----------Unsupported pragma: Suppress initialization----------
+N_Pragma (Node_Id=2351) (source,analyzed)
+ Sloc = 9008  more_pragmas.adb:23:4
+ Pragma_Argument_Associations = List (List_Id=-99999969)
+ Pragma_Identifier = N_Identifier "suppress_initialization" (Node_Id=2352)
+----------At: Process_Pragma_Declaration----------
+----------Unsupported pragma: Suppress initialization----------
+N_Pragma (Node_Id=2370) (source,analyzed)
+ Sloc = 9172  more_pragmas.adb:27:4
+ Pragma_Argument_Associations = List (List_Id=-99999966)
+ Pragma_Identifier = N_Identifier "suppress_initialization" (Node_Id=2371)
+ Next_Rep_Item = N_Aspect_Specification (Node_Id=2368)
+----------At: Process_Pragma_Declaration----------
+----------Unsupported pragma: Suppress initialization----------
+N_Pragma (Node_Id=2384) (source,analyzed)
+ Sloc = 9304  more_pragmas.adb:31:4
+ Pragma_Argument_Associations = List (List_Id=-99999964)
+ Pragma_Identifier = N_Identifier "suppress_initialization" (Node_Id=2385)
+
+Standard_Error from gnat2goto more_pragmas:
+more_pragmas.adb:5:33: warning: This should not be reported as unsupported
+more_pragmas.adb:35:33: warning: This should not be reported as unsupported
+
+[more_pragmas.assertion.1] line 36 assertion V = 0: SUCCESS
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/more_pragmas/test.py
+++ b/testsuite/gnat2goto/tests/more_pragmas/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()

--- a/testsuite/gnat2goto/tests/record_address_model/test.out
+++ b/testsuite/gnat2goto/tests/record_address_model/test.out
@@ -1,11 +1,3 @@
-Standard_Output from gnat2goto record_address_model:
-----------At: Process_Pragma_Declaration----------
-----------Unknown pragma: compile_time_warning----------
-N_Pragma (Node_Id=3577) (source,analyzed)
- Sloc = 19196  s-atacco.ads:42:4 [record_address_model.adb:12:4]
- Pragma_Argument_Associations = List (List_Id=-99999834)
- Pragma_Identifier = N_Identifier "compile_time_warning" (Node_Id=3589)
-
 [record_address_model.assertion.1] line 23 assertion PV.all.A = 3: SUCCESS
 [record_address_model.assertion.2] line 24 assertion PV.all.B = 5: SUCCESS
 [record_address_model.assertion.3] line 29 assertion V.A = 7: SUCCESS

--- a/testsuite/gnat2goto/tests/simple_address_model/test.out
+++ b/testsuite/gnat2goto/tests/simple_address_model/test.out
@@ -1,11 +1,3 @@
-Standard_Output from gnat2goto simple_address_model:
-----------At: Process_Pragma_Declaration----------
-----------Unknown pragma: compile_time_warning----------
-N_Pragma (Node_Id=3509) (source,analyzed)
- Sloc = 19196  s-atacco.ads:42:4 [simple_address_model.adb:10:4]
- Pragma_Argument_Associations = List (List_Id=-99999839)
- Pragma_Identifier = N_Identifier "compile_time_warning" (Node_Id=3521)
-
 [simple_address_model.assertion.1] line 21 assertion PV.all = 3: SUCCESS
 [simple_address_model.assertion.2] line 26 assertion V = 5: SUCCESS
 [simple_address_model.assertion.3] line 31 assertion V'Address = To_Address (Object_Pointer (PV)): SUCCESS

--- a/testsuite/gnat2goto/tests/u_array_address_model/test.out
+++ b/testsuite/gnat2goto/tests/u_array_address_model/test.out
@@ -1,11 +1,3 @@
-Standard_Output from gnat2goto u_array_address_model:
-----------At: Process_Pragma_Declaration----------
-----------Unknown pragma: compile_time_warning----------
-N_Pragma (Node_Id=3669) (source,analyzed)
- Sloc = 19196  s-atacco.ads:42:4 [u_array_address_model.adb:10:4]
- Pragma_Argument_Associations = List (List_Id=-99999824)
- Pragma_Identifier = N_Identifier "compile_time_warning" (Node_Id=3681)
-
 Standard_Error from gnat2goto u_array_address_model:
 u_array_address_model.adb:10:04: warning: in instantiation at s-atacco.ads:43
 u_array_address_model.adb:10:04: warning: Object is unconstrained array type


### PR DESCRIPTION
Ignore pragmas Compile_Time_Warning, Linker_Options, and partially ignore pragma Suppress_Initialization.

Linker_Options may be processed in a later release if symtab2gb was to have more options.

Suppress_Initialization is only ignored if it is applied to an array type or scalar type which has no default value aspect.  Otherwise it is still reported as unsupported.

It could be improved with more work so that it could be ignored in more cases or actually to change the initialisation code.  But for the moment it clears all but one instance in the CI tests.
