### PR TITLE
Record aggregates

### DIFF
--- a/gnat2goto/driver/goto_utils.ads
+++ b/gnat2goto/driver/goto_utils.ads
@@ -92,7 +92,7 @@ package GOTO_Utils is
                                        A_Symbol_Table : in out Symbol_Table)
                                        return Symbol
      with Pre => (Kind (Symbol_Type) = I_Code_Type
-                  and then (Kind (Value) = I_Code_Block
+                  and then (Kind (Value) in I_Code_Block | I_Code_Assert
                     or else Value = Ireps.Empty));
 
    function Create_Fun_Parameter (Fun_Name : String; Param_Name : String;

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -687,8 +687,11 @@ package body Tree_Walk is
                                                   "Actual iter not present");
                      return Struct_Expr;
                   end if;
-                  if Defining_Identifier (Substruct_Component_List) /=
-                    Entity (First (Choices (Actual_Iter)))
+
+                  if Get_Name_String
+                    (Chars (Defining_Identifier (Substruct_Component_List))) /=
+                    Get_Name_String
+                      (Chars (Entity (First (Choices (Actual_Iter)))))
                   then
                      Report_Unhandled_Node_Empty (N,
                                                  "Do_Aggregate_Literal_Record",

--- a/testsuite/gnat2goto/tests/record_aggregates/record_aggregates.adb
+++ b/testsuite/gnat2goto/tests/record_aggregates/record_aggregates.adb
@@ -1,0 +1,95 @@
+procedure Record_Aggregates is
+   type Subsystem is (Example_Subsystem,
+		      Health_Monitor,
+		      Battery_Controller,
+		      IO_Processor,
+		      Primary_Sensors,
+		      Secondary_Sensors);
+
+   type Topics is (Outside_Temperature,
+                   Air_Pressure,
+                   Current_Speed,
+                   Current_Altitude);
+
+   type Message_Header is record
+      Sender       : Subsystem;
+      Topic        : Topics;
+      Content_Size : Natural;  -- The amount of data in the message (in bits)
+   end record;
+
+   type Temp_Type   is range -40 .. 200;
+   type Press_Type  is range -100 .. 100;
+   type Speed_Type  is range 0 .. 1000;
+   type Alt_Type    is range -100 .. 100_000;
+
+   type Temperature_Message is record
+      Header      : Message_Header;
+      Temperature : Temp_Type;
+   end record;
+   pragma Pack (Temperature_Message);
+   for Temperature_Message'Size use 88;
+
+   type Pressure_Message is record
+      Header      : Message_Header;
+      Pressure    : Press_Type;
+   end record;
+   pragma Pack (Pressure_Message);
+   for Pressure_Message'Size use 80;
+
+   type Speed_Message is record
+      Header      : Message_Header;
+      Speed       : Speed_Type;
+   end record;
+   pragma Pack (Speed_Message);
+   for Speed_Message'Size use 88;
+
+   type Altitude_Message is record
+      Header      : Message_Header;
+      Altitude    : Alt_Type;
+   end record;
+   pragma Pack (Altitude_Message);
+   for Altitude_Message'Size use 96;
+
+   type Message (Topic : Topics := Outside_Temperature) is record
+      case Topic is
+         when Outside_Temperature => Temp  : Temperature_Message;
+         when Air_Pressure        => Press : Pressure_Message;
+         when Current_Speed       => Speed : Speed_Message;
+         when Current_Altitude    => Alt   : Altitude_Message;
+      end case;
+   end record;
+
+   procedure Fill_Message (Topic : Topics;
+                           Filled_Message : out Message) is
+      Header : constant Message_Header:=
+      (Example_Subsystem, Topic, 100);
+   begin
+      case Topic is
+         when Outside_Temperature =>
+            Filled_Message := (Outside_Temperature,
+                               (Header      => Header,
+                                Temperature => 4));
+          when Air_Pressure =>
+            Filled_Message := (Air_Pressure,
+                               (Header   => Header,
+                                Pressure => 5));
+          when Current_Speed =>
+            Filled_Message := (Current_Speed,
+                               (Header => Header,
+                                Speed => 6));
+          when Current_Altitude =>
+            Filled_Message := (Current_Altitude,
+                               (Header   => Header,
+                                Altitude => 7));
+      end case;
+   end Fill_Message;
+
+   M : Message;
+
+begin
+   Fill_Message (Outside_Temperature, M);
+   pragma Assert (M.Temp.Temperature = 4);
+
+   Fill_Message (Current_Speed, M);
+   pragma Assert (M.Speed.Speed = 6);
+end Record_Aggregates;

--- a/testsuite/gnat2goto/tests/record_aggregates/test.opt
+++ b/testsuite/gnat2goto/tests/record_aggregates/test.opt
@@ -1,0 +1,2 @@
+ALL XFAIL cbmc Invariant check failed - reason precondition
+

--- a/testsuite/gnat2goto/tests/record_aggregates/test.out
+++ b/testsuite/gnat2goto/tests/record_aggregates/test.out
@@ -1,0 +1,34 @@
+Error from cbmc record_aggregates:
+--- begin invariant violation report ---
+Invariant check failed
+File: ../util/std_types.h:305 function: to_struct_type
+Condition: can_cast_type<struct_typet>(type)
+Reason: Precondition
+Backtrace:
+cbmc(+0x24357d) [0x55919ad0457d]
+cbmc(+0x243adf) [0x55919ad04adf]
+cbmc(+0x16d51c) [0x55919ac2e51c]
+cbmc(+0x605392) [0x55919b0c6392]
+cbmc(+0x60493e) [0x55919b0c593e]
+cbmc(+0x602cc4) [0x55919b0c3cc4]
+cbmc(+0x5c8fb5) [0x55919b089fb5]
+cbmc(+0x62b9c0) [0x55919b0ec9c0]
+cbmc(+0x62be73) [0x55919b0ece73]
+cbmc(+0x4c865d) [0x55919af8965d]
+cbmc(+0x62beae) [0x55919b0eceae]
+cbmc(+0x62c0c8) [0x55919b0ed0c8]
+cbmc(+0x62ce0a) [0x55919b0ede0a]
+cbmc(+0x4a5886) [0x55919af66886]
+cbmc(+0x4a550b) [0x55919af6650b]
+cbmc(+0x2d2fb2) [0x55919ad93fb2]
+cbmc(+0x2cdfa7) [0x55919ad8efa7]
+cbmc(+0x161759) [0x55919ac22759]
+cbmc(+0x150e11) [0x55919ac11e11]
+/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xeb) [0x7f95f031509b]
+cbmc(+0x16222a) [0x55919ac2322a]
+
+
+--- end invariant violation report ---
+
+ERROR code  -6 returned by cbmc when processing record_aggregates
+

--- a/testsuite/gnat2goto/tests/record_aggregates/test.py
+++ b/testsuite/gnat2goto/tests/record_aggregates/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()

--- a/testsuite/gnat2goto/tests/record_aggregates_box/record_aggregates_box.adb
+++ b/testsuite/gnat2goto/tests/record_aggregates_box/record_aggregates_box.adb
@@ -1,0 +1,11 @@
+procedure Record_Aggregates_Box is
+   type R is record
+      A, B, C, D : Integer;
+   end record;
+
+   V : R := (A => 0, others => <>);
+begin
+   V := (B => 1, others => <>);
+   pragma Assert (V.A = 0);
+   pragma Assert (V.B = 1);
+end Record_Aggregates_Box;

--- a/testsuite/gnat2goto/tests/record_aggregates_box/test.opt
+++ b/testsuite/gnat2goto/tests/record_aggregates_box/test.opt
@@ -1,0 +1,2 @@
+ALL XFAIL gnt2goto Failed precondition from tree_walk.ads
+

--- a/testsuite/gnat2goto/tests/record_aggregates_box/test.out
+++ b/testsuite/gnat2goto/tests/record_aggregates_box/test.out
@@ -1,23 +1,3 @@
-Standard_Error from gnat2goto record_aggregates_box:
-+===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from tree_walk.ads:108|
-| Error detected at record_aggregates_box.adb:1:11                         |
-| Please submit a bug report; see https://gcc.gnu.org/bugs/ .              |
-| Use a subject line meaningful to you and us to track the bug.            |
-| Include the entire contents of this bug box in the report.               |
-| Include the exact command that you entered.                              |
-| Also include sources listed below.                                       |
-+==========================================================================+
-
-Please include these source files with error report
-Note that list may not be accurate in some cases,
-so please double check that the problem can still
-be reproduced with the set of files listed.
-Consider also -gnatd.n switch (see debug.adb).
-
-record_aggregates_box.adb
-
-compilation abandoned
-
-ERROR code  5  returned by gnat2goto when translating record_aggregates_box
-CBMC not run
+[record_aggregates_box.assertion.1] line  9 assertion V.A = 0: SUCCESS
+[record_aggregates_box.assertion.2] line 10 assertion V.B = 1: SUCCESS
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/record_aggregates_box/test.out
+++ b/testsuite/gnat2goto/tests/record_aggregates_box/test.out
@@ -1,0 +1,23 @@
+Standard_Error from gnat2goto record_aggregates_box:
++===========================GNAT BUG DETECTED==============================+
+| GNU Ada (ada2goto) Assert_Failure failed precondition from tree_walk.ads:108|
+| Error detected at record_aggregates_box.adb:1:11                         |
+| Please submit a bug report; see https://gcc.gnu.org/bugs/ .              |
+| Use a subject line meaningful to you and us to track the bug.            |
+| Include the entire contents of this bug box in the report.               |
+| Include the exact command that you entered.                              |
+| Also include sources listed below.                                       |
++==========================================================================+
+
+Please include these source files with error report
+Note that list may not be accurate in some cases,
+so please double check that the problem can still
+be reproduced with the set of files listed.
+Consider also -gnatd.n switch (see debug.adb).
+
+record_aggregates_box.adb
+
+compilation abandoned
+
+ERROR code  5  returned by gnat2goto when translating record_aggregates_box
+CBMC not run

--- a/testsuite/gnat2goto/tests/record_aggregates_box/test.py
+++ b/testsuite/gnat2goto/tests/record_aggregates_box/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
This patch fixes two issues which cause gnat2goto to fail when processing the example pub/sub system.

They both related to record aggregates, particularly when the record is discriminated.
The first issue is fixed by using the component name string rather than its node id as the front-end seems to frequently rewrite such nodes giving them a different node id.
The other failure, due to an unsatisfied precondition is solved by relaxing the precondition to allow I_Code_Assert Ireps.

The patch does not solve all the problems, i.e. others => <> in a record still causes gnat2goto to fail a precondition and the symbol table generated seems to be very large and cbmc fails when run on the symbol table.  However, it does solve the immediate problem of the gnat2goto failures when processing the example pub/sub system.
