### PR TITLE
For loop vars

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -23,9 +23,14 @@ Calling function: Process_Pragma_Declaration
 Error message: Unknown pragma: volatile_full_access
 Nkind: N_Pragma
 --
-Occurs: 22 times
+Occurs: 32 times
 Calling function: Do_Expression
 Error message: First of string unsupported
+Nkind: N_Attribute_Reference
+--
+Occurs: 23 times
+Calling function: Do_Expression
+Error message: Last of string unsupported
 Nkind: N_Attribute_Reference
 --
 Occurs: 22 times
@@ -33,17 +38,12 @@ Calling function: Do_Expression
 Error message: Index of string unsupported
 Nkind: N_Indexed_Component
 --
-Occurs: 13 times
-Calling function: Do_Expression
-Error message: Last of string unsupported
-Nkind: N_Attribute_Reference
---
 Occurs: 10 times
 Calling function: Do_Expression
 Error message: ATTRIBUTE_MACHINE unsupported
 Nkind: N_Attribute_Reference
 --
-Occurs: 8 times
+Occurs: 10 times
 Calling function: Do_Type_Reference
 Error message: Type of type not a type
 Nkind: N_Defining_Identifier
@@ -99,11 +99,6 @@ Error message: Unknown Ekind E_ENUMERATION_SUBTYPE
 Nkind: N_Defining_Identifier
 --
 Occurs: 2 times
-Calling function: Do_Itype_Integer_Subtype
-Error message: Non-literal bound unsupported
-Nkind: N_Defining_Identifier
---
-Occurs: 2 times
 Calling function: Process_Pragma_Declaration
 Error message: pragma Import: Multi-language analysis unsupported
 Nkind: N_Pragma
@@ -112,11 +107,6 @@ Occurs: 1 times
 Calling function: Do_Base_Range_Constraint
 Error message: unsupported lower range kind
 Nkind: N_Real_Literal
---
-Occurs: 1 times
-Calling function: Do_Constant
-Error message: Unsupported constant type
-Nkind: N_Integer_Literal
 --
 Occurs: 1 times
 Calling function: Do_Expression
@@ -132,6 +122,11 @@ Occurs: 1 times
 Calling function: Do_Function_Call
 Error message: function entity not defining identifier
 Nkind: N_Defining_Operator_Symbol
+--
+Occurs: 1 times
+Calling function: Do_In
+Error message: gnat2goto currently only supports one mebership_choice
+Nkind: N_In
 --
 Occurs: 1 times
 Calling function: Do_Op_Expon
@@ -1755,6 +1750,11 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
+| GNU Ada (ada2goto) Assert_Failure failed postcondition from tree_walk.ads:113|
+Error detected at REDACTED
+--
+Occurs: 1 times
++===========================GNAT BUG DETECTED==============================+
 | GNU Ada (ada2goto) Assert_Failure failed precondition from arrays.ads:71 |
 Error detected at REDACTED
 --
@@ -1841,11 +1841,6 @@ Error detected at REDACTED
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
 | GNU Ada (ada2goto) Assert_Failure sinfo.adb:1113                         |
-Error detected at REDACTED
---
-Occurs: 1 times
-+===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure sinfo.adb:1183                         |
 Error detected at REDACTED
 --
 Occurs: 1 times

--- a/experiments/golden-results/UKNI-Information-Barrier-summary.txt
+++ b/experiments/golden-results/UKNI-Information-Barrier-summary.txt
@@ -3,20 +3,20 @@ Calling function: Process_Declaration
 Error message: Address representation clauses are not currently supported
 Nkind: N_Attribute_Definition_Clause
 --
-Occurs: 1 times
+Occurs: 2 times
 Calling function: Do_Expression
 Error message: First of string unsupported
+Nkind: N_Attribute_Reference
+--
+Occurs: 2 times
+Calling function: Do_Expression
+Error message: Last of string unsupported
 Nkind: N_Attribute_Reference
 --
 Occurs: 1 times
 Calling function: Do_Expression
 Error message: Index of string unsupported
 Nkind: N_Indexed_Component
---
-Occurs: 1 times
-Calling function: Do_Expression
-Error message: Last of string unsupported
-Nkind: N_Attribute_Reference
 --
 Occurs: 1 times
 Calling function: Process_Pragma_Declaration

--- a/experiments/golden-results/libsparkcrypto-summary.txt
+++ b/experiments/golden-results/libsparkcrypto-summary.txt
@@ -18,15 +18,10 @@ Calling function: Process_Pragma_Declaration
 Error message: Unknown pragma: ghost
 Nkind: N_Pragma
 --
-Occurs: 88 times
+Occurs: 82 times
 Calling function: Do_Function_Call
 Error message: function entity not defining identifier
 Nkind: N_Defining_Operator_Symbol
---
-Occurs: 70 times
-Calling function: Do_Type_Reference
-Error message: Type of type not a type
-Nkind: N_Defining_Identifier
 --
 Occurs: 68 times
 Calling function: Do_Expression
@@ -39,21 +34,16 @@ Error message: sym id not in symbol table
 Nkind: N_Procedure_Call_Statement
 --
 Occurs: 26 times
-Calling function: Do_Itype_Integer_Subtype
-Error message: Non-literal bound unsupported
-Nkind: N_Defining_Identifier
---
-Occurs: 26 times
 Calling function: Process_Pragma_Declaration
 Error message: pragma Import: Multi-language analysis unsupported
 Nkind: N_Pragma
 --
-Occurs: 23 times
+Occurs: 21 times
 Calling function: Do_Expression
 Error message: Quantified
 Nkind: N_Quantified_Expression
 --
-Occurs: 8 times
+Occurs: 7 times
 Calling function: Do_Op_Expon
 Error message: Exponentiation unhandled for non mod types at the moment
 Nkind: N_Op_Expon
@@ -337,8 +327,3 @@ Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
 | GNU Ada (ada2goto) Constraint_Error Symbol_Table_Info.Symbol_Maps.Constant_Reference: key not in map|
 Error detected at REDACTED
---
-Occurs: 1 times
-<========================>
-raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from goto_utils.ads:147
-

--- a/experiments/golden-results/muen-summary.txt
+++ b/experiments/golden-results/muen-summary.txt
@@ -28,25 +28,15 @@ Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Precondition
 Nkind: N_Pragma
 --
-Occurs: 7 times
-Calling function: Do_Type_Reference
-Error message: Type of type not a type
-Nkind: N_Defining_Identifier
---
 Occurs: 5 times
-Calling function: Do_Itype_Integer_Subtype
-Error message: Non-literal bound unsupported
-Nkind: N_Defining_Identifier
+Calling function: Do_Expression
+Error message: First of string unsupported
+Nkind: N_Attribute_Reference
 --
 Occurs: 5 times
 Calling function: Process_Pragma_Declaration
 Error message: Unsupported pragma: Postcondition
 Nkind: N_Pragma
---
-Occurs: 4 times
-Calling function: Do_Expression
-Error message: First of string unsupported
-Nkind: N_Attribute_Reference
 --
 Occurs: 4 times
 Calling function: Do_Full_Type_Declaration
@@ -70,8 +60,8 @@ Nkind: N_Aggregate
 --
 Occurs: 2 times
 Calling function: Do_Expression
-Error message: Index of string unsupported
-Nkind: N_Indexed_Component
+Error message: Last of string unsupported
+Nkind: N_Attribute_Reference
 --
 Occurs: 2 times
 Calling function: Process_Declaration
@@ -95,8 +85,8 @@ Nkind: N_Attribute_Reference
 --
 Occurs: 1 times
 Calling function: Do_Expression
-Error message: Last of string unsupported
-Nkind: N_Attribute_Reference
+Error message: Index of string unsupported
+Nkind: N_Indexed_Component
 --
 Occurs: 1 times
 Calling function: Do_Op_Expon

--- a/gnat2goto/driver/goto_utils.adb
+++ b/gnat2goto/driver/goto_utils.adb
@@ -895,7 +895,7 @@ package body GOTO_Utils is
    end Get_Int32_T_Zero;
 
    function Get_Ada_Check_Symbol (Name : String;
-                                  A_Symbol_Table : out Symbol_Table;
+                                  A_Symbol_Table : in out Symbol_Table;
                                   Source_Loc : Irep)
                                   return Symbol is
    begin

--- a/gnat2goto/driver/goto_utils.ads
+++ b/gnat2goto/driver/goto_utils.ads
@@ -219,7 +219,7 @@ package GOTO_Utils is
                               return Irep;
    function Get_Int32_T_Zero return Irep;
    function Get_Ada_Check_Symbol (Name : String;
-                                  A_Symbol_Table : out Symbol_Table;
+                                  A_Symbol_Table : in out Symbol_Table;
                                   Source_Loc : Irep)
                                   return Symbol;
 

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -310,9 +310,6 @@ package body Tree_Walk is
 
    function Get_Variant_Union_Member_Name (N : Node_Id) return String;
 
-   function Make_Increment
-     (Sym : Irep; Sym_Type : Node_Id; Amount : Integer) return Irep;
-
    function Make_Integer_Constant (Val : Integer; Ty : Node_Id) return Irep;
 
    function Make_Runtime_Check (Condition : Irep) return Irep
@@ -2112,72 +2109,103 @@ package body Tree_Walk is
 
    function Do_Loop_Statement (N : Node_Id) return Irep is
       Iter_Scheme  : constant Node_Id := Iteration_Scheme (N);
-      Body_Block   : constant Irep := Process_Statements (Statements (N));
       Loop_Irep : Irep;
       Loop_Wrapper : constant Irep := Make_Code_Block
         (Get_Source_Location (N));
    begin
-      if not Present (Iter_Scheme) then
-         Loop_Irep := Make_Code_While
-           (Loop_Body => Body_Block,
-            Cond => CProver_True,
-            Source_Location => Get_Source_Location (N));
-      else
-         if Present (Condition (Iter_Scheme)) then
-            --  WHILE loop
-            declare
-               Cond : constant Irep := Do_Expression (Condition (Iter_Scheme));
-            begin
+      if not Present (Iter_Scheme) or else Present (Condition (Iter_Scheme))
+      then
+         --  The statements of the loop can be processed.
+         declare
+            Body_Block : constant Irep :=
+              Process_Statements (Statements (N));
+            Loop_Cond  : constant Irep :=
+              (if not Present (Iter_Scheme) then
+               --  It is a simple loop condition is True.
+                  CProver_True
+               else
+               --  It is a WHILE loop get the loop condition.
+                  Do_Expression (Condition (Iter_Scheme))
+              );
+         begin
                Loop_Irep := Make_Code_While
                  (Loop_Body => Body_Block,
-                  Cond => Cond,
+                  Cond => Loop_Cond,
                   Source_Location => Get_Source_Location (N));
-            end;
-         else
-            --  FOR loop.
-            --   Ada 1995: loop_parameter_specification
-            --   Ada 2012: +iterator_specification
-            if Present (Loop_Parameter_Specification (Iter_Scheme)) then
+         end;
+      else
+         --  It's a FOR loop.
+         --  The statements in the body of the loop cannot be processed
+         --  until the loop variable has been inserted into the symbol table.
+         --
+         --   Ada 1995: loop_parameter_specification
+         --   Ada 2012: +iterator_specification
+         if Present (Loop_Parameter_Specification (Iter_Scheme)) then
+            declare
+               Spec : constant Node_Id :=
+                 Loop_Parameter_Specification (Iter_Scheme);
+               Loopvar      : constant Entity_Id :=
+                 Defining_Identifier (Spec);
+               Loopvar_Name : constant String :=
+                 Unique_Name (Loopvar);
+               Loopvar_Type : constant Entity_Id := Etype (Loopvar);
+
+               function Get_Range (Spec : Node_Id) return Node_Id;
+
+               function Get_Range (Spec : Node_Id) return Node_Id
+               is
+                  Dsd : Node_Id := Discrete_Subtype_Definition (Spec);
+               begin
+                  if Nkind (Dsd) = N_Subtype_Indication then
+                     Dsd := Range_Expression (Constraint (Dsd));
+                  end if;
+
+                  return Dsd;
+               end Get_Range;
+
+               Dsd : Node_Id;
+
+               Type_Loopvar : constant Irep := Do_Type_Reference
+                 (Etype (Etype (Defining_Identifier (Spec))));
+
+               Sym_Loopvar : constant Irep :=
+                 Make_Symbol_Expr
+                   (Source_Location =>
+                      Get_Source_Location (Defining_Identifier (Spec)),
+                    I_Type          => Type_Loopvar,
+                    Identifier      => Loopvar_Name);
+
+               Init : Irep;
+               Cond : Irep;
+               Post : Irep;
+
+               Bound_Low : Irep;
+               Bound_High : Irep;
+               Pre_Dsd : Node_Id := Discrete_Subtype_Definition (Spec);
+            begin
+               --  Add the loop variable to the symbol table
+               New_Object_Symbol_Entry
+                 (Object_Name       => Intern (Loopvar_Name),
+                  Object_Type       => Do_Type_Reference (Loopvar_Type),
+                  Object_Init_Value => Ireps.Empty,
+                  A_Symbol_Table    => Global_Symbol_Table);
+
+               --  Now the statements of the for loop can be processed.
                declare
-                  Spec : constant Node_Id :=
-                    Loop_Parameter_Specification (Iter_Scheme);
-                  Loopvar_Name : constant String :=
-                    Unique_Name (Defining_Identifier (Spec));
+                  Body_Block : constant Irep :=
+                    Process_Statements (Statements (N));
+                  --  And, if the loop variable is an enumeration type,
+                  --  the underlying numerical representation of the
+                  --  enumeration can be obtained.
+                  --  If the loop variable is a discrete numeric type,
+                  --  the function Cast_Enum is an identity function.
+                  Loopvar_Numeric_Rep : constant Irep :=
+                    Cast_Enum (Sym_Loopvar, Global_Symbol_Table);
 
-                  function Get_Range (Spec : Node_Id)
-                     return Node_Id;
-
-                  function Get_Range (Spec : Node_Id)
-                     return Node_Id
-                  is
-                     Dsd : Node_Id := Discrete_Subtype_Definition (Spec);
-                  begin
-                     if Nkind (Dsd) = N_Subtype_Indication then
-                        Dsd := Range_Expression (Constraint (Dsd));
-                     end if;
-
-                     return Dsd;
-                  end Get_Range;
-
-                  Dsd : Node_Id;
-
-                  Type_Loopvar : constant Irep := Do_Type_Reference
-                    (Etype (Etype (Defining_Identifier (Spec))));
-
-                  Sym_Loopvar : constant Irep :=
-                    Make_Symbol_Expr
-                      (Source_Location =>
-                         Get_Source_Location (Defining_Identifier (Spec)),
-                       I_Type          => Type_Loopvar,
-                       Identifier      => Loopvar_Name);
-
-                  Init : Irep;
-                  Cond : Irep;
-                  Post : Irep;
-
-                  Bound_Low : Irep;
-                  Bound_High : Irep;
-                  Pre_Dsd : Node_Id := Discrete_Subtype_Definition (Spec);
+                  --  A loop increment/decrement constant is required
+                  --  for a FOR loop.
+                  Loop_Inc_Dec : constant Irep :=
+                    Make_Integer_Constant (1, Loopvar_Type);
                begin
                   if Nkind (Pre_Dsd) = N_Subtype_Indication then
                      Pre_Dsd := Range_Expression (Constraint (Pre_Dsd));
@@ -2187,9 +2215,10 @@ package body Tree_Walk is
                     and  Nkind (Pre_Dsd) /= N_Real_Range_Specification
                     and not (Present (Scalar_Range (Etype (Pre_Dsd))))
                   then
-                     Report_Unhandled_Node_Empty (Pre_Dsd,
-                                                  "Do_While_Statement",
-                                                  "Wrong Nkind spec");
+                     Report_Unhandled_Node_Empty
+                       (Pre_Dsd,
+                        "Do_Loop_Statement - FOR loop",
+                        "Invalid Discrete_Subtype_Definition");
                      return Loop_Wrapper;
                   end if;
                   if Nkind (Pre_Dsd) = N_Identifier or
@@ -2200,55 +2229,109 @@ package body Tree_Walk is
                      Dsd := Get_Range (Spec);
                   end if;
                   if not (Present (Low_Bound (Dsd))) then
-                     Report_Unhandled_Node_Empty (Dsd,
-                                                  "Do_While_Statement",
-                                                  "No range in subtype");
+                     Report_Unhandled_Node_Empty
+                       (Dsd,
+                        "Do_Loop_Statement  FOR loop",
+                        "Mebership_choice subtype has unknown range");
                      return Loop_Wrapper;
                   end if;
                   Bound_Low := Do_Expression (Low_Bound (Dsd));
                   Bound_High := Do_Expression (High_Bound (Dsd));
+
                   --  Loop var decl
                   Append_Op (Loop_Wrapper, Make_Code_Decl
                              (Symbol          => Sym_Loopvar,
                               Source_Location => Get_Source_Location
                                 (Defining_Identifier (Spec))));
 
-                  --  TODO: needs generalization to support enums
                   if Reverse_Present (Spec) then
-                     Init := Make_Code_Assign
-                       (Lhs => Sym_Loopvar,
-                        Rhs => Typecast_If_Necessary
-                          (Bound_High,
-                           Get_Type (Sym_Loopvar),
-                           Global_Symbol_Table),
-                        Source_Location => Get_Source_Location (Spec));
-                     Cond := Make_Op_Geq
-                       (Rhs             => Bound_Low,
-                        Lhs             => Sym_Loopvar,
-                        Source_Location => Get_Source_Location (Spec),
-                        Overflow_Check  => False,
-                        I_Type          => Make_Bool_Type,
-                        Range_Check     => False);
-                     Post := Make_Increment
-                       (Sym_Loopvar, Etype (Low_Bound (Dsd)), -1);
+                     declare
+                        --  Arithmetic has to be performed on numeric types.
+                        Dec : constant Irep := Make_Op_Sub
+                          (Lhs => Loopvar_Numeric_Rep,
+                           Rhs => Typecast_If_Necessary
+                             (Loop_Inc_Dec,
+                              Get_Type (Loopvar_Numeric_Rep),
+                              Global_Symbol_Table),
+                           I_Type => Get_Type (Loopvar_Numeric_Rep),
+                          Source_Location => Internal_Source_Location);
+                     begin
+                        Init := Make_Code_Assign
+                          (Lhs => Sym_Loopvar,
+                           Rhs => Typecast_If_Necessary
+                             (Bound_High,
+                              Get_Type (Sym_Loopvar),
+                              Global_Symbol_Table),
+                           Source_Location => Get_Source_Location (Spec));
+                        --  Here the numeric representation of the loop
+                        --  variable must be used for the relational operator.
+                        Cond := Make_Op_Geq
+                          (Rhs             =>
+                             Typecast_If_Necessary
+                               (Bound_Low,
+                                Get_Type (Loopvar_Numeric_Rep),
+                                Global_Symbol_Table),
+                           Lhs             => Loopvar_Numeric_Rep,
+                           Source_Location => Get_Source_Location (Spec),
+                           Overflow_Check  => False,
+                           I_Type          => Make_Bool_Type,
+                           Range_Check     => False);
+                        --  Assignment has the given type.
+                        Post :=
+                          Make_Side_Effect_Expr_Assign
+                            (Lhs => Sym_Loopvar,
+                             Rhs => Typecast_If_Necessary
+                               (Expr           => Dec,
+                                New_Type       => Get_Type (Sym_Loopvar),
+                                A_Symbol_Table => Global_Symbol_Table),
+                             Source_Location => Internal_Source_Location,
+                             I_Type => Get_Type (Sym_Loopvar));
+                     end;
                   else
-                     Init := Make_Code_Assign
-                       (Lhs => Sym_Loopvar,
-                        Rhs => Typecast_If_Necessary
-                          (Bound_Low,
-                           Get_Type (Sym_Loopvar),
-                           Global_Symbol_Table),
-                        Source_Location => Get_Source_Location (Spec));
-                     Cond := Make_Op_Leq
-                       (Rhs             => Bound_High,
-                        Lhs             => Sym_Loopvar,
-                        Source_Location => Get_Source_Location (Spec),
-                        Overflow_Check  => False,
-                        I_Type          => Make_Bool_Type,
-                        Range_Check     => False);
-                     Post := Make_Increment
-                       (Sym_Loopvar, Etype (Low_Bound (Dsd)), 1);
+                     declare
+                        --  Arithmetic has to be performed on numeric types.
+                        Inc : constant Irep := Make_Op_Add
+                          (Lhs => Loopvar_Numeric_Rep,
+                           Rhs => Typecast_If_Necessary
+                             (Loop_Inc_Dec,
+                              Get_Type (Loopvar_Numeric_Rep),
+                              Global_Symbol_Table),
+                           I_Type => Get_Type (Loopvar_Numeric_Rep),
+                          Source_Location => Internal_Source_Location);
+                     begin
+                        Init := Make_Code_Assign
+                          (Lhs => Sym_Loopvar,
+                           Rhs => Typecast_If_Necessary
+                             (Bound_Low,
+                              Get_Type (Sym_Loopvar),
+                              Global_Symbol_Table),
+                           Source_Location => Get_Source_Location (Spec));
+                        --  Here the numeric representation of the loop
+                        --  variable must be used for the relational operator.
+                        Cond := Make_Op_Leq
+                          (Rhs             =>
+                             Typecast_If_Necessary
+                               (Bound_High,
+                                Get_Type (Loopvar_Numeric_Rep),
+                                Global_Symbol_Table),
+                           Lhs             => Loopvar_Numeric_Rep,
+                           Source_Location => Get_Source_Location (Spec),
+                           Overflow_Check  => False,
+                           I_Type          => Make_Bool_Type,
+                           Range_Check     => False);
+                        --  Assignment has the given type.
+                        Post :=
+                          Make_Side_Effect_Expr_Assign
+                            (Lhs => Sym_Loopvar,
+                             Rhs => Typecast_If_Necessary
+                               (Expr           => Inc,
+                                New_Type       => Get_Type (Sym_Loopvar),
+                                A_Symbol_Table => Global_Symbol_Table),
+                             Source_Location => Internal_Source_Location,
+                             I_Type => Get_Type (Sym_Loopvar));
+                     end;
                   end if;
+
                   Set_Source_Location (Post, Get_Source_Location (Spec));
                   Loop_Irep := Make_Code_For
                     (Loop_Body => Body_Block,
@@ -2257,21 +2340,20 @@ package body Tree_Walk is
                      Iter => Post,
                      Source_Location => Get_Source_Location (N));
                end;
-            else
-               if not Present (Iterator_Specification (Iter_Scheme)) then
-                  Report_Unhandled_Node_Empty (N, "Do_While_Statement",
-                                           "Scheme specification not present");
-                  return Loop_Wrapper;
-
-               end if;
-               Report_Unhandled_Node_Empty (N, "Do_While_Statement",
-                                            "Loop iterators not implemented");
+            end;
+         else
+            if not Present (Iterator_Specification (Iter_Scheme)) then
+               Report_Unhandled_Node_Empty
+                 (N, "Do_Loop_Statement",
+                  "Scheme specification not present");
                return Loop_Wrapper;
+
             end if;
+            Report_Unhandled_Node_Empty (N, "Do_Loop_Statement",
+                                         "Loop iterators not implemented");
+            return Loop_Wrapper;
          end if;
       end if;
-
-      Set_Loop_Body (Loop_Irep, Body_Block);
 
       Append_Op (Loop_Wrapper, Loop_Irep);
 
@@ -5372,39 +5454,24 @@ package body Tree_Walk is
       return To_String (Variant_Name);
    end Get_Variant_Union_Member_Name;
 
-   --------------------
-   -- Make_Increment --
-   --------------------
-
-   function Make_Increment
-     (Sym : Irep; Sym_Type : Node_Id; Amount : Integer) return Irep
-   is
-      Amount_Expr : constant Irep :=
-        Make_Integer_Constant (Amount, Sym_Type);
-      Plus : constant Irep := Make_Op_Add
-        (Lhs => Sym,
-         Rhs => Amount_Expr,
-         I_Type => Get_Type (Sym),
-         Source_Location => Internal_Source_Location);
-   begin
-      return Make_Side_Effect_Expr_Assign
-        (Lhs => Sym,
-         Rhs => Plus,
-         Source_Location => Internal_Source_Location,
-         I_Type => Get_Type (Sym));
-   end Make_Increment;
-
    ---------------------------
    -- Make_Integer_Constant --
    ---------------------------
 
    function Make_Integer_Constant (Val : Integer; Ty : Node_Id) return Irep is
-      Type_Width : constant Int := UI_To_Int (Esize (Ty));
-      Val_Binary : constant String := Convert_Int_To_Binary (Val, Type_Width);
+      Type_Width    : constant Int := UI_To_Int (Esize (Ty));
+      Val_Binary    : constant String :=
+        Convert_Int_To_Binary (Val, Type_Width);
+      Type_Irep     : constant Irep := Do_Type_Reference (Ty);
+      Resolved_Type : constant Irep :=
+        (if Kind (Type_Irep) = I_C_Enum_Type then
+              Get_Subtype (Type_Irep)
+         else
+            Type_Irep);
    begin
       return Make_Constant_Expr
         (Value => Val_Binary,
-         I_Type => Do_Type_Reference (Ty),
+         I_Type => Resolved_Type,
          Source_Location => Internal_Source_Location);
    end Make_Integer_Constant;
 

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -795,11 +795,11 @@ package body Tree_Walk is
            Kind (Mem) = I_Symbol_Expr
          then
             declare
-               Val : constant Irep := Global_Symbol_Table
-                 (Intern
-                    (Get_Identifier
-                     (Mem)))
-                 .Value;
+               Key : constant Symbol_Id :=
+                 Intern (Get_Identifier (Mem));
+               pragma Assert (Global_Symbol_Table.Contains (Key),
+                              "Enum symbol not in symbol table");
+               Val : constant Irep := Global_Symbol_Table (Key).Value;
             begin
                if Val = Ireps.Empty then
                   return Mem;

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -4330,7 +4330,11 @@ package body Tree_Walk is
             Bound_Value :=
               Store_Nat_Bound (Bound_Type_Nat (Intval (Bound)));
             Ok := True;
-         when N_Identifier =>
+         when N_Character_Literal =>
+            Bound_Value :=
+              Store_Symbol_Bound (Bound_Type_Symbol (Bound));
+            Ok := True;
+         when N_Identifier | N_Expanded_Name =>
             Bound_Value :=
                  Store_Symbol_Bound (Bound_Type_Symbol (
                                      Do_Identifier (Bound)));

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -1462,7 +1462,12 @@ package body Tree_Walk is
          when N_Aggregate            => return Do_Aggregate_Literal (N);
          when N_Indexed_Component    => return Do_Indexed_Component (N);
          when N_Slice                => return Do_Slice (N);
-         when N_In                   =>  return Do_In (N);
+         when N_In                   => return Do_In (N);
+         when N_Not_In               => return
+              Make_Op_Not (Op0             => Do_In (N),
+                           Source_Location => Get_Source_Location (N),
+                           I_Type          => CProver_Bool_T,
+                           Range_Check     => False);
          when N_Real_Literal => return Do_Real_Constant (N);
          when N_If_Expression => return Do_If_Expression (N);
          when N_And_Then => return Do_And_Then (N);

--- a/gnat2goto/driver/tree_walk.ads
+++ b/gnat2goto/driver/tree_walk.ads
@@ -109,7 +109,7 @@ package Tree_Walk is
      Post => Kind (Do_Expression'Result) in Class_Expr;
 
    function Do_In (N : Node_Id) return Irep
-     with Pre => Nkind (N) in N_In,
+     with Pre => Nkind (N) in N_In | N_Not_In,
      Post => Kind (Do_In'Result) = I_Op_And;
 
    function Make_Memcpy_Function_Call_Expr (Destination : Irep;

--- a/testsuite/gnat2goto/tests/do_in/do_in_int.adb
+++ b/testsuite/gnat2goto/tests/do_in/do_in_int.adb
@@ -1,0 +1,48 @@
+procedure Do_In_Int is
+   type Small_Int is range 1 .. 6;
+
+  procedure Inc (E : in out Small_Int) is
+   begin
+      --  This assertion should succeed.
+      pragma Assert (E in Small_Int);
+      --  Should get a check failure here if E = 6.
+      --  TJJ 23/06/20 - cbmc - check does fail when E = 6.
+      E := E + 1;
+   end Inc;
+
+   procedure Dec (E : in out Small_Int) is
+   begin
+      --  This assertion should succeed.
+      pragma Assert (E in Small_Int);
+      --  Should get a check failure here if E = .
+      --  TJJ 23/06/20 - cbmc no range check failure given when E = 1.
+      E := E - 1;
+   end Dec;
+
+   I : Small_Int;
+
+begin
+   I := 6;
+   Inc (I);
+   --  TJJ 23/06/20 - Assertion seems to succeed. Is it because the
+   --  range check at line 10?
+   pragma Assert (I in Small_Int);
+
+   I := 1;
+   Dec (I);
+   --  TJJ 23/06/20 - Assertion seems to succeed. Is it because the
+   --  range check at line 19?
+   pragma Assert (I in Small_Int);
+
+   I := 3;
+   Inc (I);
+   --  Assertion shoul succeed - and does.
+   pragma Assert (I in Small_Int);
+
+   Dec (I);
+   --  Assertion shoul succeed - and does.
+   pragma Assert (I in Small_Int);
+
+   --  Assertion shoul succeed - and does.
+   pragma Assert (I = 3);
+end Do_In_Int;

--- a/testsuite/gnat2goto/tests/do_in/test.opt
+++ b/testsuite/gnat2goto/tests/do_in/test.opt
@@ -1,0 +1,1 @@
+ALL XFAIL cbmc does not fail a range check at line 19 when E = 1

--- a/testsuite/gnat2goto/tests/do_in/test.out
+++ b/testsuite/gnat2goto/tests/do_in/test.out
@@ -1,0 +1,4 @@
+[do_in_int.assertion.1] line 14 assertion I in Small_Int: SUCCESS
+[inc.assertion.2] line 6 assertion E in Small_Int: SUCCESS
+[inc.assertion.1] line 7 Ada Check assertion: FAILURE
+VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/do_in/test.py
+++ b/testsuite/gnat2goto/tests/do_in/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()

--- a/testsuite/gnat2goto/tests/do_not_in/do_not_in_int.adb
+++ b/testsuite/gnat2goto/tests/do_not_in/do_not_in_int.adb
@@ -1,0 +1,35 @@
+procedure Do_Not_In_Int is
+   subtype Small_Int is Integer range 1 .. 6;
+
+  procedure Inc (E : in out Integer) is
+   begin
+      pragma Assert (E in Small_Int);
+      E := E + 1;
+   end Inc;
+
+   procedure Dec (E : in out Integer) is
+   begin
+      pragma Assert (E in Small_Int);
+      E := E - 1;
+   end Dec;
+
+   I : Integer;
+
+begin
+   I := 6;
+   Inc (I);
+   pragma Assert (I not in Small_Int);
+
+   I := 1;
+   Dec (I);
+   pragma Assert (I not in Small_Int);
+
+   I := 3;
+   Inc (I);
+   pragma Assert (I in Small_Int);
+
+   Dec (I);
+   pragma Assert (I in Small_Int);
+
+   pragma Assert (I = 3);
+end Do_Not_In_Int;

--- a/testsuite/gnat2goto/tests/do_not_in/test.out
+++ b/testsuite/gnat2goto/tests/do_not_in/test.out
@@ -1,0 +1,9 @@
+[dec.assertion.1] line 12 assertion E in Small_Int: SUCCESS
+[do_not_in_int.assertion.1] line 21 assertion I not in Small_Int: SUCCESS
+[do_not_in_int.assertion.2] line 25 assertion I not in Small_Int: SUCCESS
+[do_not_in_int.assertion.3] line 29 assertion I in Small_Int: SUCCESS
+[do_not_in_int.assertion.4] line 32 assertion I in Small_Int: SUCCESS
+[do_not_in_int.assertion.5] line 34 assertion I = 3: SUCCESS
+[inc.assertion.2] line 6 assertion E in Small_Int: SUCCESS
+[inc.assertion.1] line 7 Ada Check assertion: SUCCESS
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/do_not_in/test.py
+++ b/testsuite/gnat2goto/tests/do_not_in/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()

--- a/testsuite/gnat2goto/tests/for_loop_char/for_loop_char.adb
+++ b/testsuite/gnat2goto/tests/for_loop_char/for_loop_char.adb
@@ -1,0 +1,27 @@
+procedure For_Loop_Char is
+   subtype Small_char is Character range 'a' .. 'g';
+
+   type A is array (Small_Char) of Integer;
+
+   procedure Inc (E : Small_Char; N : in out Integer) is
+   begin
+      pragma Assert (E in Small_Char);
+      N := N + 1;
+   end Inc;
+
+   Arr : A;
+   I : Integer := 1;
+
+begin
+   for E in Small_Char loop
+      Arr (E) := I;
+      Inc (E, I);
+   end loop;
+
+   I := 1;
+   for E in Small_Char loop
+      pragma Assert (Arr (E) = I);
+      Inc (E, I);
+   end loop;
+
+end For_Loop_Char;

--- a/testsuite/gnat2goto/tests/for_loop_char/test.out
+++ b/testsuite/gnat2goto/tests/for_loop_char/test.out
@@ -1,0 +1,5 @@
+[for_loop_char.assertion.1] line 17 Ada Check assertion: SUCCESS
+[for_loop_char.assertion.2] line 23 assertion Arr (E) = I: SUCCESS
+[inc.assertion.2] line 8 assertion E in Small_Char: SUCCESS
+[inc.assertion.1] line 9 Ada Check assertion: SUCCESS
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/for_loop_char/test.py
+++ b/testsuite/gnat2goto/tests/for_loop_char/test.py
@@ -1,0 +1,4 @@
+from test_support import *
+
+# need feature/bool to run completely. Here we only show that the loop is actually translated
+prove()

--- a/testsuite/gnat2goto/tests/for_loop_enum/for_loop_enum.adb
+++ b/testsuite/gnat2goto/tests/for_loop_enum/for_loop_enum.adb
@@ -1,0 +1,44 @@
+procedure For_Loop_Enum is
+   type Enum is (one, two, three, four, five, six);
+
+   type A is array (Enum) of Integer;
+
+   procedure Inc (E : Enum; N : in out Integer) is
+   begin
+      pragma Assert (E in one .. six);
+      N := N + 1;
+   end Inc;
+
+   Arr : A;
+   I : Integer := 1;
+
+begin
+   --  cbmc incorrectly fails this first range check.
+   --  I have seen this several times in tests dependent on
+   --  the structure of the code it succeeds or fails.
+   Arr (one) := -1;
+
+   for E in Enum loop
+      Arr (E) := I;
+      Inc (E, I);
+   end loop;
+
+   I := 1;
+   for E in Enum loop
+      pragma Assert (Arr (E) = I);
+      Inc (E, I);
+   end loop;
+
+   I := 1;
+   for E in reverse Enum loop
+      Arr (E) := I;
+      Inc (E, I);
+   end loop;
+
+   I := 1;
+   for E in reverse Enum loop
+      pragma Assert (Arr (E) = I);
+      Inc (E, I);
+   end loop;
+
+end For_Loop_Enum;

--- a/testsuite/gnat2goto/tests/for_loop_enum/test.out
+++ b/testsuite/gnat2goto/tests/for_loop_enum/test.out
@@ -1,0 +1,6 @@
+[for_loop_enum.assertion.1] line 19 Ada Check assertion: FAILURE
+[for_loop_enum.assertion.2] line 28 assertion Arr (E) = I: SUCCESS
+[for_loop_enum.assertion.3] line 40 assertion Arr (E) = I: SUCCESS
+[inc.assertion.2] line 8 assertion E in one .. six: SUCCESS
+[inc.assertion.1] line 9 Ada Check assertion: SUCCESS
+VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/for_loop_enum/test.py
+++ b/testsuite/gnat2goto/tests/for_loop_enum/test.py
@@ -1,0 +1,4 @@
+from test_support import *
+
+# need feature/bool to run completely. Here we only show that the loop is actually translated
+prove()

--- a/testsuite/gnat2goto/tests/for_loop_int/for_loop_int.adb
+++ b/testsuite/gnat2goto/tests/for_loop_int/for_loop_int.adb
@@ -1,0 +1,30 @@
+procedure For_Loop_Int is
+   type Small_Int is range 1 .. 6;
+
+   type A is array (Small_Int) of Integer;
+
+   procedure Inc (E : Small_Int;
+                  N : in out Integer) is
+   begin
+      pragma Assert (E in Small_Int);
+      N := N + 1;
+   end Inc;
+
+   Arr : A;
+   I : Integer := 1;
+
+begin
+   for E in Small_Int loop
+      Arr (E) := I;
+      Inc (E,
+           I);
+   end loop;
+
+   I := 1;
+   for E in Small_Int loop
+      pragma Assert (Arr (E) = I);
+      Inc (E,
+           I);
+   end loop;
+
+end For_Loop_Int;

--- a/testsuite/gnat2goto/tests/for_loop_int/test.out
+++ b/testsuite/gnat2goto/tests/for_loop_int/test.out
@@ -1,0 +1,5 @@
+[for_loop_int.assertion.1] line 18 Ada Check assertion: SUCCESS
+[for_loop_int.assertion.2] line 25 assertion Arr (E) = I: SUCCESS
+[inc.assertion.2] line 9 assertion E in Small_Int: SUCCESS
+[inc.assertion.1] line 10 Ada Check assertion: SUCCESS
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/for_loop_int/test.py
+++ b/testsuite/gnat2goto/tests/for_loop_int/test.py
@@ -1,0 +1,4 @@
+from test_support import *
+
+# need feature/bool to run completely. Here we only show that the loop is actually translated
+prove()

--- a/testsuite/gnat2goto/tests/for_loop_int_explicit/for_loop_int_1.adb
+++ b/testsuite/gnat2goto/tests/for_loop_int_explicit/for_loop_int_1.adb
@@ -1,0 +1,27 @@
+procedure For_Loop_Int_1 is
+   type Small_Int is range 1 .. 6;
+
+   type A is array (Small_Int) of Integer;
+
+   procedure Inc (E : Small_Int; N : in out Integer) is
+   begin
+      pragma Assert (E in Small_Int);
+      N := N + 1;
+   end Inc;
+
+   Arr : A;
+   I : Integer := 1;
+
+begin
+   for E in Small_Int range 1 .. 6 loop
+      Arr (E) := I;
+      Inc (E, I);
+   end loop;
+
+   I := 1;
+   for E in Small_Int range 1 .. 6 loop
+      pragma Assert (Arr (E) = I);
+      Inc (E, I);
+   end loop;
+
+end For_Loop_Int_1;

--- a/testsuite/gnat2goto/tests/for_loop_int_explicit/test.out
+++ b/testsuite/gnat2goto/tests/for_loop_int_explicit/test.out
@@ -1,0 +1,5 @@
+[for_loop_int_1.assertion.1] line 17 Ada Check assertion: SUCCESS
+[for_loop_int_1.assertion.2] line 23 assertion Arr (E) = I: SUCCESS
+[inc.assertion.2] line 8 assertion E in Small_Int: SUCCESS
+[inc.assertion.1] line 9 Ada Check assertion: SUCCESS
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/for_loop_int_explicit/test.py
+++ b/testsuite/gnat2goto/tests/for_loop_int_explicit/test.py
@@ -1,0 +1,4 @@
+from test_support import *
+
+# need feature/bool to run completely. Here we only show that the loop is actually translated
+prove()

--- a/testsuite/gnat2goto/tests/for_loop_sub_int/for_loop_sub_int.adb
+++ b/testsuite/gnat2goto/tests/for_loop_sub_int/for_loop_sub_int.adb
@@ -1,0 +1,27 @@
+procedure For_Loop_Sub_Int is
+   subtype Small_Int is Integer range 1 .. 6;
+   subtype Smaller is Small_Int range 1 .. 5;
+
+   type A is array (Small_Int) of Integer;
+
+   procedure Inc (E : Small_Int; N : in out Integer) is
+   begin
+      N := N + 1;
+   end Inc;
+
+   Arr : A;
+   I : Integer := 1;
+
+begin
+   for E in Small_Int loop
+      Arr (E) := I;
+      Inc (E, I);
+   end loop;
+
+   I := 1;
+   for E in Small_Int loop
+      pragma Assert (Arr (E) = I);
+      Inc (E, I);
+   end loop;
+
+end For_Loop_Sub_Int;

--- a/testsuite/gnat2goto/tests/for_loop_sub_int/test.out
+++ b/testsuite/gnat2goto/tests/for_loop_sub_int/test.out
@@ -1,0 +1,4 @@
+[for_loop_sub_int.assertion.1] line 17 Ada Check assertion: SUCCESS
+[for_loop_sub_int.assertion.2] line 23 assertion Arr (E) = I: SUCCESS
+[inc.assertion.1] line 9 Ada Check assertion: SUCCESS
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/for_loop_sub_int/test.py
+++ b/testsuite/gnat2goto/tests/for_loop_sub_int/test.py
@@ -1,0 +1,4 @@
+from test_support import *
+
+# need feature/bool to run completely. Here we only show that the loop is actually translated
+prove()

--- a/testsuite/gnat2goto/tests/for_loop_sub_int_exp/for_loop_sub_int_1.adb
+++ b/testsuite/gnat2goto/tests/for_loop_sub_int_exp/for_loop_sub_int_1.adb
@@ -1,0 +1,27 @@
+procedure For_Loop_Sub_Int_1 is
+   subtype Small_Int is Integer range 1 .. 6;
+
+   type A is array (Small_Int) of Integer;
+
+   procedure Inc (E : Small_Int; N : in out Integer) is
+   begin
+      pragma Assert (E in Small_Int);
+      N := N + 1;
+   end Inc;
+
+   Arr : A;
+   I : Integer := 1;
+
+begin
+   for E in 1 .. 5 loop
+      Arr (E) := I;
+      Inc (E, I);
+   end loop;
+
+   I := 1;
+   for E in 1 .. 5 loop
+      pragma Assert (Arr (E) = I);
+      Inc (E, I);
+   end loop;
+
+end For_Loop_Sub_Int_1;

--- a/testsuite/gnat2goto/tests/for_loop_sub_int_exp/test.out
+++ b/testsuite/gnat2goto/tests/for_loop_sub_int_exp/test.out
@@ -1,0 +1,5 @@
+[for_loop_sub_int_1.assertion.1] line 17 Ada Check assertion: SUCCESS
+[for_loop_sub_int_1.assertion.2] line 23 assertion Arr (E) = I: SUCCESS
+[inc.assertion.2] line 8 assertion E in Small_Int: SUCCESS
+[inc.assertion.1] line 9 Ada Check assertion: SUCCESS
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/for_loop_sub_int_exp/test.py
+++ b/testsuite/gnat2goto/tests/for_loop_sub_int_exp/test.py
@@ -1,0 +1,4 @@
+from test_support import *
+
+# need feature/bool to run completely. Here we only show that the loop is actually translated
+prove()

--- a/testsuite/gnat2goto/tests/for_loop_var_bound/for_loop_var_bound.adb
+++ b/testsuite/gnat2goto/tests/for_loop_var_bound/for_loop_var_bound.adb
@@ -1,0 +1,139 @@
+procedure for_loop_var_bound is
+   Count, Lower, Upper : Integer;
+begin
+   Count := 0;
+   Lower := 1;
+   Upper := 3;
+   for I in Integer range 1 .. Upper loop
+      if I in 1 .. Upper then
+         Count := Count + 1;
+      end if;
+   end loop;
+
+   pragma Assert (Count = Upper);
+
+   Count := 0;
+
+   for I in Integer range Lower .. 4 loop
+      if I in Lower .. 4 then
+         Count := Count + 1;
+      end if;
+   end loop;
+
+   pragma Assert (Count = 4);
+
+   Count := 0;
+   Upper := 5;
+
+   for I in Integer range Lower .. Upper loop
+      if I in Lower .. Upper then
+         Count := Count + 1;
+      end if;
+   end loop;
+
+   pragma Assert (Count = Upper);
+
+   Count := 0;
+   Lower := 5; Upper := 9;
+
+   for I in Integer range Lower .. upper loop
+      if I in 5 .. 9 then
+         Count := Count + 1;
+      end if;
+   end loop;
+
+   pragma Assert (Count = Upper - Lower + 1);
+
+   Count := 0;
+
+   for I in Integer range Lower .. Upper loop
+      if I in 5 .. 9 then
+         Lower := Lower + 1;
+         Upper := Upper + 1;
+         Count := Count + 1;
+      end if;
+   end loop;
+
+   pragma Assert (Lower = 5 + Count);
+   pragma Assert (Upper = 9 + Count);
+
+   Count := 0;
+   Lower := 0;
+
+   for I in Lower + 1 .. Lower + 3 loop
+      if I in 1 .. 3 then
+         Count := Count + 1;
+      end if;
+   end loop;
+
+   pragma Assert (Count = 3);
+
+   Count := 0;
+   Lower := 1;
+   Upper := 3;
+   for I in reverse Integer range 1 .. Upper loop
+      if I in 1 .. Upper then
+         Count := Count + 1;
+      end if;
+   end loop;
+
+   pragma Assert (Count = Upper);
+
+   Count := 0;
+
+   for I in reverse Integer range Lower .. 4 loop
+      if I in Lower .. 4 then
+         Count := Count + 1;
+      end if;
+   end loop;
+
+   pragma Assert (Count = 4);
+
+   Count := 0;
+   Upper := 5;
+
+   for I in reverse Integer range Lower .. Upper loop
+      if I in Lower .. Upper then
+         Count := Count + 1;
+      end if;
+   end loop;
+
+   pragma Assert (Count = Upper);
+
+   Count := 0;
+   Lower := 5; Upper := 9;
+
+   for I in reverse Integer range Lower .. Upper loop
+      if I in Lower .. Upper then
+         Count := Count + 1;
+      end if;
+   end loop;
+
+   pragma Assert (Count = Upper - Lower + 1);
+
+   Count := 0;
+
+   for I in reverse Integer range Lower .. Upper loop
+      if I in 5 .. 9 then
+         Lower := Lower + 1;
+         Upper := Upper + 1;
+         Count := Count + 1;
+      end if;
+   end loop;
+
+   pragma Assert (Count = 5);
+   pragma Assert (Lower = 5 + Count);
+   pragma Assert (Upper = 9 + Count);
+
+   Count := 0;
+   Lower := 0;
+
+   for I in reverse Lower + 1 .. Lower + 3 loop
+      if I in 1 .. 3 then
+         Count := Count + 1;
+      end if;
+   end loop;
+
+   pragma Assert (Count = 3);
+
+end for_loop_var_bound;

--- a/testsuite/gnat2goto/tests/for_loop_var_bound/test.out
+++ b/testsuite/gnat2goto/tests/for_loop_var_bound/test.out
@@ -1,0 +1,17 @@
+[for_loop_var_bound.assertion.1] line 9 Ada Check assertion: SUCCESS
+[for_loop_var_bound.assertion.2] line 13 assertion Count = Upper: SUCCESS
+[for_loop_var_bound.assertion.3] line 23 assertion Count = 4: SUCCESS
+[for_loop_var_bound.assertion.4] line 34 assertion Count = Upper: SUCCESS
+[for_loop_var_bound.assertion.5] line 45 assertion Count = Upper - Lower + 1: SUCCESS
+[for_loop_var_bound.assertion.6] line 57 assertion Lower = 5 + Count: SUCCESS
+[for_loop_var_bound.assertion.7] line 58 assertion Upper = 9 + Count: SUCCESS
+[for_loop_var_bound.assertion.8] line 69 assertion Count = 3: SUCCESS
+[for_loop_var_bound.assertion.9] line 80 assertion Count = Upper: SUCCESS
+[for_loop_var_bound.assertion.10] line 90 assertion Count = 4: SUCCESS
+[for_loop_var_bound.assertion.11] line 101 assertion Count = Upper: SUCCESS
+[for_loop_var_bound.assertion.12] line 112 assertion Count = Upper - Lower + 1: SUCCESS
+[for_loop_var_bound.assertion.13] line 124 assertion Count = 5: SUCCESS
+[for_loop_var_bound.assertion.14] line 125 assertion Lower = 5 + Count: SUCCESS
+[for_loop_var_bound.assertion.15] line 126 assertion Upper = 9 + Count: SUCCESS
+[for_loop_var_bound.assertion.16] line 137 assertion Count = 3: SUCCESS
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/for_loop_var_bound/test.py
+++ b/testsuite/gnat2goto/tests/for_loop_var_bound/test.py
@@ -1,0 +1,4 @@
+from test_support import *
+
+# need feature/bool to run completely. Here we only show that the loop is actually translated
+prove()


### PR DESCRIPTION
For loops were not handled correctly.
Loop variables were not being inserted into the symbol table making references to the loop variable in the body of the loop invalid.
Also extended for loops so that loop variables may be enumerations, characters and have non-static bounds.
