### PR TITLE
Model size

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -1710,7 +1710,7 @@ Error detected at REDACTED
 --
 Occurs: 7 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:147|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:148|
 Error detected at REDACTED
 --
 Occurs: 3 times
@@ -1770,12 +1770,12 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:147|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:148|
 Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:147|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:148|
 Error detected at REDACTED
 --
 Occurs: 1 times
@@ -2190,7 +2190,7 @@ Error detected at REDACTED
 --
 Occurs: 25 times
 <========================>
-raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from goto_utils.ads:147
+raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from goto_utils.ads:148
 
 --
 Occurs: 2 times

--- a/experiments/golden-results/libsparkcrypto-summary.txt
+++ b/experiments/golden-results/libsparkcrypto-summary.txt
@@ -320,7 +320,7 @@ Raw compiler error message:
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:147|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:148|
 Error detected at REDACTED
 --
 Occurs: 1 times

--- a/experiments/golden-results/muen-summary.txt
+++ b/experiments/golden-results/muen-summary.txt
@@ -2945,7 +2945,7 @@ Error detected at REDACTED
 --
 Occurs: 3 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:147|
+| GNU Ada (ada2goto) Assert_Failure failed precondition from goto_utils.ads:148|
 Error detected at REDACTED
 --
 Occurs: 2 times

--- a/gnat2goto/driver/arrays.adb
+++ b/gnat2goto/driver/arrays.adb
@@ -4,7 +4,7 @@ with Namet;                 use Namet;
 with Tree_Walk;             use Tree_Walk;
 with Follow;                use Follow;
 with Range_Check;           use Range_Check;
-
+with ASVAT.Size_Model;
 package body Arrays is
 
    --------------------------------
@@ -73,7 +73,8 @@ package body Arrays is
            (if Kind (Follow_Symbol_Type (Element_Type_Pre,
             Global_Symbol_Table)) = I_C_Enum_Type
             then
-               Make_Signedbv_Type (32)
+               Make_Signedbv_Type
+              (ASVAT.Size_Model.Static_Size (Element_Type_Ent))
             else
                Element_Type_Pre);
          Element_Size : constant Uint :=
@@ -477,7 +478,8 @@ package body Arrays is
         (if Kind (Follow_Symbol_Type (Sub_Pre, Global_Symbol_Table))
          = I_C_Enum_Type
          then
-            Make_Signedbv_Type (32)
+            Make_Signedbv_Type
+           (ASVAT.Size_Model.Static_Size (Etype (Sub_Identifier)))
          else
             Sub_Pre);
       Data_Type : constant Irep :=

--- a/gnat2goto/driver/asvat-address_model.ads
+++ b/gnat2goto/driver/asvat-address_model.ads
@@ -2,7 +2,6 @@ with Types;               use Types;
 with Atree;               use Atree;
 with Sinfo;               use Sinfo;
 with Snames;              use Snames;
-with Ireps;               use Ireps;
 package ASVAT.Address_Model is
 
    type Address_To_Access_Functions is

--- a/gnat2goto/driver/asvat-modelling.adb
+++ b/gnat2goto/driver/asvat-modelling.adb
@@ -4,7 +4,6 @@ with Nlists;                  use Nlists;
 with Einfo;                   use Einfo;
 with Aspects;                 use Aspects;
 with Sem_Util;                use Sem_Util;
-with Ireps;                   use Ireps;
 with Follow;                  use Follow;
 with Range_Check;             use Range_Check;
 with GOTO_Utils;              use GOTO_Utils;

--- a/gnat2goto/driver/asvat-size_model.ads
+++ b/gnat2goto/driver/asvat-size_model.ads
@@ -1,8 +1,31 @@
 with Types;              use Types;
-with Ireps;              use Ireps;
 package ASVAT.Size_Model is
+   --  The size of an object in ASVAT is the size of the model of the object.
+   --  This may not be the same size as the object in the executable code of
+   --  the program.
+   --  When the size attribute is applied to a (sub)type, as opposed to an
+   --  object, gnat2goto attempts to obtain the value from the front end,
+   --  where possible, otherwise it uses the size required by the ASVAT model
+   --  for an object of the subtype.
+   --
+   --  Furthermore, the size of objects and components of a subtype may
+   --  not be known or provided by the front-end leaving the determination
+   --  of the size taken by an object of the subtype to the back-end code
+   --  generator.
+   --  Gnat2goto is effectively the back-end generating an ASVAT model and
+   --  has to provide a size value for a subtype when the front-end does not.
+   --
+   --  The ASVAT model does not perform any sort of packing so that any
+   --  pragma pack or size representation clause applied to an entity for
+   --  which the attribute size is obtained from the ASVAT model will be
+   --  ignored.
+   --
+
+   --  The function to obtain the value of X'Size or S'Size.
    function Do_Attribute_Size (N : Node_Id) return Irep;
 
+   --  The various sizes, either specified in the source text, or determined
+   --  from the model are set and read by the following subprograms.
    function Has_Size_Rep_Clause (E : Entity_Id) return Boolean;
    function Get_Rep_Size (E : Entity_Id) return Uint
      with Pre => Has_Size_Rep_Clause (E);
@@ -14,4 +37,22 @@ package ASVAT.Size_Model is
      with Pre => Has_Component_Size_Rep_Clause (E);
    procedure Set_Rep_Component_Size (E : Entity_Id; Size : Uint)
      with Pre => not Has_Component_Size_Rep_Clause (E);
+
+   --  Sometimes the size of the ASVAT model of of a type is required
+   --  rather than the compiler size.
+   --  These subprograms are used to set and get the model size
+   --  of a type.
+   procedure Set_Static_Size (E : Entity_Id; Model_Size : Natural);
+   procedure Set_Computed_Size (E : Entity_Id; Size_Expr : Irep);
+   function Has_Static_Size (E : Entity_Id) return Boolean;
+   function Has_Size (E : Entity_Id) return Boolean;
+   function Static_Size (E : Entity_Id) return Natural
+     with Pre => Has_Static_Size (E);
+   function Computed_Size (E : Entity_Id) return Irep
+     with Pre => Has_Size (E);
+
+   --  Model representations of entities are byte aligned.
+   function Make_Byte_Aligned_Size (S : Uint) return Uint;
+   function Make_Byte_Aligned_Size (S : Integer) return Integer;
+
 end ASVAT.Size_Model;

--- a/gnat2goto/driver/asvat.ads
+++ b/gnat2goto/driver/asvat.ads
@@ -3,16 +3,21 @@ with Ada.Containers;            use Ada.Containers;
 with GNATCOLL.Symbols;
 with Symbol_Table_Info;         use Symbol_Table_Info;
 with Uintp;                     use Uintp;
+with Ireps;                     use Ireps;
 package ASVAT is
 private
    type Entity_Info is record
       Specified_Rep_Size           : Uint;
       Specified_Rep_Component_Size : Uint;
+      Model_Size                   : Natural;
+      Computed_Model_Size          : Irep;
    end record;
 
    Empty_Entity_Info : constant Entity_Info :=
      (Specified_Rep_Size           => Uint_0,
-      Specified_Rep_Component_Size => Uint_0);
+      Specified_Rep_Component_Size => Uint_0,
+      Model_Size                   => 0,
+      Computed_Model_Size          => Ireps.Empty);
 
    use type GNATCOLL.Symbols.Symbol;  --  for "=" operator
 

--- a/gnat2goto/driver/goto_utils.ads
+++ b/gnat2goto/driver/goto_utils.ads
@@ -18,7 +18,6 @@ package GOTO_Utils is
    function CProver_True return Irep;
    function CProver_False return Irep;
 
-   --  TODO change this to Irep
    function Internal_Source_Location return Irep;
 
    function Float32_T return Irep;
@@ -34,7 +33,9 @@ package GOTO_Utils is
 
    Pointer_Type_Width : constant Positive := 64;
    Size_T_Width : constant Int := 64;
-   --  ??? this should be queried at runtime from GNAT
+   --  The width of CProver_Bool_T has been obtained from the
+   --  cprover source code cbmc/src/util/config.cpp
+   CProver_Bool_Width : constant Positive := 8;
 
    Synthetic_Variable_Counter : Positive := 1;
 

--- a/testsuite/gnat2goto/tests/iss_131_implicit_packing/iss_131.adb
+++ b/testsuite/gnat2goto/tests/iss_131_implicit_packing/iss_131.adb
@@ -247,7 +247,10 @@ begin
    pragma Assert (VSIS'size = 16);
    pragma Assert (neigh_array'size = 4);
    pragma Assert (Vna'size = 8);
+   --  The following assertion fails because the ASVAT model size (= 8) is used
    pragma Assert (Vna (barbara)'size = 1);
+   --  This is the ASVAT model size.
+   pragma Assert (Vna (barbara)'size = 8);
    --  The following 2 assertions fail with this configuration.
    --  The Slice'Size gives the unpacked result of 16.
    --  The Slice'Component_Size gives the upacked result of 8.
@@ -331,7 +334,10 @@ begin
 
    pragma Assert (A_T'Size = 8);
    pragma Assert (VA'Size = 8);
+   --  The following assertion fails because the ASVAT model size (= 8) is used
    pragma Assert (VA (1)'Size = 2);
+   --  This is the ASVAT model size.
+   pragma Assert (VA (1)'Size = 8);
    pragma Assert (VA (0 .. 2)'Size = 8);
 
    --  Component_Size does not seem to be handled properly by the front-end

--- a/testsuite/gnat2goto/tests/iss_131_implicit_packing/test.out
+++ b/testsuite/gnat2goto/tests/iss_131_implicit_packing/test.out
@@ -1,108 +1,108 @@
 Standard_Output from gnat2goto iss_131:
 ----------At: Do_Attribute_Size----------
 ----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
-N_Identifier "r4" (Node_Id=3663) (source)
- Parent = N_Attribute_Reference (Node_Id=6711)
- Sloc = 17482  iss_131.adb:278:19
+N_Identifier "r4" (Node_Id=3673) (source)
+ Parent = N_Attribute_Reference (Node_Id=6741)
+ Sloc = 17642  iss_131.adb:281:19
  Chars = "r4" (Name_Id=300001470)
  Etype = N_Defining_Identifier "r4" (Entity_Id=2613)
  Entity = N_Defining_Identifier "r4" (Entity_Id=2613)
  Associated_Node = N_Defining_Identifier "r4" (Entity_Id=2613)
 ----------At: Do_Attribute_Size----------
 ----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
-N_Identifier "r5" (Node_Id=3672) (source)
- Parent = N_Attribute_Reference (Node_Id=6721)
- Sloc = 17515  iss_131.adb:279:19
+N_Identifier "r5" (Node_Id=3682) (source)
+ Parent = N_Attribute_Reference (Node_Id=6751)
+ Sloc = 17675  iss_131.adb:282:19
  Chars = "r5" (Name_Id=300001471)
  Etype = N_Defining_Identifier "r5" (Entity_Id=2645)
  Entity = N_Defining_Identifier "r5" (Entity_Id=2645)
  Associated_Node = N_Defining_Identifier "r5" (Entity_Id=2645)
 ----------At: Do_Attribute_Size----------
 ----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
-N_Identifier "r6" (Node_Id=3681) (source)
- Parent = N_Attribute_Reference (Node_Id=6731)
- Sloc = 17549  iss_131.adb:280:19
+N_Identifier "r6" (Node_Id=3691) (source)
+ Parent = N_Attribute_Reference (Node_Id=6761)
+ Sloc = 17709  iss_131.adb:283:19
  Chars = "r6" (Name_Id=300001472)
  Etype = N_Defining_Identifier "r6" (Entity_Id=2697)
  Entity = N_Defining_Identifier "r6" (Entity_Id=2697)
  Associated_Node = N_Defining_Identifier "r6" (Entity_Id=2697)
 ----------At: Do_Attribute_Size----------
 ----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
-N_Identifier "rns" (Node_Id=3717) (source)
- Parent = N_Attribute_Reference (Node_Id=6771)
- Sloc = 17869  iss_131.adb:289:19
+N_Identifier "rns" (Node_Id=3727) (source)
+ Parent = N_Attribute_Reference (Node_Id=6801)
+ Sloc = 18029  iss_131.adb:292:19
  Chars = "rns" (Name_Id=300001478)
  Etype = N_Defining_Identifier "rns" (Entity_Id=2907)
  Entity = N_Defining_Identifier "rns" (Entity_Id=2907)
  Associated_Node = N_Defining_Identifier "rns" (Entity_Id=2907)
 ----------At: Do_Attribute_Size----------
 ----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
-N_Identifier "vrns" (Node_Id=3726) (source,analyzed)
- Parent = N_Attribute_Reference (Node_Id=6781)
- Sloc = 17903  iss_131.adb:290:19
+N_Identifier "vrns" (Node_Id=3736) (source,analyzed)
+ Parent = N_Attribute_Reference (Node_Id=6811)
+ Sloc = 18063  iss_131.adb:293:19
  Chars = "vrns" (Name_Id=300001479)
  Etype = N_Defining_Identifier "rns" (Entity_Id=2907)
  Entity = N_Defining_Identifier "vrns" (Entity_Id=3009)
  Associated_Node = N_Defining_Identifier "vrns" (Entity_Id=3009)
 ----------At: Do_Attribute_Size----------
 ----------Size attribute applied to indefinite type is implementation defined----------
-N_Identifier "v1" (Node_Id=3735) (source)
- Parent = N_Attribute_Reference (Node_Id=6791)
- Sloc = 18239  iss_131.adb:297:19
+N_Identifier "v1" (Node_Id=3745) (source)
+ Parent = N_Attribute_Reference (Node_Id=6821)
+ Sloc = 18399  iss_131.adb:300:19
  Chars = "v1" (Name_Id=300001480)
  Etype = N_Defining_Identifier "v1" (Entity_Id=3024)
  Entity = N_Defining_Identifier "v1" (Entity_Id=3024)
  Associated_Node = N_Defining_Identifier "v1" (Entity_Id=3024)
 ----------At: Do_Attribute_Size----------
 ----------Size attribute applied to indefinite type is implementation defined----------
-N_Identifier "v3" (Node_Id=3789) (source)
- Parent = N_Attribute_Reference (Node_Id=6851)
- Sloc = 18782  iss_131.adb:311:19
+N_Identifier "v3" (Node_Id=3799) (source)
+ Parent = N_Attribute_Reference (Node_Id=6881)
+ Sloc = 18942  iss_131.adb:314:19
  Chars = "v3" (Name_Id=300001486)
  Etype = N_Defining_Identifier "v3" (Entity_Id=3185)
  Entity = N_Defining_Identifier "v3" (Entity_Id=3185)
  Associated_Node = N_Defining_Identifier "v3" (Entity_Id=3185)
 ----------At: Do_Attribute_Size----------
 ----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
-N_Identifier "v4" (Node_Id=3798) (source)
- Parent = N_Attribute_Reference (Node_Id=6861)
- Sloc = 18996  iss_131.adb:316:19
+N_Identifier "v4" (Node_Id=3808) (source)
+ Parent = N_Attribute_Reference (Node_Id=6891)
+ Sloc = 19156  iss_131.adb:319:19
  Chars = "v4" (Name_Id=300001495)
  Etype = N_Defining_Identifier "v4" (Entity_Id=3345)
  Entity = N_Defining_Identifier "v4" (Entity_Id=3345)
  Associated_Node = N_Defining_Identifier "v4" (Entity_Id=3345)
 ----------At: Do_Attribute_Size----------
 ----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
-N_Identifier "stv3_no_size_rep" (Node_Id=3843) (source)
- Parent = N_Attribute_Reference (Node_Id=6911)
- Sloc = 19351  iss_131.adb:326:19
+N_Identifier "stv3_no_size_rep" (Node_Id=3853) (source)
+ Parent = N_Attribute_Reference (Node_Id=6941)
+ Sloc = 19511  iss_131.adb:329:19
  Chars = "stv3_no_size_rep" (Name_Id=300001489)
  Etype = N_Defining_Identifier "stv3_no_size_rep" (Entity_Id=3262)
  Entity = N_Defining_Identifier "stv3_no_size_rep" (Entity_Id=3262)
  Associated_Node = N_Defining_Identifier "stv3_no_size_rep" (Entity_Id=3262)
 ----------At: Do_Attribute_Size----------
 ----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
-N_Identifier "sfv3_no_size_rep" (Node_Id=3852) (source)
- Parent = N_Attribute_Reference (Node_Id=6921)
- Sloc = 19398  iss_131.adb:327:19
+N_Identifier "sfv3_no_size_rep" (Node_Id=3862) (source)
+ Parent = N_Attribute_Reference (Node_Id=6951)
+ Sloc = 19558  iss_131.adb:330:19
  Chars = "sfv3_no_size_rep" (Name_Id=300001490)
  Etype = N_Defining_Identifier "sfv3_no_size_rep" (Entity_Id=3274)
  Entity = N_Defining_Identifier "sfv3_no_size_rep" (Entity_Id=3274)
  Associated_Node = N_Defining_Identifier "sfv3_no_size_rep" (Entity_Id=3274)
 ----------At: Do_Attribute_Size----------
-----------The size of the composite subtype is not known by the front-end. Use a size representation clause on the base type or a Value_Size clause on the subtype declaration----------
-N_Identifier "vst3_ns" (Node_Id=3861) (source,analyzed)
- Parent = N_Attribute_Reference (Node_Id=6931)
- Sloc = 19444  iss_131.adb:328:19
+----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
+N_Identifier "vst3_ns" (Node_Id=3871) (source,analyzed)
+ Parent = N_Attribute_Reference (Node_Id=6961)
+ Sloc = 19604  iss_131.adb:331:19
  Chars = "vst3_ns" (Name_Id=300001493)
  Etype = N_Defining_Identifier "stv3_no_size_rep" (Entity_Id=3262)
  Entity = N_Defining_Identifier "vst3_ns" (Entity_Id=3315)
  Associated_Node = N_Defining_Identifier "vst3_ns" (Entity_Id=3315)
 ----------At: Do_Attribute_Size----------
-----------The size of the composite subtype is not known by the front-end. Use a size representation clause on the base type or a Value_Size clause on the subtype declaration----------
-N_Identifier "vsf3_ns" (Node_Id=3870) (source,analyzed)
- Parent = N_Attribute_Reference (Node_Id=6941)
- Sloc = 19482  iss_131.adb:329:19
+----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
+N_Identifier "vsf3_ns" (Node_Id=3880) (source,analyzed)
+ Parent = N_Attribute_Reference (Node_Id=6971)
+ Sloc = 19642  iss_131.adb:332:19
  Chars = "vsf3_ns" (Name_Id=300001494)
  Etype = N_Defining_Identifier "sfv3_no_size_rep" (Entity_Id=3274)
  Entity = N_Defining_Identifier "vsf3_ns" (Entity_Id=3330)
@@ -125,53 +125,55 @@ N_Identifier "vsf3_ns" (Node_Id=3870) (source,analyzed)
 [iss_131.assertion.6] line 247 assertion VSIS'size = 16: SUCCESS
 [iss_131.assertion.7] line 248 assertion neigh_array'size = 4: SUCCESS
 [iss_131.assertion.8] line 249 assertion Vna'size = 8: SUCCESS
-[iss_131.assertion.9] line 250 assertion Vna (barbara)'size = 1: SUCCESS
-[iss_131.assertion.10] line 256 assertion Vna (barbara .. margo)'Size = 8: FAILURE
-[iss_131.assertion.11] line 257 assertion Vna (barbara .. margo)'Component_Size = 1: FAILURE
-[iss_131.assertion.12] line 259 assertion neigh_array_NS'size = 32: SUCCESS
-[iss_131.assertion.13] line 260 assertion VnaNS'size = 32: SUCCESS
-[iss_131.assertion.14] line 261 assertion VnaNS (barbara)'Size = 8: SUCCESS
-[iss_131.assertion.15] line 262 assertion VnaNS (barbara .. margo)'Size = 16: SUCCESS
-[iss_131.assertion.16] line 263 assertion VnaNS (barbara .. margo)'Component_Size = 8: SUCCESS
-[iss_131.assertion.17] line 266 assertion R1'Size = 64: SUCCESS
-[iss_131.assertion.18] line 267 assertion R2'Size = 132: SUCCESS
-[iss_131.assertion.19] line 268 assertion R3'Size = 66: SUCCESS
-[iss_131.assertion.20] line 269 assertion VR1'Size = 64: SUCCESS
-[iss_131.assertion.21] line 270 assertion VR2'Size = 136: SUCCESS
-[iss_131.assertion.22] line 271 assertion VR3'Size = 72: SUCCESS
-[iss_131.assertion.23] line 272 assertion r'Size = 16: SUCCESS
-[iss_131.assertion.24] line 273 assertion Vr'Size = 16: SUCCESS
-[iss_131.assertion.25] line 278 assertion R4'Size = 64: FAILURE
-[iss_131.assertion.26] line 279 assertion R5'Size = 132: FAILURE
-[iss_131.assertion.27] line 280 assertion R6'Size = 80: FAILURE
-[iss_131.assertion.28] line 282 assertion VR4'Size = 64: SUCCESS
-[iss_131.assertion.29] line 283 assertion VR5'Size = 136: SUCCESS
-[iss_131.assertion.30] line 284 assertion VR6'Size = 72: SUCCESS
-[iss_131.assertion.31] line 289 assertion rNS'Size = 72: FAILURE
-[iss_131.assertion.32] line 290 assertion VrNS'Size = 72: FAILURE
-[iss_131.assertion.33] line 297 assertion V1'Size = 40: FAILURE
-[iss_131.assertion.34] line 299 assertion V2'Size = 39: SUCCESS
-[iss_131.assertion.35] line 300 assertion STV1'Size = 40: SUCCESS
-[iss_131.assertion.36] line 301 assertion SFV1'Size = 1: SUCCESS
-[iss_131.assertion.37] line 302 assertion VST'Size = 40: SUCCESS
-[iss_131.assertion.38] line 303 assertion VSF'Size = 8: SUCCESS
-[iss_131.assertion.39] line 311 assertion V3'Size = 64: FAILURE
-[iss_131.assertion.40] line 316 assertion V4'Size = 64: FAILURE
-[iss_131.assertion.41] line 318 assertion STV3'Size = 64: SUCCESS
-[iss_131.assertion.42] line 319 assertion SFV3'Size = 8: SUCCESS
-[iss_131.assertion.43] line 320 assertion VST3'Size = 64: SUCCESS
-[iss_131.assertion.44] line 321 assertion VSF3'Size = 8: SUCCESS
-[iss_131.assertion.45] line 326 assertion STV3_No_Size_Rep'Size = 64: FAILURE
-[iss_131.assertion.46] line 327 assertion SFV3_No_Size_Rep'Size = 8: FAILURE
-[iss_131.assertion.47] line 328 assertion VST3_NS'Size = 64: FAILURE
-[iss_131.assertion.48] line 329 assertion VSF3_NS'Size = 32: FAILURE
-[iss_131.assertion.49] line 332 assertion A_T'Size = 8: SUCCESS
-[iss_131.assertion.50] line 333 assertion VA'Size = 8: SUCCESS
-[iss_131.assertion.51] line 334 assertion VA (1)'Size = 2: SUCCESS
-[iss_131.assertion.52] line 335 assertion VA (0 .. 2)'Size = 8: SUCCESS
-[iss_131.assertion.53] line 339 assertion Vna'Component_size = 1: FAILURE
-[iss_131.assertion.54] line 340 assertion neigh_array'component_size = 1: FAILURE
-[iss_131.assertion.55] line 352 assertion Vna'Component_size = 8: SUCCESS
-[iss_131.assertion.56] line 353 assertion neigh_array'component_size = 8: SUCCESS
-[iss_131.assertion.57] line 357 assertion Vna (barbara .. margo)'Size = 16: SUCCESS
+[iss_131.assertion.9] line 251 assertion Vna (barbara)'size = 1: FAILURE
+[iss_131.assertion.10] line 253 assertion Vna (barbara)'size = 8: SUCCESS
+[iss_131.assertion.11] line 259 assertion Vna (barbara .. margo)'Size = 8: FAILURE
+[iss_131.assertion.12] line 260 assertion Vna (barbara .. margo)'Component_Size = 1: FAILURE
+[iss_131.assertion.13] line 262 assertion neigh_array_NS'size = 32: SUCCESS
+[iss_131.assertion.14] line 263 assertion VnaNS'size = 32: SUCCESS
+[iss_131.assertion.15] line 264 assertion VnaNS (barbara)'Size = 8: SUCCESS
+[iss_131.assertion.16] line 265 assertion VnaNS (barbara .. margo)'Size = 16: SUCCESS
+[iss_131.assertion.17] line 266 assertion VnaNS (barbara .. margo)'Component_Size = 8: SUCCESS
+[iss_131.assertion.18] line 269 assertion R1'Size = 64: SUCCESS
+[iss_131.assertion.19] line 270 assertion R2'Size = 132: SUCCESS
+[iss_131.assertion.20] line 271 assertion R3'Size = 66: SUCCESS
+[iss_131.assertion.21] line 272 assertion VR1'Size = 64: SUCCESS
+[iss_131.assertion.22] line 273 assertion VR2'Size = 136: SUCCESS
+[iss_131.assertion.23] line 274 assertion VR3'Size = 72: SUCCESS
+[iss_131.assertion.24] line 275 assertion r'Size = 16: SUCCESS
+[iss_131.assertion.25] line 276 assertion Vr'Size = 16: SUCCESS
+[iss_131.assertion.26] line 281 assertion R4'Size = 64: FAILURE
+[iss_131.assertion.27] line 282 assertion R5'Size = 132: FAILURE
+[iss_131.assertion.28] line 283 assertion R6'Size = 80: FAILURE
+[iss_131.assertion.29] line 285 assertion VR4'Size = 64: SUCCESS
+[iss_131.assertion.30] line 286 assertion VR5'Size = 136: SUCCESS
+[iss_131.assertion.31] line 287 assertion VR6'Size = 72: SUCCESS
+[iss_131.assertion.32] line 292 assertion rNS'Size = 72: FAILURE
+[iss_131.assertion.33] line 293 assertion VrNS'Size = 72: FAILURE
+[iss_131.assertion.34] line 300 assertion V1'Size = 40: FAILURE
+[iss_131.assertion.35] line 302 assertion V2'Size = 39: SUCCESS
+[iss_131.assertion.36] line 303 assertion STV1'Size = 40: SUCCESS
+[iss_131.assertion.37] line 304 assertion SFV1'Size = 1: SUCCESS
+[iss_131.assertion.38] line 305 assertion VST'Size = 40: SUCCESS
+[iss_131.assertion.39] line 306 assertion VSF'Size = 8: SUCCESS
+[iss_131.assertion.40] line 314 assertion V3'Size = 64: FAILURE
+[iss_131.assertion.41] line 319 assertion V4'Size = 64: FAILURE
+[iss_131.assertion.42] line 321 assertion STV3'Size = 64: SUCCESS
+[iss_131.assertion.43] line 322 assertion SFV3'Size = 8: SUCCESS
+[iss_131.assertion.44] line 323 assertion VST3'Size = 64: SUCCESS
+[iss_131.assertion.45] line 324 assertion VSF3'Size = 8: SUCCESS
+[iss_131.assertion.46] line 329 assertion STV3_No_Size_Rep'Size = 64: FAILURE
+[iss_131.assertion.47] line 330 assertion SFV3_No_Size_Rep'Size = 8: FAILURE
+[iss_131.assertion.48] line 331 assertion VST3_NS'Size = 64: FAILURE
+[iss_131.assertion.49] line 332 assertion VSF3_NS'Size = 32: FAILURE
+[iss_131.assertion.50] line 335 assertion A_T'Size = 8: SUCCESS
+[iss_131.assertion.51] line 336 assertion VA'Size = 8: SUCCESS
+[iss_131.assertion.52] line 338 assertion VA (1)'Size = 2: FAILURE
+[iss_131.assertion.53] line 340 assertion VA (1)'Size = 8: SUCCESS
+[iss_131.assertion.54] line 341 assertion VA (0 .. 2)'Size = 8: SUCCESS
+[iss_131.assertion.55] line 345 assertion Vna'Component_size = 1: FAILURE
+[iss_131.assertion.56] line 346 assertion neigh_array'component_size = 1: FAILURE
+[iss_131.assertion.57] line 358 assertion Vna'Component_size = 8: SUCCESS
+[iss_131.assertion.58] line 359 assertion neigh_array'component_size = 8: SUCCESS
+[iss_131.assertion.59] line 363 assertion Vna (barbara .. margo)'Size = 16: SUCCESS
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/iss_131_rational/test.out
+++ b/testsuite/gnat2goto/tests/iss_131_rational/test.out
@@ -80,7 +80,7 @@ N_Identifier "v4" (Node_Id=3756) (source)
  Entity = N_Defining_Identifier "v4" (Entity_Id=3347)
  Associated_Node = N_Defining_Identifier "v4" (Entity_Id=3347)
 ----------At: Do_Attribute_Size----------
-----------The size of the composite subtype is not known by the front-end. Use a size representation clause on the base type or a Value_Size clause on the subtype declaration----------
+----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
 N_Identifier "stv3_no_size_rep" (Node_Id=3801) (source)
  Parent = N_Attribute_Reference (Node_Id=4646)
  Sloc = 18746  iss_131.adb:310:19
@@ -89,7 +89,7 @@ N_Identifier "stv3_no_size_rep" (Node_Id=3801) (source)
  Entity = N_Defining_Identifier "stv3_no_size_rep" (Entity_Id=3264)
  Associated_Node = N_Defining_Identifier "stv3_no_size_rep" (Entity_Id=3264)
 ----------At: Do_Attribute_Size----------
-----------The size of the composite subtype is not known by the front-end. Use a size representation clause on the base type or a Value_Size clause on the subtype declaration----------
+----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
 N_Identifier "sfv3_no_size_rep" (Node_Id=3810) (source)
  Parent = N_Attribute_Reference (Node_Id=4656)
  Sloc = 18793  iss_131.adb:311:19
@@ -98,7 +98,7 @@ N_Identifier "sfv3_no_size_rep" (Node_Id=3810) (source)
  Entity = N_Defining_Identifier "sfv3_no_size_rep" (Entity_Id=3276)
  Associated_Node = N_Defining_Identifier "sfv3_no_size_rep" (Entity_Id=3276)
 ----------At: Do_Attribute_Size----------
-----------The size of the composite subtype is not known by the front-end. Use a size representation clause on the base type or a Value_Size clause on the subtype declaration----------
+----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
 N_Identifier "vst3_ns" (Node_Id=3819) (source,analyzed)
  Parent = N_Attribute_Reference (Node_Id=4666)
  Sloc = 18839  iss_131.adb:312:19
@@ -107,7 +107,7 @@ N_Identifier "vst3_ns" (Node_Id=3819) (source,analyzed)
  Entity = N_Defining_Identifier "vst3_ns" (Entity_Id=3317)
  Associated_Node = N_Defining_Identifier "vst3_ns" (Entity_Id=3317)
 ----------At: Do_Attribute_Size----------
-----------The size of the composite subtype is not known by the front-end. Use a size representation clause on the base type or a Value_Size clause on the subtype declaration----------
+----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
 N_Identifier "vsf3_ns" (Node_Id=3828) (source,analyzed)
  Parent = N_Attribute_Reference (Node_Id=4676)
  Sloc = 18877  iss_131.adb:313:19

--- a/testsuite/gnat2goto/tests/iss_131_use_VADS/test.out
+++ b/testsuite/gnat2goto/tests/iss_131_use_VADS/test.out
@@ -80,7 +80,7 @@ N_Identifier "v4" (Node_Id=3801) (source)
  Entity = N_Defining_Identifier "v4" (Entity_Id=3357)
  Associated_Node = N_Defining_Identifier "v4" (Entity_Id=3357)
 ----------At: Do_Attribute_Size----------
-----------The size of the composite subtype is not known by the front-end. Use a size representation clause on the base type or a Value_Size clause on the subtype declaration----------
+----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
 N_Identifier "stv3_no_size_rep" (Node_Id=3846) (source)
  Parent = N_Attribute_Reference (Node_Id=6962)
  Sloc = 19399  iss_131.adb:327:19
@@ -89,7 +89,7 @@ N_Identifier "stv3_no_size_rep" (Node_Id=3846) (source)
  Entity = N_Defining_Identifier "stv3_no_size_rep" (Entity_Id=3274)
  Associated_Node = N_Defining_Identifier "stv3_no_size_rep" (Entity_Id=3274)
 ----------At: Do_Attribute_Size----------
-----------The size of the composite subtype is not known by the front-end. Use a size representation clause on the base type or a Value_Size clause on the subtype declaration----------
+----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
 N_Identifier "sfv3_no_size_rep" (Node_Id=3855) (source)
  Parent = N_Attribute_Reference (Node_Id=6972)
  Sloc = 19446  iss_131.adb:328:19
@@ -98,7 +98,7 @@ N_Identifier "sfv3_no_size_rep" (Node_Id=3855) (source)
  Entity = N_Defining_Identifier "sfv3_no_size_rep" (Entity_Id=3286)
  Associated_Node = N_Defining_Identifier "sfv3_no_size_rep" (Entity_Id=3286)
 ----------At: Do_Attribute_Size----------
-----------The size of the composite subtype is not known by the front-end. Use a size representation clause on the base type or a Value_Size clause on the subtype declaration----------
+----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
 N_Identifier "vst3_ns" (Node_Id=3864) (source,analyzed)
  Parent = N_Attribute_Reference (Node_Id=6982)
  Sloc = 19492  iss_131.adb:329:19
@@ -107,7 +107,7 @@ N_Identifier "vst3_ns" (Node_Id=3864) (source,analyzed)
  Entity = N_Defining_Identifier "vst3_ns" (Entity_Id=3327)
  Associated_Node = N_Defining_Identifier "vst3_ns" (Entity_Id=3327)
 ----------At: Do_Attribute_Size----------
-----------The size of the composite subtype is not known by the front-end. Use a size representation clause on the base type or a Value_Size clause on the subtype declaration----------
+----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
 N_Identifier "vsf3_ns" (Node_Id=3873) (source,analyzed)
  Parent = N_Attribute_Reference (Node_Id=6992)
  Sloc = 19530  iss_131.adb:330:19

--- a/testsuite/gnat2goto/tests/iss_131_vanilla/iss_131.adb
+++ b/testsuite/gnat2goto/tests/iss_131_vanilla/iss_131.adb
@@ -248,7 +248,10 @@ begin
    pragma Assert (VSIS'size = 16);
    pragma Assert (neigh_array'size = 4);
    pragma Assert (Vna'size = 8);
+   --  The following assertion fails because the ASVAT model size (= 8) is used
    pragma Assert (Vna (barbara)'size = 1);
+   --  This is the ASVAT model size.
+   pragma Assert (Vna (barbara)'size = 8);
    pragma Assert (Vna (barbara .. margo)'Size = 8);
    pragma Assert (Vna (barbara .. margo)'Component_Size = 1);
    pragma Assert (neigh_array_NS'size = 32);
@@ -333,7 +336,10 @@ begin
 
    pragma Assert (A_T'Size = 8);
    pragma Assert (VA'Size = 8);
+   --  The following assertion fails because the ASVAT model size (= 8) is used
    pragma Assert (VA (1)'Size = 2);
+   --  This is the ASVAT model size.
+   pragma Assert (VA (1)'Size = 8);
    pragma Assert (VA (0 .. 2)'Size = 8);
 
    pragma Assert (Vna'Component_size = 1);

--- a/testsuite/gnat2goto/tests/iss_131_vanilla/test.out
+++ b/testsuite/gnat2goto/tests/iss_131_vanilla/test.out
@@ -1,108 +1,108 @@
 Standard_Output from gnat2goto iss_131:
 ----------At: Do_Attribute_Size----------
 ----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
-N_Identifier "r4" (Node_Id=3664) (source)
- Parent = N_Attribute_Reference (Node_Id=6769)
- Sloc = 17175  iss_131.adb:273:19
+N_Identifier "r4" (Node_Id=3674) (source)
+ Parent = N_Attribute_Reference (Node_Id=6799)
+ Sloc = 17335  iss_131.adb:276:19
  Chars = "r4" (Name_Id=300001470)
  Etype = N_Defining_Identifier "r4" (Entity_Id=2619)
  Entity = N_Defining_Identifier "r4" (Entity_Id=2619)
  Associated_Node = N_Defining_Identifier "r4" (Entity_Id=2619)
 ----------At: Do_Attribute_Size----------
 ----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
-N_Identifier "r5" (Node_Id=3673) (source)
- Parent = N_Attribute_Reference (Node_Id=6779)
- Sloc = 17208  iss_131.adb:274:19
+N_Identifier "r5" (Node_Id=3683) (source)
+ Parent = N_Attribute_Reference (Node_Id=6809)
+ Sloc = 17368  iss_131.adb:277:19
  Chars = "r5" (Name_Id=300001471)
  Etype = N_Defining_Identifier "r5" (Entity_Id=2651)
  Entity = N_Defining_Identifier "r5" (Entity_Id=2651)
  Associated_Node = N_Defining_Identifier "r5" (Entity_Id=2651)
 ----------At: Do_Attribute_Size----------
 ----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
-N_Identifier "r6" (Node_Id=3682) (source)
- Parent = N_Attribute_Reference (Node_Id=6789)
- Sloc = 17242  iss_131.adb:275:19
+N_Identifier "r6" (Node_Id=3692) (source)
+ Parent = N_Attribute_Reference (Node_Id=6819)
+ Sloc = 17402  iss_131.adb:278:19
  Chars = "r6" (Name_Id=300001472)
  Etype = N_Defining_Identifier "r6" (Entity_Id=2703)
  Entity = N_Defining_Identifier "r6" (Entity_Id=2703)
  Associated_Node = N_Defining_Identifier "r6" (Entity_Id=2703)
 ----------At: Do_Attribute_Size----------
 ----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
-N_Identifier "rns" (Node_Id=3718) (source)
- Parent = N_Attribute_Reference (Node_Id=6829)
- Sloc = 17562  iss_131.adb:284:19
+N_Identifier "rns" (Node_Id=3728) (source)
+ Parent = N_Attribute_Reference (Node_Id=6859)
+ Sloc = 17722  iss_131.adb:287:19
  Chars = "rns" (Name_Id=300001478)
  Etype = N_Defining_Identifier "rns" (Entity_Id=2917)
  Entity = N_Defining_Identifier "rns" (Entity_Id=2917)
  Associated_Node = N_Defining_Identifier "rns" (Entity_Id=2917)
 ----------At: Do_Attribute_Size----------
 ----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
-N_Identifier "vrns" (Node_Id=3727) (source,analyzed)
- Parent = N_Attribute_Reference (Node_Id=6839)
- Sloc = 17596  iss_131.adb:285:19
+N_Identifier "vrns" (Node_Id=3737) (source,analyzed)
+ Parent = N_Attribute_Reference (Node_Id=6869)
+ Sloc = 17756  iss_131.adb:288:19
  Chars = "vrns" (Name_Id=300001479)
  Etype = N_Defining_Identifier "rns" (Entity_Id=2917)
  Entity = N_Defining_Identifier "vrns" (Entity_Id=3019)
  Associated_Node = N_Defining_Identifier "vrns" (Entity_Id=3019)
 ----------At: Do_Attribute_Size----------
 ----------Size attribute applied to indefinite type is implementation defined----------
-N_Identifier "v1" (Node_Id=3736) (source)
- Parent = N_Attribute_Reference (Node_Id=6849)
- Sloc = 17932  iss_131.adb:292:19
+N_Identifier "v1" (Node_Id=3746) (source)
+ Parent = N_Attribute_Reference (Node_Id=6879)
+ Sloc = 18092  iss_131.adb:295:19
  Chars = "v1" (Name_Id=300001480)
  Etype = N_Defining_Identifier "v1" (Entity_Id=3034)
  Entity = N_Defining_Identifier "v1" (Entity_Id=3034)
  Associated_Node = N_Defining_Identifier "v1" (Entity_Id=3034)
 ----------At: Do_Attribute_Size----------
 ----------Size attribute applied to indefinite type is implementation defined----------
-N_Identifier "v3" (Node_Id=3790) (source)
- Parent = N_Attribute_Reference (Node_Id=6909)
- Sloc = 18475  iss_131.adb:306:19
+N_Identifier "v3" (Node_Id=3800) (source)
+ Parent = N_Attribute_Reference (Node_Id=6939)
+ Sloc = 18635  iss_131.adb:309:19
  Chars = "v3" (Name_Id=300001486)
  Etype = N_Defining_Identifier "v3" (Entity_Id=3195)
  Entity = N_Defining_Identifier "v3" (Entity_Id=3195)
  Associated_Node = N_Defining_Identifier "v3" (Entity_Id=3195)
 ----------At: Do_Attribute_Size----------
 ----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
-N_Identifier "v4" (Node_Id=3799) (source)
- Parent = N_Attribute_Reference (Node_Id=6919)
- Sloc = 18689  iss_131.adb:311:19
+N_Identifier "v4" (Node_Id=3809) (source)
+ Parent = N_Attribute_Reference (Node_Id=6949)
+ Sloc = 18849  iss_131.adb:314:19
  Chars = "v4" (Name_Id=300001495)
  Etype = N_Defining_Identifier "v4" (Entity_Id=3355)
  Entity = N_Defining_Identifier "v4" (Entity_Id=3355)
  Associated_Node = N_Defining_Identifier "v4" (Entity_Id=3355)
 ----------At: Do_Attribute_Size----------
 ----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
-N_Identifier "stv3_no_size_rep" (Node_Id=3853) (source)
- Parent = N_Attribute_Reference (Node_Id=6979)
- Sloc = 19343  iss_131.adb:328:19
+N_Identifier "stv3_no_size_rep" (Node_Id=3863) (source)
+ Parent = N_Attribute_Reference (Node_Id=7009)
+ Sloc = 19503  iss_131.adb:331:19
  Chars = "stv3_no_size_rep" (Name_Id=300001489)
  Etype = N_Defining_Identifier "stv3_no_size_rep" (Entity_Id=3272)
  Entity = N_Defining_Identifier "stv3_no_size_rep" (Entity_Id=3272)
  Associated_Node = N_Defining_Identifier "stv3_no_size_rep" (Entity_Id=3272)
 ----------At: Do_Attribute_Size----------
 ----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
-N_Identifier "sfv3_no_size_rep" (Node_Id=3862) (source)
- Parent = N_Attribute_Reference (Node_Id=6989)
- Sloc = 19390  iss_131.adb:329:19
+N_Identifier "sfv3_no_size_rep" (Node_Id=3872) (source)
+ Parent = N_Attribute_Reference (Node_Id=7019)
+ Sloc = 19550  iss_131.adb:332:19
  Chars = "sfv3_no_size_rep" (Name_Id=300001490)
  Etype = N_Defining_Identifier "sfv3_no_size_rep" (Entity_Id=3284)
  Entity = N_Defining_Identifier "sfv3_no_size_rep" (Entity_Id=3284)
  Associated_Node = N_Defining_Identifier "sfv3_no_size_rep" (Entity_Id=3284)
 ----------At: Do_Attribute_Size----------
-----------The size of the composite subtype is not known by the front-end. Use a size representation clause on the base type or a Value_Size clause on the subtype declaration----------
-N_Identifier "vst3_ns" (Node_Id=3871) (source,analyzed)
- Parent = N_Attribute_Reference (Node_Id=6999)
- Sloc = 19436  iss_131.adb:330:19
+----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
+N_Identifier "vst3_ns" (Node_Id=3881) (source,analyzed)
+ Parent = N_Attribute_Reference (Node_Id=7029)
+ Sloc = 19596  iss_131.adb:333:19
  Chars = "vst3_ns" (Name_Id=300001493)
  Etype = N_Defining_Identifier "stv3_no_size_rep" (Entity_Id=3272)
  Entity = N_Defining_Identifier "vst3_ns" (Entity_Id=3325)
  Associated_Node = N_Defining_Identifier "vst3_ns" (Entity_Id=3325)
 ----------At: Do_Attribute_Size----------
-----------The size of the composite subtype is not known by the front-end. Use a size representation clause on the base type or a Value_Size clause on the subtype declaration----------
-N_Identifier "vsf3_ns" (Node_Id=3880) (source,analyzed)
- Parent = N_Attribute_Reference (Node_Id=7009)
- Sloc = 19474  iss_131.adb:331:19
+----------The size of the composite is not known by the front-end. Use a size representation clause on its declaration----------
+N_Identifier "vsf3_ns" (Node_Id=3890) (source,analyzed)
+ Parent = N_Attribute_Reference (Node_Id=7039)
+ Sloc = 19634  iss_131.adb:334:19
  Chars = "vsf3_ns" (Name_Id=300001494)
  Etype = N_Defining_Identifier "sfv3_no_size_rep" (Entity_Id=3284)
  Entity = N_Defining_Identifier "vsf3_ns" (Entity_Id=3340)
@@ -125,51 +125,53 @@ N_Identifier "vsf3_ns" (Node_Id=3880) (source,analyzed)
 [iss_131.assertion.6] line 248 assertion VSIS'size = 16: SUCCESS
 [iss_131.assertion.7] line 249 assertion neigh_array'size = 4: SUCCESS
 [iss_131.assertion.8] line 250 assertion Vna'size = 8: SUCCESS
-[iss_131.assertion.9] line 251 assertion Vna (barbara)'size = 1: SUCCESS
-[iss_131.assertion.10] line 252 assertion Vna (barbara .. margo)'Size = 8: SUCCESS
-[iss_131.assertion.11] line 253 assertion Vna (barbara .. margo)'Component_Size = 1: SUCCESS
-[iss_131.assertion.12] line 254 assertion neigh_array_NS'size = 32: SUCCESS
-[iss_131.assertion.13] line 255 assertion VnaNS'size = 32: SUCCESS
-[iss_131.assertion.14] line 256 assertion VnaNS (barbara)'Size = 8: SUCCESS
-[iss_131.assertion.15] line 257 assertion VnaNS (barbara .. margo)'Size = 16: SUCCESS
-[iss_131.assertion.16] line 258 assertion VnaNS (barbara .. margo)'Component_Size = 8: SUCCESS
-[iss_131.assertion.17] line 261 assertion R1'Size = 64: SUCCESS
-[iss_131.assertion.18] line 262 assertion R2'Size = 132: SUCCESS
-[iss_131.assertion.19] line 263 assertion R3'Size = 66: SUCCESS
-[iss_131.assertion.20] line 264 assertion VR1'Size = 64: SUCCESS
-[iss_131.assertion.21] line 265 assertion VR2'Size = 136: SUCCESS
-[iss_131.assertion.22] line 266 assertion VR3'Size = 72: SUCCESS
-[iss_131.assertion.23] line 267 assertion r'Size = 16: SUCCESS
-[iss_131.assertion.24] line 268 assertion Vr'Size = 16: SUCCESS
-[iss_131.assertion.25] line 273 assertion R4'Size = 64: FAILURE
-[iss_131.assertion.26] line 274 assertion R5'Size = 132: FAILURE
-[iss_131.assertion.27] line 275 assertion R6'Size = 80: FAILURE
-[iss_131.assertion.28] line 277 assertion VR4'Size = 64: SUCCESS
-[iss_131.assertion.29] line 278 assertion VR5'Size = 136: SUCCESS
-[iss_131.assertion.30] line 279 assertion VR6'Size = 72: SUCCESS
-[iss_131.assertion.31] line 284 assertion rNS'Size = 72: FAILURE
-[iss_131.assertion.32] line 285 assertion VrNS'Size = 72: FAILURE
-[iss_131.assertion.33] line 292 assertion V1'Size = 40: FAILURE
-[iss_131.assertion.34] line 294 assertion V2'Size = 39: SUCCESS
-[iss_131.assertion.35] line 295 assertion STV1'Size = 40: SUCCESS
-[iss_131.assertion.36] line 296 assertion SFV1'Size = 1: SUCCESS
-[iss_131.assertion.37] line 297 assertion VST'Size = 40: SUCCESS
-[iss_131.assertion.38] line 298 assertion VSF'Size = 8: SUCCESS
-[iss_131.assertion.39] line 306 assertion V3'Size = 64: FAILURE
-[iss_131.assertion.40] line 311 assertion V4'Size = 64: FAILURE
-[iss_131.assertion.41] line 313 assertion STV3'Size = 64: SUCCESS
-[iss_131.assertion.42] line 314 assertion SFV3'Size = 8: SUCCESS
-[iss_131.assertion.43] line 315 assertion VST3'Size = 64: SUCCESS
-[iss_131.assertion.44] line 321 assertion VSF3'Size = 32: FAILURE
-[iss_131.assertion.45] line 323 assertion VSF3'Size = 8: SUCCESS
-[iss_131.assertion.46] line 328 assertion STV3_No_Size_Rep'Size = 64: FAILURE
-[iss_131.assertion.47] line 329 assertion SFV3_No_Size_Rep'Size = 8: FAILURE
-[iss_131.assertion.48] line 330 assertion VST3_NS'Size = 64: FAILURE
-[iss_131.assertion.49] line 331 assertion VSF3_NS'Size = 32: FAILURE
-[iss_131.assertion.50] line 334 assertion A_T'Size = 8: SUCCESS
-[iss_131.assertion.51] line 335 assertion VA'Size = 8: SUCCESS
-[iss_131.assertion.52] line 336 assertion VA (1)'Size = 2: SUCCESS
-[iss_131.assertion.53] line 337 assertion VA (0 .. 2)'Size = 8: SUCCESS
-[iss_131.assertion.54] line 339 assertion Vna'Component_size = 1: SUCCESS
-[iss_131.assertion.55] line 340 assertion neigh_array'component_size = 1: SUCCESS
+[iss_131.assertion.9] line 252 assertion Vna (barbara)'size = 1: FAILURE
+[iss_131.assertion.10] line 254 assertion Vna (barbara)'size = 8: SUCCESS
+[iss_131.assertion.11] line 255 assertion Vna (barbara .. margo)'Size = 8: SUCCESS
+[iss_131.assertion.12] line 256 assertion Vna (barbara .. margo)'Component_Size = 1: SUCCESS
+[iss_131.assertion.13] line 257 assertion neigh_array_NS'size = 32: SUCCESS
+[iss_131.assertion.14] line 258 assertion VnaNS'size = 32: SUCCESS
+[iss_131.assertion.15] line 259 assertion VnaNS (barbara)'Size = 8: SUCCESS
+[iss_131.assertion.16] line 260 assertion VnaNS (barbara .. margo)'Size = 16: SUCCESS
+[iss_131.assertion.17] line 261 assertion VnaNS (barbara .. margo)'Component_Size = 8: SUCCESS
+[iss_131.assertion.18] line 264 assertion R1'Size = 64: SUCCESS
+[iss_131.assertion.19] line 265 assertion R2'Size = 132: SUCCESS
+[iss_131.assertion.20] line 266 assertion R3'Size = 66: SUCCESS
+[iss_131.assertion.21] line 267 assertion VR1'Size = 64: SUCCESS
+[iss_131.assertion.22] line 268 assertion VR2'Size = 136: SUCCESS
+[iss_131.assertion.23] line 269 assertion VR3'Size = 72: SUCCESS
+[iss_131.assertion.24] line 270 assertion r'Size = 16: SUCCESS
+[iss_131.assertion.25] line 271 assertion Vr'Size = 16: SUCCESS
+[iss_131.assertion.26] line 276 assertion R4'Size = 64: FAILURE
+[iss_131.assertion.27] line 277 assertion R5'Size = 132: FAILURE
+[iss_131.assertion.28] line 278 assertion R6'Size = 80: FAILURE
+[iss_131.assertion.29] line 280 assertion VR4'Size = 64: SUCCESS
+[iss_131.assertion.30] line 281 assertion VR5'Size = 136: SUCCESS
+[iss_131.assertion.31] line 282 assertion VR6'Size = 72: SUCCESS
+[iss_131.assertion.32] line 287 assertion rNS'Size = 72: FAILURE
+[iss_131.assertion.33] line 288 assertion VrNS'Size = 72: FAILURE
+[iss_131.assertion.34] line 295 assertion V1'Size = 40: FAILURE
+[iss_131.assertion.35] line 297 assertion V2'Size = 39: SUCCESS
+[iss_131.assertion.36] line 298 assertion STV1'Size = 40: SUCCESS
+[iss_131.assertion.37] line 299 assertion SFV1'Size = 1: SUCCESS
+[iss_131.assertion.38] line 300 assertion VST'Size = 40: SUCCESS
+[iss_131.assertion.39] line 301 assertion VSF'Size = 8: SUCCESS
+[iss_131.assertion.40] line 309 assertion V3'Size = 64: FAILURE
+[iss_131.assertion.41] line 314 assertion V4'Size = 64: FAILURE
+[iss_131.assertion.42] line 316 assertion STV3'Size = 64: SUCCESS
+[iss_131.assertion.43] line 317 assertion SFV3'Size = 8: SUCCESS
+[iss_131.assertion.44] line 318 assertion VST3'Size = 64: SUCCESS
+[iss_131.assertion.45] line 324 assertion VSF3'Size = 32: FAILURE
+[iss_131.assertion.46] line 326 assertion VSF3'Size = 8: SUCCESS
+[iss_131.assertion.47] line 331 assertion STV3_No_Size_Rep'Size = 64: FAILURE
+[iss_131.assertion.48] line 332 assertion SFV3_No_Size_Rep'Size = 8: FAILURE
+[iss_131.assertion.49] line 333 assertion VST3_NS'Size = 64: FAILURE
+[iss_131.assertion.50] line 334 assertion VSF3_NS'Size = 32: FAILURE
+[iss_131.assertion.51] line 337 assertion A_T'Size = 8: SUCCESS
+[iss_131.assertion.52] line 338 assertion VA'Size = 8: SUCCESS
+[iss_131.assertion.53] line 340 assertion VA (1)'Size = 2: FAILURE
+[iss_131.assertion.54] line 342 assertion VA (1)'Size = 8: SUCCESS
+[iss_131.assertion.55] line 343 assertion VA (0 .. 2)'Size = 8: SUCCESS
+[iss_131.assertion.56] line 345 assertion Vna'Component_size = 1: SUCCESS
+[iss_131.assertion.57] line 346 assertion neigh_array'component_size = 1: SUCCESS
 VERIFICATION FAILED


### PR DESCRIPTION
First stage of an implementation to record and publish (via attribute 'Size) the ASVAT model size of an object as opposed to its code size.