### PR TITLE
Issue 122

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -119,11 +119,6 @@ Error message: type not in symbol table after declaration
 Nkind: N_Full_Type_Declaration
 --
 Occurs: 1 times
-Calling function: Do_Function_Call
-Error message: function entity not defining identifier
-Nkind: N_Defining_Operator_Symbol
---
-Occurs: 1 times
 Calling function: Do_In
 Error message: gnat2goto currently only supports one mebership_choice
 Nkind: N_In

--- a/experiments/golden-results/libsparkcrypto-summary.txt
+++ b/experiments/golden-results/libsparkcrypto-summary.txt
@@ -18,20 +18,10 @@ Calling function: Process_Pragma_Declaration
 Error message: Unknown pragma: ghost
 Nkind: N_Pragma
 --
-Occurs: 82 times
-Calling function: Do_Function_Call
-Error message: function entity not defining identifier
-Nkind: N_Defining_Operator_Symbol
---
 Occurs: 68 times
 Calling function: Do_Expression
 Error message: ATTRIBUTE_UNRESTRICTED_ACCESS unsupported
 Nkind: N_Attribute_Reference
---
-Occurs: 47 times
-Calling function: Do_Procedure_Call_Statement
-Error message: sym id not in symbol table
-Nkind: N_Procedure_Call_Statement
 --
 Occurs: 26 times
 Calling function: Process_Pragma_Declaration
@@ -42,6 +32,11 @@ Occurs: 21 times
 Calling function: Do_Expression
 Error message: Quantified
 Nkind: N_Quantified_Expression
+--
+Occurs: 14 times
+Calling function: Do_Expression
+Error message: ATTRIBUTE_LOOP_ENTRY unsupported
+Nkind: N_Attribute_Reference
 --
 Occurs: 7 times
 Calling function: Do_Op_Expon
@@ -67,6 +62,11 @@ Occurs: 3 times
 Calling function: Do_Expression
 Error message: ATTRIBUTE_ASM_OUTPUT unsupported
 Nkind: N_Attribute_Reference
+--
+Occurs: 1 times
+Calling function: Do_Operator_General
+Error message: Concat unsupported
+Nkind: N_Op_Concat
 --
 Occurs: 32 times
 Redacted compiler error message:

--- a/experiments/golden-results/vct-summary.txt
+++ b/experiments/golden-results/vct-summary.txt
@@ -28,11 +28,6 @@ Calling function: Do_Expression
 Error message: ATTRIBUTE_REMAINDER unsupported
 Nkind: N_Attribute_Reference
 --
-Occurs: 3 times
-Calling function: Do_Procedure_Call_Statement
-Error message: sym id not in symbol table
-Nkind: N_Procedure_Call_Statement
---
 Occurs: 2 times
 Calling function: Do_Expression
 Error message: ATTRIBUTE_SCALING unsupported

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -1757,9 +1757,12 @@ package body Tree_Walk is
          Func_Declared : constant Boolean :=
            Global_Symbol_Table.Contains (Func_Id);
       begin
-         if Nkind (Func_Ent) /= N_Defining_Identifier then
-            return Report_Unhandled_Node_Irep (Func_Ent, "Do_Function_Call",
-                                    "function entity not defining identifier");
+         if Nkind (Func_Ent) not in N_Defining_Identifier |
+                                N_Defining_Operator_Symbol
+         then
+            return Report_Unhandled_Node_Irep
+              (Func_Ent, "Do_Function_Call",
+               "function entity not defining identifier");
          end if;
 
          if Func_Declared then

--- a/testsuite/gnat2goto/tests/subprog_renaming/my_intefaces.ads
+++ b/testsuite/gnat2goto/tests/subprog_renaming/my_intefaces.ads
@@ -1,0 +1,11 @@
+package My_Intefaces is
+   type Byte is range 0 .. 255;
+   function Shift_Left (Value : Byte; N : Natural) return Byte
+   is
+     (if N = 0 then
+         Value
+      elsif Value >= 128 then
+        (Value - 128) * 2
+      else
+         Value * 2);
+end My_Intefaces;

--- a/testsuite/gnat2goto/tests/subprog_renaming/subprog_renaming.adb
+++ b/testsuite/gnat2goto/tests/subprog_renaming/subprog_renaming.adb
@@ -1,0 +1,83 @@
+with Interfaces;  use type Interfaces.Unsigned_32;
+with My_Intefaces; use type My_Intefaces.Byte;
+procedure Subprog_Renaming is
+   --  Note: function Interfaces.Shift_Left is an Intrinsic imported function
+   --  and has no body defined in Interfaces and so will give a warning from
+   --  cbmc that it has no body.
+   FUNCTION sl (value : interfaces.unsigned_32; amount : natural)
+                RETURN interfaces.unsigned_32
+                RENAMES interfaces.shift_left;
+
+   FUNCTION Do_It (n : interfaces.unsigned_32; bits : integer)
+                         RETURN interfaces.unsigned_32 IS
+      r : interfaces.unsigned_32 := n;-- result
+   BEGIN
+      r := sl (n, bits);
+      RETURN r;
+   END Do_It;
+
+   function My_sl (Value : My_Intefaces.Byte; Amount : Natural)
+                   return My_Intefaces.Byte
+                   renames My_Intefaces.Shift_Left;
+
+   function Id (X : Integer) return Integer is (X);
+
+   function Ident  (X : Integer) return Integer;
+
+   function Ident (X : Integer) return Integer renames Id;
+
+   procedure Inc (X : in out Integer) is
+   begin
+      X := X + 1;
+   end Inc;
+
+   procedure Increment (Y : in out Integer) renames Inc;
+
+   procedure Add_1 (X : in out Integer);
+
+   procedure Add_1 (X : in out Integer) renames Inc;
+
+   procedure Add_One (W : in out Integer) renames Increment;
+
+   type Enum is (one, two, three);
+
+   function Number_One return Enum renames one;
+   
+   --  A horrible thing to do but here it is used to
+   --  check the renaming with an operator symbol.
+   function "-" (Left, Right : Integer) return Integer
+                 renames "+";
+   
+   E : Enum := Number_One;
+
+   V : Integer := 0;
+
+   U : Interfaces.Unsigned_32 := 2;
+
+   W : My_Intefaces.Byte := 2;
+
+begin
+   Increment (V);
+   pragma Assert (V = 1);
+   Add_1 (V);
+   pragma Assert (V = 2);
+   Add_One (V);
+   pragma Assert (V = 3);
+   V := Ident (V);
+   pragma Assert (V = 3);
+   U := Do_It (U, 1);
+   --  Fails because the body of renamed function Interface_Shift_Left
+   --  is an Imported intrinsic function.
+   pragma Assert (U = 4);
+   W := My_sl (W, 1);
+   pragma Assert (W = 4);
+   pragma Assert (E = one);
+   --  Not a renaming declaration but was causing an unsupported report
+   --  and was raised by Do_Function_Call that needed changing to support
+   --  subprogram renamin renaming so it has been fixed and this statement
+   --  checks that the problem has been resolved.
+   V := "+" (V, 1);
+   pragma Assert (V = 4);
+   --  Because "-" has been renamed as "+"
+   pragma Assert (V - 1 = 5);
+end Subprog_Renaming;

--- a/testsuite/gnat2goto/tests/subprog_renaming/test.out
+++ b/testsuite/gnat2goto/tests/subprog_renaming/test.out
@@ -1,0 +1,18 @@
+Standard_Error from gnat2goto subprog_renaming:
+subprog_renaming.adb:49:18: warning: "+" is being renamed as a different operator
+
+Error from cbmc subprog_renaming:
+**** WARNING: no body for function interfaces__shift_left__3
+
+[shift_left.assertion.1] line 8 Ada Check assertion: SUCCESS
+[shift_left.assertion.2] line 8 Ada Check assertion: SUCCESS
+[subprog_renaming.assertion.1] line 61 assertion V = 1: SUCCESS
+[subprog_renaming.assertion.2] line 63 assertion V = 2: SUCCESS
+[subprog_renaming.assertion.3] line 65 assertion V = 3: SUCCESS
+[subprog_renaming.assertion.4] line 67 assertion V = 3: SUCCESS
+[subprog_renaming.assertion.5] line 71 assertion U = 4: FAILURE
+[subprog_renaming.assertion.6] line 73 assertion W = 4: SUCCESS
+[subprog_renaming.assertion.7] line 74 assertion E = one: SUCCESS
+[subprog_renaming.assertion.8] line 80 assertion V = 4: SUCCESS
+[subprog_renaming.assertion.9] line 82 assertion V - 1 = 5: SUCCESS
+VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/subprog_renaming/test.py
+++ b/testsuite/gnat2goto/tests/subprog_renaming/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
The changes in this branch address the shortcomings raised in issue #122 to do with subprogram renaming.
The changes also address a related shortcoming of not accepting an operator as a function call.

The changes fix the the the problem posed by the example given in issue #122 as far as gnat2goto is concerned but, because no body is parsed for Interfaces.Shift_Left (an imported intrinsic function) cbmc raises a warning that no body is supplied for Shift_Left.

These changes also seem to produce a few extra unsupported feature reports from libsparkcrypto (the use of the attribute 'Loop_Entry and the use of the concatenation operator).  Neither of these have been or are currently supported by gnat2goto, so gnat2goto must be parsing more of the source code than before these changes.