### PR TITLE
fixes for issue #108 to update XFAIL state

### DIFF
--- a/testsuite/gnat2goto/tests/arrays/test.opt
+++ b/testsuite/gnat2goto/tests/arrays/test.opt
@@ -1,1 +1,1 @@
-ALL XFAIL CBMC fails with __new_array not found
+ALL XFAIL gnat2goto Assert_Failure failed postcondition from arrays.ads

--- a/testsuite/gnat2goto/tests/attrib_size_object/test.opt
+++ b/testsuite/gnat2goto/tests/attrib_size_object/test.opt
@@ -1,2 +1,0 @@
-ALL XFAIL gnat2goto does not handle size attribute clauses applied to an object
-

--- a/testsuite/gnat2goto/tests/attrib_size_object/test.out
+++ b/testsuite/gnat2goto/tests/attrib_size_object/test.out
@@ -1,0 +1,5 @@
+[object_size.assertion.1] line 15 assertion Small_Pos = 7: SUCCESS
+[object_size.assertion.2] line 22 assertion Small_Pos = 8: SUCCESS
+[object_size.assertion.4] line 29 Ada Check assertion: SUCCESS
+[object_size.assertion.3] line 30 assertion Uncons_SP = 32: SUCCESS
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/attrib_size_simple/test.opt
+++ b/testsuite/gnat2goto/tests/attrib_size_simple/test.opt
@@ -1,2 +1,0 @@
-ALL XFAIL cbmc fails with "reason unimplemented"
-

--- a/testsuite/gnat2goto/tests/attrib_size_simple/test.out
+++ b/testsuite/gnat2goto/tests/attrib_size_simple/test.out
@@ -1,0 +1,10 @@
+[good_size.assertion.2] line 25 assertion I = 8: SUCCESS
+[good_size.assertion.1] line 28 Ada Check assertion: FAILURE
+[good_size.assertion.3] line 29 assertion I = 8: SUCCESS
+[good_size.assertion.4] line 35 assertion J = 4: SUCCESS
+[good_size.assertion.5] line 42 assertion J = 8: SUCCESS
+[good_size.assertion.6] line 46 assertion K = 32: SUCCESS
+[good_size.assertion.7] line 49 assertion K = 32: SUCCESS
+[good_size.assertion.8] line 53 assertion R'Size = 33: SUCCESS
+[good_size.assertion.9] line 57 assertion R_Obj'Size >= R'Size: SUCCESS
+VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/do_in/test.opt
+++ b/testsuite/gnat2goto/tests/do_in/test.opt
@@ -1,1 +1,0 @@
-ALL XFAIL cbmc does not fail a range check at line 19 when E = 1

--- a/testsuite/gnat2goto/tests/do_in/test.out
+++ b/testsuite/gnat2goto/tests/do_in/test.out
@@ -1,4 +1,9 @@
-[do_in_int.assertion.1] line 14 assertion I in Small_Int: SUCCESS
-[inc.assertion.2] line 6 assertion E in Small_Int: SUCCESS
-[inc.assertion.1] line 7 Ada Check assertion: FAILURE
+[dec.assertion.1] line 16 assertion E in Small_Int: SUCCESS
+[do_in_int.assertion.1] line 29 assertion I in Small_Int: SUCCESS
+[do_in_int.assertion.2] line 35 assertion I in Small_Int: SUCCESS
+[do_in_int.assertion.3] line 40 assertion I in Small_Int: SUCCESS
+[do_in_int.assertion.4] line 44 assertion I in Small_Int: SUCCESS
+[do_in_int.assertion.5] line 47 assertion I = 3: SUCCESS
+[inc.assertion.2] line 7 assertion E in Small_Int: SUCCESS
+[inc.assertion.1] line 10 Ada Check assertion: FAILURE
 VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/loop_array_range/test.opt
+++ b/testsuite/gnat2goto/tests/loop_array_range/test.opt
@@ -1,1 +1,0 @@
-ALL XFAIL gnat2goto fails with contraint_error (loop_array_range__TTmy_arrSP1 is not is symbol table)

--- a/testsuite/gnat2goto/tests/loop_array_range/test.out
+++ b/testsuite/gnat2goto/tests/loop_array_range/test.out
@@ -1,0 +1,7 @@
+[precondition_instance.1] file <internal> memcpy src/dst overlap: SUCCESS
+[precondition_instance.2] file <internal> memcpy source region readable: SUCCESS
+[precondition_instance.3] file <internal> memcpy destination region writeable: SUCCESS
+[loop_array_range.assertion.1] line 8 Ada Check assertion: SUCCESS
+[loop_array_range.assertion.3] line 8 Ada Check assertion: SUCCESS
+[loop_array_range.assertion.2] line 11 assertion Sum=6: FAILURE
+VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/nondet_int/test.opt
+++ b/testsuite/gnat2goto/tests/nondet_int/test.opt
@@ -1,2 +1,0 @@
-ALL XFAIL cbmc fails with "unimplemented"
-

--- a/testsuite/gnat2goto/tests/nondet_int/test.out
+++ b/testsuite/gnat2goto/tests/nondet_int/test.out
@@ -1,0 +1,3 @@
+[nondet_int.assertion.1] line 15 assertion V >= My_Int'First and V <= My_Int'Last: SUCCESS
+[nondet_int.assertion.2] line 16 assertion V in My_Int: SUCCESS
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/object_declaration_statement_bounds_crashing/test.opt
+++ b/testsuite/gnat2goto/tests/object_declaration_statement_bounds_crashing/test.opt
@@ -1,1 +1,0 @@
-ALL XFAIL gnat2goto fails because bounds are non constant expressions (#326)

--- a/testsuite/gnat2goto/tests/object_declaration_statement_bounds_crashing/test.out
+++ b/testsuite/gnat2goto/tests/object_declaration_statement_bounds_crashing/test.out
@@ -1,0 +1,3 @@
+[callit.assertion.1] line 10 assertion I < 70: FAILURE
+[callit.assertion.2] line 13 assertion A < -5: FAILURE
+VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/op_concat/test.opt
+++ b/testsuite/gnat2goto/tests/op_concat/test.opt
@@ -1,1 +1,1 @@
-ALL XFAIL CBMC fails with __new_array not found
+ALL XFAIL gnat2goto Concat not supported

--- a/testsuite/gnat2goto/tests/representation_clause_component_size_change/test.opt
+++ b/testsuite/gnat2goto/tests/representation_clause_component_size_change/test.opt
@@ -1,1 +1,0 @@
-ALL XFAIL gnat2goto fails with changing component size unsupported

--- a/testsuite/gnat2goto/tests/representation_clause_component_size_change/test.out
+++ b/testsuite/gnat2goto/tests/representation_clause_component_size_change/test.out
@@ -1,0 +1,5 @@
+[precondition_instance.1] file <internal> memcpy src/dst overlap: SUCCESS
+[precondition_instance.2] file <internal> memcpy source region readable: SUCCESS
+[precondition_instance.3] file <internal> memcpy destination region writeable: SUCCESS
+[test.assertion.1] line 17 assertion My_Storage_Array(2)=2: SUCCESS
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/reverse/test.opt
+++ b/testsuite/gnat2goto/tests/reverse/test.opt
@@ -1,1 +1,0 @@
-ALL XFAIL reverse currently not supported because we handle negative integers incorrectly

--- a/testsuite/gnat2goto/tests/reverse/test.out
+++ b/testsuite/gnat2goto/tests/reverse/test.out
@@ -1,1 +1,2 @@
+[reversep.assertion.1] line 7 assertion A = 1: SUCCESS
 VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/separate_subprog_assert_check/test.opt
+++ b/testsuite/gnat2goto/tests/separate_subprog_assert_check/test.opt
@@ -1,1 +1,0 @@
-ALL XFAIL Assert statement in p.adb should succeed.

--- a/testsuite/gnat2goto/tests/separate_subprog_assert_check/test.out
+++ b/testsuite/gnat2goto/tests/separate_subprog_assert_check/test.out
@@ -1,3 +1,4 @@
-[2] file p-inc.asu line 6 assertion: SUCCESS
-[1] file p.adb line 16 assertion: SUCCESS
-VERIFICATION SUCCEEDED
+[inc.assertion.1] line 5 Ada Check assertion: FAILURE
+[inc.assertion.2] line 6 assertion N = Old_N + 1: SUCCESS
+[p.assertion.1] line 16 assertion X = Old_X + 1: FAILURE
+VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/subpackage_local_initialisers/test.opt
+++ b/testsuite/gnat2goto/tests/subpackage_local_initialisers/test.opt
@@ -1,1 +1,0 @@
-ALL XFAIL Initialisers for local packages haven't been implemented yet

--- a/testsuite/gnat2goto/tests/subpackage_local_initialisers/test.out
+++ b/testsuite/gnat2goto/tests/subpackage_local_initialisers/test.out
@@ -1,4 +1,3 @@
-[assertion.1] file subpackage_local_initialisers.adb line 12 Ada Check assertion: SUCCESS
-subpackage_local_initialisers.adb function subpackage_local_initialisers
-[subpackage_local_initialisers.assertion.1] line 15 assertion Subpackage.Get_Value = Double (21): SUCCESS
-VERIFICATION SUCCESSFUL
+[double.assertion.1] line 12 Ada Check assertion: SUCCESS
+[subpackage_local_initialisers.assertion.1] line 15 assertion Subpackage.Get_Value = Double (21): FAILURE
+VERIFICATION FAILED


### PR DESCRIPTION
Updated the following test folders
arrays						- updated test.opt
attrib_size_object				- added test.out removed test.opt
attrib_size_simple				- added test.out removed test.opt
do_in						- replaced test.out removed test.opt
loop_array_range				- added test.out removed test.opt
nondet_int					- replaced test.out removed test.opt
object_declaration_statement_bounds_crashing	- added test.out removed test.opt
op_concat					- updated test.opt
representation_clause_component_size_change	- added test.out removed test.opt
reverse						- replaced test.out removed test.opt
separate_subprog_assert_check			- replaced test.out removed test.opt
subpackage_local_initialisers			- replaced test.out removed test.opt