### PR TITLE
Rec data/working

### DIFF
--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -6602,14 +6602,19 @@ package body Tree_Walk is
    is
       E : constant Entity_Id := Defining_Identifier (Parent (N));
       Sub_Indication : constant Node_Id := Subtype_Indication (N);
-      Under_Type : constant Node_Id := Etype
-        (if Nkind (Sub_Indication) = N_Subtype_Indication
-         then Subtype_Mark (Sub_Indication)
-         else Sub_Indication);
+      Under_Type : constant Node_Id := Underlying_Type
+        (Etype
+           (if Nkind (Sub_Indication) = N_Subtype_Indication
+            then Subtype_Mark (Sub_Indication)
+            else Sub_Indication));
    begin
       ASVAT.Size_Model.Set_Static_Size (E          => E,
-                                 Model_Size => Pointer_Type_Width);
-      return Make_Pointer_Type (Do_Type_Reference (Under_Type));
+                                        Model_Size => Pointer_Type_Width);
+      return Make_Pointer_Type
+        (if Is_Record_Type (Under_Type) then
+              Make_Struct_Tag_Type (Unique_Name (Under_Type))
+         else
+            Do_Type_Reference (Under_Type));
    end Do_Access_To_Object_Definition;
 
    function Get_No_Return_Check return Irep is

--- a/testsuite/gnat2goto/tests/recursive_datatype/rec_data.adb
+++ b/testsuite/gnat2goto/tests/recursive_datatype/rec_data.adb
@@ -1,0 +1,37 @@
+procedure Rec_Data is
+   type R_D;
+   type R_D_I is range 1 .. 10;
+   type R_D_Ptr is access all R_D;
+
+   type R_D is record
+      N : Integer;
+      Next : R_D_Ptr;
+   end record;
+
+   type R_D_A;
+   type R_D_A is record
+      N : Integer;
+      Next : access all R_D_A;
+   end record;
+
+   V : R_D;
+   Next : aliased R_D;
+
+   W : R_D_A;
+   W_Next : aliased R_D_A;
+begin
+   V.N := 3;
+   V.Next := Next'Access;
+   V.Next.N := 5;
+   pragma Assert (V.N = 3);
+   pragma Assert (V.Next.N = 5);
+
+   W.N := 7;
+   W.Next := W_Next'Access;
+   W.Next.N := 11;
+   pragma Assert (W.N = 7);
+   pragma Assert (W.Next.N = 11);
+
+   null;
+end Rec_Data;
+

--- a/testsuite/gnat2goto/tests/recursive_datatype/test.out
+++ b/testsuite/gnat2goto/tests/recursive_datatype/test.out
@@ -1,0 +1,5 @@
+[rec_data.assertion.1] line 26 assertion V.N = 3: SUCCESS
+[rec_data.assertion.2] line 27 assertion V.Next.N = 5: SUCCESS
+[rec_data.assertion.3] line 32 assertion W.N = 7: SUCCESS
+[rec_data.assertion.4] line 33 assertion W.Next.N = 11: SUCCESS
+VERIFICATION SUCCESSFUL

--- a/testsuite/gnat2goto/tests/recursive_datatype/test.py
+++ b/testsuite/gnat2goto/tests/recursive_datatype/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
The declaration of a recursive data type was causing infinite recursion and a stack overflow.
This change addresses this issue for simple recursive data type declarations.

