### PR TITLE
Resolve an assertion failure cause by array initialisation without 'o…

### DIFF
--- a/gnat2goto/driver/arrays.adb
+++ b/gnat2goto/driver/arrays.adb
@@ -206,16 +206,15 @@ package body Arrays is
                   Maybe_Others_Choices : constant List_Id :=
                     Choices (Maybe_Others_Node);
                begin
-                  pragma Assert (List_Length (Maybe_Others_Choices) = 1);
-
-                  --  this association does not end with others -> bail
-                  if Nkind (First (Maybe_Others_Choices)) /= N_Others_Choice
+                  if List_Length (Maybe_Others_Choices) > 0
+                    and then
+                    Nkind (First (Maybe_Others_Choices)) = N_Others_Choice
                   then
+                     Others_Expression :=
+                       Do_Expression (Expression (Maybe_Others_Node));
+                  else
                      return;
                   end if;
-
-                  Others_Expression :=
-                    Do_Expression (Expression (Maybe_Others_Node));
                end;
             else
                return;

--- a/testsuite/gnat2goto/tests/array_position_without_others/array_position_without_others.adb
+++ b/testsuite/gnat2goto/tests/array_position_without_others/array_position_without_others.adb
@@ -1,0 +1,7 @@
+procedure Array_Position_Without_Others is
+   type My_Array_Type is array (1..5) of Integer;
+   A : My_Array_Type := (1 => 1, 2 | 3 | 4 | 5 => 2);
+--   B : My_Array_Type := (1 => 1, 3..4 => 3, 2 | 5 => 2);
+begin
+   pragma Assert(A(1) = 2);
+end Array_Position_Without_Others;

--- a/testsuite/gnat2goto/tests/array_position_without_others/test.out
+++ b/testsuite/gnat2goto/tests/array_position_without_others/test.out
@@ -1,0 +1,6 @@
+[precondition_instance.1] file <internal> memcpy src/dst overlap: SUCCESS
+[precondition_instance.2] file <internal> memcpy source region readable: SUCCESS
+[precondition_instance.3] file <internal> memcpy destination region writeable: SUCCESS
+[array_position_without_others.assertion.1] line 6 Ada Check assertion: SUCCESS
+[array_position_without_others.assertion.2] line 6 assertion A(1) = 2: FAILURE
+VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/array_position_without_others/test.py
+++ b/testsuite/gnat2goto/tests/array_position_without_others/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
…thers'

The assertion made an incorrect assumption about the case when there are
elements assigned but no others statement.