### PR TITLE
Reduce the size of JSON files by printing in compact mode

### DIFF
--- a/experiments/golden-results/StratoX-summary.txt
+++ b/experiments/golden-results/StratoX-summary.txt
@@ -2080,11 +2080,6 @@ Error detected at REDACTED
 --
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
-| GNU Ada (ada2goto) Storage_Error System.Memory.Alloc: heap exhausted     |
-Error detected at REDACTED
---
-Occurs: 1 times
-+===========================GNAT BUG DETECTED==============================+
 | GNU Ada (ada2goto) Storage_Error stack overflow or erroneous memory access|
 Error detected at REDACTED
 --

--- a/gnat2goto/driver/driver.adb
+++ b/gnat2goto/driver/driver.adb
@@ -501,6 +501,11 @@ package body Driver is
           (Get_Name_String (Unit_File_Name (Main_Unit)));
 
       Sanitised_Symbol_Table : Symbol_Table;
+
+      --  This controls whether the JSON output is compact or not
+      --  True -> Compact, False -> multi-line
+      Compact_JSON : constant Boolean := True;
+
    begin
       if Nkind (The_Unit) not in  N_Subprogram_Body | N_Package_Body or else
         not Global_Symbol_Table.Contains (Unit_Name)
@@ -680,7 +685,8 @@ package body Driver is
       Sanitise_Type_Declarations (Global_Symbol_Table,
                                   Sanitised_Symbol_Table);
       Put_Line (Sym_Tab_File,
-                SymbolTable2Json (Sanitised_Symbol_Table).Write (False));
+                SymbolTable2Json (Sanitised_Symbol_Table)
+                  .Write (Compact_JSON));
       Close (Sym_Tab_File);
 
    end Translate_Compilation_Unit;


### PR DESCRIPTION
If you need the verbose mode, try running:

$ jq . whatever.json_symtab