### PR TITLE
Fix/runtime check polymorphism

### DIFF
--- a/experiments/golden-results/Tokeneer-summary.txt
+++ b/experiments/golden-results/Tokeneer-summary.txt
@@ -1275,7 +1275,7 @@ raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : failed precondition from arrays.ads:51
 --
 Occurs: 3 times
 <========================>
-raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : range_check.adb:471
+raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : range_check.adb:469
 
 --
 Occurs: 1 times

--- a/gnat2goto/driver/goto_utils.adb
+++ b/gnat2goto/driver/goto_utils.adb
@@ -1084,10 +1084,40 @@ package body GOTO_Utils is
    end Get_Context_Name;
 
    function Type_To_String (Type_Irep : Irep) return String is
+      Type_Kind : constant Irep_Kind := Kind (Type_Irep);
    begin
-      return (if Kind (Type_Irep) = I_Bounded_Floatbv_Type or else
-         Kind (Type_Irep) = I_Floatbv_Type then
-              "_Flt" else "_Int");
+      if Type_Kind in Class_Bitvector_Type
+      then
+         --  This does not distinguish between instances of 2D
+         --  types such as floats, that have the same total width.
+         --  I don't think it is possible to create these from Ada.
+         return Id (Type_Irep) & "_" &
+           Ada.Strings.Fixed.Trim (Get_Width (Type_Irep)'Image,
+                                   Ada.Strings.Left);
+         --  The trim is for a lead space where the sign would be.
+      elsif Type_Kind = I_Struct_Type or
+        Type_Kind = I_Union_Type or
+        Type_Kind = I_Class_Type
+      then
+         return Id (Type_Irep) & "_" & Get_Tag (Type_Irep);
+
+      elsif Type_Kind = I_Enumeration_Type
+      then
+         return Id (Type_Irep) & "_" &
+           Type_To_String (Get_Elements (Type_Irep));
+
+      elsif Type_Kind = I_Array_Type or Type_Kind = I_Array_Type or
+        Type_Kind = I_C_Enum_Type or Type_Kind = I_Complex_Type or
+        Type_Kind = I_Incomplete_Array_Type or Type_Kind = I_Pointer_Type or
+        Type_Kind = I_Reference_Type or Type_Kind = I_Vector_Type
+      then
+         return Id (Type_Irep) & "_" &
+           Type_To_String (Get_Subtype (Type_Irep));
+
+      else
+         --  The default case, should be sufficient
+         return Id (Type_Irep);
+      end if;
    end Type_To_String;
 
 end GOTO_Utils;

--- a/gnat2goto/driver/goto_utils.adb
+++ b/gnat2goto/driver/goto_utils.adb
@@ -1082,4 +1082,12 @@ package body GOTO_Utils is
             return Get_Context_Name (Parent (Intermediate_Node));
       end case;
    end Get_Context_Name;
+
+   function Type_To_String (Type_Irep : Irep) return String is
+   begin
+      return (if Kind (Type_Irep) = I_Bounded_Floatbv_Type or else
+         Kind (Type_Irep) = I_Floatbv_Type then
+              "_Flt" else "_Int");
+   end Type_To_String;
+
 end GOTO_Utils;

--- a/gnat2goto/driver/goto_utils.ads
+++ b/gnat2goto/driver/goto_utils.ads
@@ -244,4 +244,9 @@ package GOTO_Utils is
    --  (whichever comes earlier)
    function Get_Context_Name (Intermediate_Node : Node_Id)
                               return String;
+
+   --  Convert a type to a string
+   --  Useful for creating multiple, type specific, versions of a function.
+   function Type_To_String (Type_Irep : Irep) return String;
+
 end GOTO_Utils;

--- a/gnat2goto/driver/goto_utils.ads
+++ b/gnat2goto/driver/goto_utils.ads
@@ -247,6 +247,7 @@ package GOTO_Utils is
 
    --  Convert a type to a string
    --  Useful for creating multiple, type specific, versions of a function.
-   function Type_To_String (Type_Irep : Irep) return String;
+   function Type_To_String (Type_Irep : Irep) return String
+     with Pre => Kind (Type_Irep) in Class_Type;
 
 end GOTO_Utils;

--- a/gnat2goto/driver/range_check.adb
+++ b/gnat2goto/driver/range_check.adb
@@ -179,10 +179,7 @@ package body Range_Check is
         (if Kind (Value_Type) = I_Bounded_Floatbv_Type or else
          Kind (Value_Type) = I_Floatbv_Type then
               Float64_T else Int64_T);
-      Type_String : constant String :=
-        (if Kind (Value_Type) = I_Bounded_Floatbv_Type or else
-         Kind (Value_Type) = I_Floatbv_Type then
-              "_Flt" else "_Int");
+      Type_String : constant String := Type_To_String (Value_Type);
 
       function Build_Assert_Function return Symbol;
 
@@ -367,10 +364,7 @@ package body Range_Check is
         (if Kind (Underlying_Lower_Type) = I_Bounded_Floatbv_Type or else
          Kind (Underlying_Lower_Type) = I_Floatbv_Type then
               Float64_T else Int64_T);
-      Type_String : constant String :=
-        (if Kind (Underlying_Lower_Type) = I_Bounded_Floatbv_Type or else
-         Kind (Underlying_Lower_Type) = I_Floatbv_Type then
-              "_Flt" else "_Int");
+      Type_String : constant String := Type_To_String (Underlying_Lower_Type);
 
       function Build_Assert_Function return Symbol;
 

--- a/gnat2goto/driver/range_check.adb
+++ b/gnat2goto/driver/range_check.adb
@@ -196,7 +196,7 @@ package body Range_Check is
       function Build_Assert_Function return Symbol
       is
          Func_Name : constant String :=
-           "__CPROVER_Ada_Div_Zero" & Type_String;
+           "__CPROVER_Ada_Div_Zero_" & Type_String;
          Body_Block : constant Irep := Make_Code_Block (Source_Loc);
          Func_Params : constant Irep := Make_Parameter_List;
          Value_Arg : constant Irep :=
@@ -364,7 +364,9 @@ package body Range_Check is
         (if Kind (Underlying_Lower_Type) = I_Bounded_Floatbv_Type or else
          Kind (Underlying_Lower_Type) = I_Floatbv_Type then
               Float64_T else Int64_T);
-      Type_String : constant String := Type_To_String (Underlying_Lower_Type);
+      Arg_Type_String : constant String := Type_To_String (Compare_Type);
+      Ret_Type_String : constant String :=
+          Type_To_String (Expected_Return_Type);
 
       function Build_Assert_Function return Symbol;
 
@@ -373,15 +375,17 @@ package body Range_Check is
       ---------------------------
 
       --  Build a symbol for the following function
-      --  Actual_Type range_check(Actual_Type value, Actual_Type lower_bound,
-      --                          Actual_Type upper_bound) {
+      --  Return_Type range_check(Compare_Type value, Compare_Type lower_bound,
+      --                          Compare_Type upper_bound) {
       --    `Check_Name` (value >= lower_bound && value <= upper_bound);
       --    return value;
       --  }
       function Build_Assert_Function return Symbol
       is
-         Func_Name : constant String := ("__CPROVER_Ada_Range_Check__"
-                                         & Check_Name & Type_String);
+         Func_Name : constant String := ("__CPROVER_Ada_Range_Check__" &
+                                           Check_Name &
+                                           "_" & Arg_Type_String &
+                                           "_" & Ret_Type_String);
          Body_Block : constant Irep :=
            Make_Code_Block (Get_Source_Location (N));
          Func_Params : constant Irep := Make_Parameter_List;

--- a/testsuite/gnat2goto/tests/constant_declarations/test.out
+++ b/testsuite/gnat2goto/tests/constant_declarations/test.out
@@ -1,6 +1,6 @@
 Error from cbmc test:
 function '__CPROVER_Ada_Overflow_Check' in module '' is shadowed by a definition in module ''
-function '__CPROVER_Ada_Range_Check__Overflow_Check_Int' in module '' is shadowed by a definition in module ''
+function '__CPROVER_Ada_Range_Check__Overflow_Check_signedbv_64_signedbv_32' in module '' is shadowed by a definition in module ''
 
 [assertion.1] file const_decs.ads line 8 Ada Check assertion: FAILURE
 [test.assertion.1] line 8 assertion My_P = 50: FAILURE


### PR DESCRIPTION
This avoids problems in linking where different files have checks with different signatures but the same name.  We just add the types into the name.