### PR TITLE
Add the name of the function to the variables generated in __CPROVER_…

### DIFF
--- a/gnat2goto/driver/driver.adb
+++ b/gnat2goto/driver/driver.adb
@@ -655,7 +655,9 @@ package body Driver is
               /= I_Empty
             then
                declare
-                  Return_Id   : constant Symbol_Id := Intern ("return'");
+                  Return_Name : constant String := "__CPROVER__start_" &
+                    Get_Identifier (Entry_Procedure) & "_return";
+                  Return_Id   : constant Symbol_Id := Intern (Return_Name);
                   Return_Symbol : constant Symbol :=
                     (Name | BaseName | PrettyName => Return_Id,
                      Mode => Intern ("C"),


### PR DESCRIPTION
…start

Previously the variable for the return value was just called return' which
causes linking failure if two or more of the linked components had
autogenerated __CPROVER_start for functions with different return types.