### PR TITLE
Issue 297

### DIFF
--- a/experiments/golden-results/Tokeneer-summary.txt
+++ b/experiments/golden-results/Tokeneer-summary.txt
@@ -28,7 +28,7 @@ Calling function: Process_Declaration
 Error message: Enumeration representation clauses are unsupported
 Nkind: N_Enumeration_Representation_Clause
 --
-Occurs: 62 times
+Occurs: 65 times
 Calling function: Computed_Size
 Error message: Entity does not have ASVAT model size
 Nkind: N_Defining_Identifier

--- a/experiments/golden-results/libkeccak-summary.txt
+++ b/experiments/golden-results/libkeccak-summary.txt
@@ -33,15 +33,15 @@ Calling function: Do_Type_Reference
 Error message: Expected I_Type found I_NIL
 Nkind: N_Defining_Identifier
 --
+Occurs: 95 times
+Calling function: Computed_Size
+Error message: Entity does not have ASVAT model size
+Nkind: N_Defining_Identifier
+--
 Occurs: 91 times
 Calling function: Do_Op_Expon
 Error message: Exponentiation unhandled for non mod types at the moment
 Nkind: N_Op_Expon
---
-Occurs: 86 times
-Calling function: Computed_Size
-Error message: Entity does not have ASVAT model size
-Nkind: N_Defining_Identifier
 --
 Occurs: 74 times
 Calling function: Process_Pragma_Declaration
@@ -416,4 +416,9 @@ Error detected at REDACTED
 Occurs: 1 times
 +===========================GNAT BUG DETECTED==============================+
 | GNU Ada (ada2goto) Assert_Failure sinfo.adb:1183                         |
+Error detected at REDACTED
+--
+Occurs: 1 times
++===========================GNAT BUG DETECTED==============================+
+| GNU Ada (ada2goto) Storage_Error stack overflow or erroneous memory access|
 Error detected at REDACTED

--- a/experiments/golden-results/muen-summary.txt
+++ b/experiments/golden-results/muen-summary.txt
@@ -18,7 +18,7 @@ Calling function: Process_Declaration
 Error message: Record representation clauses are unsupported
 Nkind: N_Record_Representation_Clause
 --
-Occurs: 237 times
+Occurs: 247 times
 Calling function: Computed_Size
 Error message: Entity does not have ASVAT model size
 Nkind: N_Defining_Identifier

--- a/gnat2goto/driver/records.adb
+++ b/gnat2goto/driver/records.adb
@@ -641,6 +641,11 @@ package body Records is
                                          Comp_Node,
                                          Add_To_List);
 
+               --  Register the record component size in the ASVAT size model.
+               Set_Size_From_Entity
+                 (Target => Defining_Identifier (Comp_Node),
+                  Source => Comp_Type_Node);
+
                ASVAT.Size_Model.Accumumulate_Size
                  (Is_Static     => Is_Static,
                   Accum_Static  => Static_Size,

--- a/testsuite/gnat2goto/tests/component_size/example.adb
+++ b/testsuite/gnat2goto/tests/component_size/example.adb
@@ -1,0 +1,17 @@
+procedure Example is
+   type Message_Header is record
+      Content_Size : Natural;
+   end record;
+
+   type System_Control_Message is record
+      Header : Message_Header;
+      Action : Integer;
+   end record;
+
+   SCM : System_Control_Message;
+
+begin
+   SCM.Action := 0;
+   pragma Assert (SCM.Header'Size = 5);
+   pragma Assert (SCM.Header'Size = 32);
+end Example;

--- a/testsuite/gnat2goto/tests/component_size/test.out
+++ b/testsuite/gnat2goto/tests/component_size/test.out
@@ -1,0 +1,3 @@
+[example.assertion.1] line 15 assertion SCM.Header'Size = 5: FAILURE
+[example.assertion.2] line 16 assertion SCM.Header'Size = 32: SUCCESS
+VERIFICATION FAILED

--- a/testsuite/gnat2goto/tests/component_size/test.py
+++ b/testsuite/gnat2goto/tests/component_size/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+prove()


### PR DESCRIPTION
These changes address issue 297.  The ASVAT size model was not registering the size of individual record components, only complete records.

Added test case.

Updated golden results.  A few extra reports of unknown size from the ASVAT size model, probably due to looking up the size of record components whose type stems from an unsupported type declaration (will have been raised as an unsupported feature).

One worrying extra failure in libkeccak is a stack overflow.  I think it comes from a unit test.
No new stack overflows have been reported from any of the other CI tests and I would think it unlikely that this change, in itself, would cause a stack overflow.
