### PR TITLE
A new-location based way of generating names for temporary variables

### DIFF
--- a/gnat2goto/driver/arrays.adb
+++ b/gnat2goto/driver/arrays.adb
@@ -1111,7 +1111,7 @@ package body Arrays is
         Is_OK_Static_Range (Aggregate_Bounds (N));
       Aggregate_Subtype : constant Entity_Id := Etype (N);
       New_Name          : constant String :=
-        Fresh_Var_Name (Get_File (Source_Location) & "aggregate_");
+        Fresh_Var_Name_Local ("aggregate", Source_Location);
       Aggregate_Obj     : constant String := New_Name & "_obj";
       Aggregate_Func    : constant String := New_Name & "_fun";
 --        Aggregate_Loop    : constant String := New_Name & "_loop";
@@ -1264,7 +1264,7 @@ package body Arrays is
            Size      => Str_Lit_Size_Irep);
 
       New_Name          : constant String :=
-        Fresh_Var_Name (Get_File (Source_Location) & "string_");
+        Fresh_Var_Name_Local ("string", Source_Location);
       String_Obj        : constant String := New_Name & "_obj";
       String_Func       : constant String := New_Name & "_fun";
       Obj_Irep          : constant Irep := Make_Symbol_Expr
@@ -2103,7 +2103,7 @@ package body Arrays is
          Index : Node_Id := First_Index (Array_Type);
 
          New_Name         : constant String :=
-           Fresh_Var_Name ("array_result_");
+           Fresh_Var_Name_Local ("array_result", Source_Loc);
          Array_Result_Obj : constant Irep :=
            Fresh_Var_Symbol_Expr (Array_I_Type, New_Name & "_obj");
          Array_Result_Fun : constant String := New_Name & "_fun";

--- a/gnat2goto/driver/goto_utils.adb
+++ b/gnat2goto/driver/goto_utils.adb
@@ -268,6 +268,21 @@ package body GOTO_Utils is
       return "__" & Infix & Binder_Number_Str;
    end Fresh_Var_Name;
 
+   --------------------------
+   -- Fresh_Var_Name_Local --
+   --------------------------
+
+   function Fresh_Var_Name_Local (Infix : String; Source_Location : Irep)
+                                 return String is
+   begin
+      --  Rather than use a counter which is sensitive to include order
+      --  we use the full source location information
+      return "__" & Infix &
+        "_" & Get_File (Source_Location) &
+        "_" & Get_Line (Source_Location) &
+        "_" & Get_Column (Source_Location);
+   end Fresh_Var_Name_Local;
+
    ---------------------------
    -- Fresh_Var_Symbol_Expr --
    ---------------------------

--- a/gnat2goto/driver/goto_utils.ads
+++ b/gnat2goto/driver/goto_utils.ads
@@ -44,6 +44,8 @@ package GOTO_Utils is
    Synthetic_Variable_Counter : Positive := 1;
 
    function Fresh_Var_Name (Infix : String) return String;
+   function Fresh_Var_Name_Local (Infix : String; Source_Location : Irep)
+                                 return String;
    function Fresh_Var_Symbol_Expr (Ty : Irep; Infix : String) return Irep;
 
    function Make_Pointer_Type (Base : Irep) return Irep;


### PR DESCRIPTION
The previous system had an issue with including headers in different orders
leading to inconsistent numbering between different files.  By using the
location, symbols should be identical across different inclusion orders.